### PR TITLE
Add support for RDS DB with read replica

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ format: format-py format-html format-frontend ## Format the code.
 
 .PHONY: format-py
 format-py:  ## Format the Python code
-	poetry run ruff check . --fix
 	poetry run ruff format .
+	poetry run ruff check . --fix
 
 .PHONY: format-html
 format-html:  ## Format the HTML code

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -1,0 +1,54 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.db import DEFAULT_DB_ALIAS, router, transaction
+from django.db.models import Model
+
+
+class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
+    """A database router which routes reads to the read replica."""
+
+    REPLICA_DB_ALIAS = "read_replica"
+
+    REPLICA_DBS = frozenset({REPLICA_DB_ALIAS, DEFAULT_DB_ALIAS})
+
+    def __init__(self) -> None:
+        if self.REPLICA_DB_ALIAS not in settings.DATABASES:
+            raise ImproperlyConfigured("Read replica is not configured.")
+
+    def db_for_read(self, model: type[Model], **hints: dict) -> str | None:
+        """Which database should be used for read queries?"""
+        # If the write database is in a (uncommitted) transaction,
+        # a subsequent SELECT (or other read query) may return inconsistent data.
+        # In this case, use the write connection for reads, with the aim of
+        # improved consistency.
+        write_db = router.db_for_write(model, **hints)
+
+        if not transaction.get_autocommit(using=write_db):
+            # In a transaction, use the write database
+            return write_db
+
+        return self.REPLICA_DB_ALIAS
+
+    def db_for_write(self, model: type[Model], **hints: dict) -> str | None:
+        """Which database should be used for write queries?"""
+        # This should always be the "default" database, since the replica
+        # doesn't allow writes.
+        return DEFAULT_DB_ALIAS
+
+    def allow_relation(self, obj1: Model, obj2: Model, **hints: dict) -> bool | None:
+        """Are two objects allowed to be related?"""
+        # If both instances are in the same database (or its replica), allow relations
+        if obj1._state.db in self.REPLICA_DBS and obj2._state.db in self.REPLICA_DBS:
+            return True
+
+        # No preference
+        return None
+
+    def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints: dict) -> bool | None:
+        """Can migrations be run for the app on the database?"""
+        # Don't allow migrations to run against the replica (they would fail anyway)
+        if db == self.REPLICA_DB_ALIAS:
+            return False
+
+        # No preference
+        return None

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -24,7 +24,7 @@ class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
             raise ImproperlyConfigured("Read replica is not configured.")
 
     def db_for_read(self, model: type[Model], **hints: Any) -> Optional[str]:
-        """Which database should be used for read queries?"""
+        """Determine which database should be used for read queries."""
         # If the write database is in a (uncommitted) transaction,
         # a subsequent SELECT (or other read query) may return inconsistent data.
         # In this case, use the write connection for reads, with the aim of
@@ -38,13 +38,13 @@ class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
         return self.REPLICA_DB_ALIAS
 
     def db_for_write(self, model: type[Model], **hints: Any) -> Optional[str]:
-        """Which database should be used for write queries?"""
+        """Determine which database should be used for write queries."""
         # This should always be the "default" database, since the replica
         # doesn't allow writes.
         return DEFAULT_DB_ALIAS
 
     def allow_relation(self, obj1: Model, obj2: Model, **hints: Any) -> Optional[bool]:
-        """Are two objects allowed to be related?"""
+        """Determine whether a relation is allowed between two models."""
         # If both instances are in the same database (or its replica), allow relations
         if obj1._state.db in self.REPLICA_DBS and obj2._state.db in self.REPLICA_DBS:
             return True
@@ -53,6 +53,6 @@ class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
         return None
 
     def allow_migrate(self, db: str, app_label: str, model_name: Optional[str] = None, **hints: Any) -> bool:
-        """Can migrations be run for the app on the database?"""
+        """Determine whether migrations be run for the app on the database."""
         # Don't allow migrations to run against the replica (they would fail anyway)
         return db != self.REPLICA_DB_ALIAS

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -7,7 +7,10 @@ from django.db.models import Model
 
 
 class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
-    """A database router which routes read queries to a read replica.
+    """A database router for directing queries between the default database and a read replica.
+
+    This router routes read queries to a read replica while ensuring write queries
+    (and migrations) are directed to the default database.
 
     https://docs.djangoproject.com/en/5.1/topics/db/multi-db/#automatic-database-routing
     """

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -5,7 +5,10 @@ from django.db.models import Model
 
 
 class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
-    """A database router which routes reads to the read replica."""
+    """A database router which routes read queries to a read replica.
+
+    https://docs.djangoproject.com/en/5.1/topics/db/multi-db/#automatic-database-routing
+    """
 
     REPLICA_DB_ALIAS = "read_replica"
 

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -44,11 +44,7 @@ class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
         # No preference
         return None
 
-    def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints: dict) -> bool | None:
+    def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints: dict) -> bool:
         """Can migrations be run for the app on the database?"""
         # Don't allow migrations to run against the replica (they would fail anyway)
-        if db == self.REPLICA_DB_ALIAS:
-            return False
-
-        # No preference
-        return None
+        return db != self.REPLICA_DB_ALIAS

--- a/cms/core/db_router.py
+++ b/cms/core/db_router.py
@@ -12,7 +12,7 @@ class ReadReplicaRouter:  # pylint: disable=unused-argument,protected-access
     REPLICA_DBS = frozenset({REPLICA_DB_ALIAS, DEFAULT_DB_ALIAS})
 
     def __init__(self) -> None:
-        if self.REPLICA_DB_ALIAS not in settings.DATABASES:
+        if self.REPLICA_DB_ALIAS not in settings.DATABASES:  # pragma: no cover
             raise ImproperlyConfigured("Read replica is not configured.")
 
     def db_for_read(self, model: type[Model], **hints: dict) -> str | None:

--- a/cms/core/tests/test_db_router.py
+++ b/cms/core/tests/test_db_router.py
@@ -1,16 +1,17 @@
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.db import router, transaction
 from wagtail.models import Page
 
+pytestmark = pytest.mark.django_db(transaction=True)
 
-@pytest.mark.django_db(transaction=True)
+
 def test_uses_replica_for_read():
     """Check the read replica is used for reads, and the default for writes."""
     assert router.db_for_write(Page) == "default"
     assert router.db_for_read(Page) == "read_replica"
 
 
-@pytest.mark.django_db(transaction=True)
 def test_uses_write_db_during_transaction():
     """Check the default is used for reads in a transaction."""
     assert router.db_for_read(Page) == "read_replica"
@@ -21,7 +22,6 @@ def test_uses_write_db_during_transaction():
     assert router.db_for_read(Page) == "read_replica"
 
 
-@pytest.mark.django_db(transaction=True)
 def test_uses_write_db_when_autocommit_disabled():
     """Check the default is used for reads when not in an autocommit context."""
     assert router.db_for_read(Page) == "read_replica"
@@ -33,3 +33,22 @@ def test_uses_write_db_when_autocommit_disabled():
         transaction.set_autocommit(True)
 
     assert router.db_for_read(Page) == "read_replica"
+
+
+def test_uses_correct_db_in_query():
+    """Check the read replica is used when running an actual query."""
+    # Choose a model which definitely exists
+    content_type = ContentType.objects.first()
+
+    assert content_type is not None
+    assert content_type._state.db == "read_replica"  # pylint: disable=protected-access
+
+
+def test_uses_correct_db_in_transaction():
+    """Check the read replica is used when running a query inside a transaction."""
+    # Choose a model which definitely exists
+    with transaction.atomic():
+        content_type = ContentType.objects.first()
+
+    assert content_type is not None
+    assert content_type._state.db == "default"  # pylint: disable=protected-access

--- a/cms/core/tests/test_db_router.py
+++ b/cms/core/tests/test_db_router.py
@@ -1,54 +1,51 @@
-import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.db import router, transaction
+from django.test import TransactionTestCase
 from wagtail.models import Page
 
-pytestmark = pytest.mark.django_db(transaction=True)
 
+class DBRouterTestCase(TransactionTestCase):
+    databases = frozenset({"default", "read_replica"})
 
-def test_uses_replica_for_read():
-    """Check the read replica is used for reads, and the default for writes."""
-    assert router.db_for_write(Page) == "default"
-    assert router.db_for_read(Page) == "read_replica"
+    def test_uses_replica_for_read(self):
+        """Check the read replica is used for reads, and the default for writes."""
+        self.assertEqual(router.db_for_write(Page), "default")
+        self.assertEqual(router.db_for_read(Page), "read_replica")
 
+    def test_uses_write_db_during_transaction(self):
+        """Check the default is used for reads in a transaction."""
+        self.assertEqual(router.db_for_read(Page), "read_replica")
 
-def test_uses_write_db_during_transaction():
-    """Check the default is used for reads in a transaction."""
-    assert router.db_for_read(Page) == "read_replica"
+        with transaction.atomic():
+            self.assertEqual(router.db_for_read(Page), "default")
 
-    with transaction.atomic():
-        assert router.db_for_read(Page) == "default"
+        self.assertEqual(router.db_for_read(Page), "read_replica")
 
-    assert router.db_for_read(Page) == "read_replica"
+    def test_uses_write_db_when_autocommit_disabled(self):
+        """Check the default is used for reads when not in an autocommit context."""
+        self.assertEqual(router.db_for_read(Page), "read_replica")
 
+        try:
+            transaction.set_autocommit(False)
+            self.assertEqual(router.db_for_read(Page), "default")
+        finally:
+            transaction.set_autocommit(True)
 
-def test_uses_write_db_when_autocommit_disabled():
-    """Check the default is used for reads when not in an autocommit context."""
-    assert router.db_for_read(Page) == "read_replica"
+        self.assertEqual(router.db_for_read(Page), "read_replica")
 
-    try:
-        transaction.set_autocommit(False)
-        assert router.db_for_read(Page) == "default"
-    finally:
-        transaction.set_autocommit(True)
-
-    assert router.db_for_read(Page) == "read_replica"
-
-
-def test_uses_correct_db_in_query():
-    """Check the read replica is used when running an actual query."""
-    # Choose a model which definitely exists
-    content_type = ContentType.objects.first()
-
-    assert content_type is not None
-    assert content_type._state.db == "read_replica"  # pylint: disable=protected-access
-
-
-def test_uses_correct_db_in_transaction():
-    """Check the read replica is used when running a query inside a transaction."""
-    # Choose a model which definitely exists
-    with transaction.atomic():
+    def test_uses_correct_db_in_query(self):
+        """Check the read replica is used when running an actual query."""
+        # Choose a model which definitely exists
         content_type = ContentType.objects.first()
 
-    assert content_type is not None
-    assert content_type._state.db == "default"  # pylint: disable=protected-access
+        self.assertIsNotNone(content_type)
+        self.assertEqual(content_type._state.db, "read_replica")  # pylint: disable=protected-access
+
+    def test_uses_correct_db_in_transaction(self):
+        """Check the read replica is used when running a query inside a transaction."""
+        # Choose a model which definitely exists
+        with transaction.atomic():
+            content_type = ContentType.objects.first()
+
+        self.assertIsNotNone(content_type)
+        self.assertEqual(content_type._state.db, "default")  # pylint: disable=protected-access

--- a/cms/core/tests/test_db_router.py
+++ b/cms/core/tests/test_db_router.py
@@ -1,0 +1,35 @@
+import pytest
+from django.db import router, transaction
+from wagtail.models import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def test_uses_replica_for_read():
+    """Check the read replica is used for reads, and the default for writes."""
+    assert router.db_for_write(Page) == "default"
+    assert router.db_for_read(Page) == "read_replica"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_uses_write_db_during_transaction():
+    """Check the default is used for reads in a transaction."""
+    assert router.db_for_read(Page) == "read_replica"
+
+    with transaction.atomic():
+        assert router.db_for_read(Page) == "default"
+
+    assert router.db_for_read(Page) == "read_replica"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_uses_write_db_when_autocommit_disabled():
+    """Check the default is used for reads when not in an autocommit context."""
+    assert router.db_for_read(Page) == "read_replica"
+
+    try:
+        transaction.set_autocommit(False)
+        assert router.db_for_read(Page) == "default"
+    finally:
+        transaction.set_autocommit(True)
+
+    assert router.db_for_read(Page) == "read_replica"

--- a/cms/core/tests/test_db_router.py
+++ b/cms/core/tests/test_db_router.py
@@ -3,6 +3,8 @@ from django.db import router, transaction
 from django.test import TransactionTestCase
 from wagtail.models import Page
 
+from cms.home.models import HomePage
+
 
 class DBRouterTestCase(TransactionTestCase):
     databases = frozenset({"default", "read_replica"})
@@ -49,3 +51,8 @@ class DBRouterTestCase(TransactionTestCase):
 
         self.assertIsNotNone(content_type)
         self.assertEqual(content_type._state.db, "default")  # pylint: disable=protected-access
+
+    def test_search_uses_correct_db(self):
+        """Check the read replica is used for search queries."""
+        with self.assertNumQueries(2, using="read_replica"), self.assertNumQueries(0, using="default"):
+            list(HomePage.objects.search("Home"))

--- a/cms/core/wagtail_search.py
+++ b/cms/core/wagtail_search.py
@@ -1,0 +1,12 @@
+from wagtail.search.backends.database.postgres.postgres import Index, PostgresSearchBackend
+
+
+class ONSPostgresSearchBackend(PostgresSearchBackend):
+    """A custom search backend which ensures the index uses the correct database backend.
+
+    A work-around until https://github.com/wagtail/wagtail/pull/12508 ships.
+    """
+
+    def get_index_for_model(self, model: str, db_alias: str | None = None) -> Index:
+        # Always defer to DB router for search backend
+        return super().get_index_for_model(model, None)

--- a/cms/core/wagtail_search.py
+++ b/cms/core/wagtail_search.py
@@ -4,7 +4,7 @@ from wagtail.search.backends.database.postgres.postgres import Index, PostgresSe
 class ONSPostgresSearchBackend(PostgresSearchBackend):
     """A custom search backend which ensures the index uses the correct database backend.
 
-    A work-around until https://github.com/wagtail/wagtail/pull/12508 ships.
+    TODO: Remove when https://github.com/wagtail/wagtail/pull/12508 ships (Wagtail 6.4).
     """
 
     def get_index_for_model(self, model: str, db_alias: str | None = None) -> Index:

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1,5 +1,7 @@
 """Django settings for ons project."""
 
+# pylint: disable=fixme
+
 import os
 import sys
 from copy import deepcopy

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -181,7 +181,7 @@ WSGI_APPLICATION = "cms.wsgi.application"
 
 # Database
 
-db_conn_max_age = env.get("PG_CONN_MAX_AGE", 870)  # Just under 15 minutes, to match password expiry
+db_conn_max_age = int(env.get("PG_CONN_MAX_AGE", 870))  # Just under 15 minutes, to match password expiry
 
 if "PG_DB_ADDR" in env:
     # Use IAM authentication to connect to the Database

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1,7 +1,5 @@
 """Django settings for ons project."""
 
-# pylint: disable=fixme
-
 import os
 import sys
 from copy import deepcopy

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -181,6 +181,8 @@ WSGI_APPLICATION = "cms.wsgi.application"
 
 # Database
 
+db_conn_max_age = env.get("PG_CONN_MAX_AGE", 870)  # Just under 15 minutes, to match password expiry
+
 if "PG_DB_ADDR" in env:
     # Use IAM authentication to connect to the Database
     DATABASES = {
@@ -192,7 +194,7 @@ if "PG_DB_ADDR" in env:
                 "USER": env["PG_DB_USER"],
                 "HOST": env["PG_DB_ADDR"],
                 "PORT": env["PG_DB_PORT"],
-                "CONN_MAX_AGE": 870,  # Just under 15 minutes, to match password expiry
+                "CONN_MAX_AGE": db_conn_max_age,
                 "OPTIONS": {"use_iam_auth": True, "sslmode": "require"},
             },
         )
@@ -204,11 +206,13 @@ if "PG_DB_ADDR" in env:
 
 else:
     DATABASES = {
-        "default": dj_database_url.config(conn_max_age=600, default="postgres:///ons"),
+        "default": dj_database_url.config(conn_max_age=db_conn_max_age, default="postgres:///ons"),
     }
 
     if "READ_REPLICA_DATABASE_URL" in env:
-        DATABASES["read_replica"] = dj_database_url.config(env="READ_REPLICA_DATABASE_URL", conn_max_age=600)
+        DATABASES["read_replica"] = dj_database_url.config(
+            env="READ_REPLICA_DATABASE_URL", conn_max_age=db_conn_max_age
+        )
 
 if "read_replica" not in DATABASES:
     DATABASES["read_replica"] = deepcopy(DATABASES["default"])

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -263,6 +263,8 @@ else:
 # Search
 # https://docs.wagtail.io/en/latest/topics/search/backends.html
 
+# TODO: revert to using "wagtail.search.backends.database" when
+# https://github.com/wagtail/wagtail/pull/12508 is fixed and released.
 WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "cms.core.search.ONSPostgresSearchBackend"}}
 
 

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -269,7 +269,7 @@ else:
 
 # TODO: revert to using "wagtail.search.backends.database" when
 # https://github.com/wagtail/wagtail/pull/12508 is fixed and released.
-WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "cms.core.search.ONSPostgresSearchBackend"}}
+WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "cms.core.wagtail_search.ONSPostgresSearchBackend"}}
 
 
 # Password validation

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -42,6 +42,6 @@ DEFENDER_DISABLE_USERNAME_LOCKOUT = True
 DEFENDER_DISABLE_IP_LOCKOUT = True
 
 
-# Set a different test database name for the replica, in case it's the same
-# as the default.
-DATABASES["read_replica"].setdefault("TEST", {"NAME": "test_read_replica"})  # noqa: F405
+# Read replica should mirror the default database during tests.
+# https://docs.djangoproject.com/en/stable/topics/testing/advanced/#tests-and-multiple-databases
+DATABASES["read_replica"].setdefault("TEST", {"MIRROR": "default"})  # noqa: F405

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -40,3 +40,8 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 DEFENDER_DISABLE_USERNAME_LOCKOUT = True
 DEFENDER_DISABLE_IP_LOCKOUT = True
+
+
+# Set a different test database name for the replica, in case it's the same
+# as the default.
+DATABASES["read_replica"].setdefault("TEST", {"NAME": "test_read_replica"})  # noqa: F405

--- a/poetry.lock
+++ b/poetry.lock
@@ -535,6 +535,22 @@ files = [
 Django = ">=4.2"
 
 [[package]]
+name = "django-iam-dbauth"
+version = "0.2.1"
+description = "Django database backends to use AWS Database IAM Authentication"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django_iam_dbauth-0.2.1-py2.py3-none-any.whl", hash = "sha256:c3ea606ce62bf872930af948a59c792c26c6372db61911ad93b0e536009f033d"},
+    {file = "django_iam_dbauth-0.2.1.tar.gz", hash = "sha256:a33885c81ecdfc8eef22842a56b6a8f545c3c1a1595945ce8e87453697481a62"},
+]
+
+[package.dependencies]
+boto3 = "*"
+django = ">=4.2"
+dnspython = "*"
+
+[[package]]
 name = "django-jinja"
 version = "2.11.0"
 description = "Jinja2 templating language integrated in Django."
@@ -719,6 +735,26 @@ files = [
 
 [package.extras]
 dev = ["nox", "pre-commit"]
+
+[[package]]
+name = "dnspython"
+version = "2.7.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86"},
+    {file = "dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.16.0)", "mypy (>=1.8)", "pylint (>=3)", "pytest (>=7.4)", "pytest-cov (>=4.1.0)", "quart-trio (>=0.11.0)", "sphinx (>=7.2.0)", "sphinx-rtd-theme (>=2.0.0)", "twine (>=4.0.0)", "wheel (>=0.42.0)"]
+dnssec = ["cryptography (>=43)"]
+doh = ["h2 (>=4.1.0)", "httpcore (>=1.0.0)", "httpx (>=0.26.0)"]
+doq = ["aioquic (>=1.0.0)"]
+idna = ["idna (>=3.7)"]
+trio = ["trio (>=0.23)"]
+wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
 name = "draftjs-exporter"
@@ -2058,4 +2094,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "4d93ff1acdcb3aafa0f83b5b2ff87f89449975de8bb838b93e27b630e64160c4"
+content-hash = "825fba50b8df79dee3a45b5680b9097a8f604610a34f32378a5744147a33e013"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ ignore = [
     "D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107",
     # indentation contains tabs
     "W191",
+    # Prefer explicit type rather than union (|) shorthand
+    "UP007"
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ apscheduler = "^3.10.4"
 wagtail-storages = "~2.0"
 wagtailmath = "~1.3.0"
 whitenoise = "~6.8"
+django-iam-dbauth = "^0.2.1"
 
 [tool.poetry.group.dev.dependencies]
 # :TODO: Remove pylint when ruff supports all pylint rules


### PR DESCRIPTION
### What is the context of this PR?

- https://jira.ons.gov.uk/browse/CMS-214
- https://jira.ons.gov.uk/browse/CMS-217

#### IAM authentication

In production, rather than a username and password, authentication to the database will be done using IAM. This means there are no credentials to leak or rotate. 

When a connection is opened, a signed token is generated and used for authentication. This token is only valid for 15 minutes. The complexities of this are handled by an external library.

Connecting the application to IAM itself is done by the cluster, hence no additional configuration. 

#### Multiple database connections

In production, multiple database connections will be used: one for writes and one for reads. The write connection points to a single database server, whilst reads are load balanced between a set of servers ("read replicas").

It's up to the application to decide whether the write or read connections is used, which is what the database router handles. Django internally identifies whether a query is a "read" or a "write", and uses the router to identify the connection. Most of the time, there's no need for a developer to worry about this.

Specifically:

- Writes should always be handled by the write server (read replica connections are read-only)
- Reads should _usually_ be handled by the read replicas
- If there is an open transaction, reads should be handled by the write connection. This ensures that whilst a transaction is open, the application gets a consistent view of state (since data held in the transaction can't be seen by the read connection).

Note: AWS is responsible for balancing traffic across the replicas - this is not the responsibility of the application.

For consistency, local development also uses multiple connections handled by the same router, however these point to the same server, and there's no restriction that the read connection only handles reads. 

### How to review

This shouldn't make a difference to local development.

Relevant Django documentation: https://docs.djangoproject.com/en/5.1/topics/db/multi-db/

### Follow-up Actions

There are discussions happening about being able to handle a completely read-only connection. "read replica" functionality is separate.  
