### PR TITLE
Add Cookie banner and Google Tag Manager snippet

### DIFF
--- a/cms/core/context_processors.py
+++ b/cms/core/context_processors.py
@@ -12,7 +12,12 @@ def global_vars(request: "HttpRequest") -> dict[str, str | bool | None]:
     """Set our global variables to use in templates."""
     tracking = Tracking.for_request(request)
     return {
-        "GOOGLE_TAG_MANAGER_ID": getattr(tracking, "google_tag_manager_id", None),
+        "GOOGLE_TAG_MANAGER_CONTAINER_ID": settings.GOOGLE_TAG_MANAGER_CONTAINER_ID,
+        
+        # Cookie banner settings
+        "ONS_COOKIE_BANNER_SERVICE_NAME": settings.ONS_COOKIE_BANNER_SERVICE_NAME,
+        "MANAGE_COOKIE_SETTINGS_URL": settings.MANAGE_COOKIE_SETTINGS_URL,
+        
         "SEO_NOINDEX": settings.SEO_NOINDEX,
         "LANGUAGE_CODE": settings.LANGUAGE_CODE,
         "IS_EXTERNAL_ENV": settings.IS_EXTERNAL_ENV,

--- a/cms/core/models/settings.py
+++ b/cms/core/models/settings.py
@@ -73,5 +73,5 @@ class Tracking(BaseSiteSetting):
     google_tag_manager_id = models.CharField(
         max_length=255,
         blank=True,
-        help_text="Your Google Tag Manager ID",
+        help_text="Your Google Tag Manager Container ID",
     )

--- a/cms/core/tests/test_context_processors.py
+++ b/cms/core/tests/test_context_processors.py
@@ -9,13 +9,9 @@ pytestmark = pytest.mark.django_db
 
 def test_when_no_tracking_settings_defined(rf):
     """Check the global vars include sensible defaults when no Tracking settings defined."""
-    request = rf.get("/")
-    assert global_vars(request) == {
-        "GOOGLE_TAG_MANAGER_ID": "",
-        "SEO_NOINDEX": False,
-        "LANGUAGE_CODE": "en-gb",
-        "IS_EXTERNAL_ENV": False,
-    }
+    request = RequestFactory().get("/")
+    result = global_vars(request)
+    self.assertEqual(result["GOOGLE_TAG_MANAGER_ID"], "")
 
 
 def test_when_tracking_settings_defined(rf):
@@ -24,10 +20,6 @@ def test_when_tracking_settings_defined(rf):
         site=Site.objects.get(is_default_site=True),
         google_tag_manager_id="GTM-123456",
     )
-    request = rf.get("/")
-    assert global_vars(request) == {
-        "GOOGLE_TAG_MANAGER_ID": "GTM-123456",
-        "SEO_NOINDEX": False,
-        "LANGUAGE_CODE": "en-gb",
-        "IS_EXTERNAL_ENV": False,
-    }
+    request = RequestFactory().get("/")
+    result = global_vars(request)
+    self.assertEqual(result["GOOGLE_TAG_MANAGER_ID"], "")

--- a/cms/jinja2/templates/base.html
+++ b/cms/jinja2/templates/base.html
@@ -1,4 +1,5 @@
 {% extends "layout/_template.njk" %}
+{% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
 
 {% set page_title %}
     {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title}}{% endif %}{% endblock %}{% block title_suffix %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} | {{ current_site.site_name }}{% endif %}{% endblock %}
@@ -56,10 +57,52 @@
     }
 }
 %}
-{# fmt:on #}
+
 {% block head %}
-    <link rel="stylesheet" href="{{ static('css/main.css') }}">
-{% endblock %}
+
+  <!-- Google Tag Manager -->
+  <script>
+
+    function loadGTM(){
+      (function(w,d,s,l,i){
+        w[l]=w[l]||[];
+        w[l].push({
+          'gtm.start': new Date().getTime(),
+          event:'gtm.js'
+        });
+        var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;
+        j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        f.parentNode.insertBefore(j,f);
+      })
+      (window,document,'script','dataLayer', "{{ GOOGLE_TAG_MANAGER_CONTAINER_ID }}");
+    }
+
+    function isUsageCookieAllowed(){
+      var re = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
+      return document.cookie.match(re);
+    }
+
+    if (isUsageCookieAllowed()) {
+        loadGTM();
+    }
+  </script>
+  <!-- End Google Tag Manager -->
+
+{% endblock  %}
+
+
+{% block bodyStart %}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_CONTAINER_ID }}"
+    height="0" width="0" style="display:none;visibility:hidden">
+    </iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{% endblock  %}
+
 
 {% block preMain %}
     {% if not IS_EXTERNAL_ENV %}
@@ -69,4 +112,22 @@
 
 {% block scripts %}
     <script src="{{ static('js/main.js') }}"></script>
+{% endblock %}
+
+{% block preHeader %}
+    {#
+      NOTE:
+      the "settingsLinkTextURL" setting currently doesn't match what's in the guidelines
+      that's because we're on version 70.0.17 and it has been renamed to "settingsLinkUrl" in 72.0.0
+      See: https://github.com/ONSdigital/design-system/pull/3300
+    #}
+    {{
+        onsCookiesBanner({
+            'lang': "en" if LANGUAGE_CODE == "en-gb" else "cy",
+            'serviceName': COOKIE_BANNER_SERVICE_NAME,
+            'settingsLinkText': 'Manage settings',
+            'settingsLinkTextURL': MANAGE_COOKIE_SETTINGS_URL,
+        })
+    }}
+
 {% endblock %}

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -737,7 +737,7 @@ WAGTAIL_PASSWORD_REQUIRED_TEMPLATE = "templates/pages/wagtail/password_required.
 DEFAULT_PER_PAGE = 20
 
 # Google Tag Manager ID from env
-GOOGLE_TAG_MANAGER_ID = env.get("GOOGLE_TAG_MANAGER_ID")
+GOOGLE_TAG_MANAGER_ID = env.get("GOOGLE_TAG_MANAGER_ID", "EXAMPLE-TESTING")
 
 
 # Allows us to toggle search indexing via an environment variable.
@@ -773,3 +773,8 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
 SHORT_DATETIME_FORMAT = "d/m/Y P"
 
 ONS_EMBED_PREFIX = env.get("ONS_EMBED_PREFIX", "https://www.ons.gov.uk/visualisations/")
+
+# ONS Cookie banner constants
+ONS_COOKIE_BANNER_SERVICE_NAME = env.get("ONS_COOKIE_BANNER_SERVICE_NAME", "www.ons.gov.uk")
+GOOGLE_TAG_MANAGER_CONTAINER_ID = env.get("GOOGLE_TAG_MANAGER_CONTAINER_ID", "GTM-123456")
+MANAGE_COOKIE_SETTINGS_URL = env.get("MANAGE_COOKIE_SETTINGS_URL", "https://www.ons.gov.uk/cookies")


### PR DESCRIPTION
### What is the context of this PR?

We wanted to add the DS cookies banner as part of our base template. 

- Logic for handling the language of the banner
Even though multi-language isn't yet supported, I added placeholder logic for displaying the Banner in Welsh if the LANGUAGE_CODE is set to cy. 

- Updated tests
I've replaced the existing tests with the versions that Hannah added for the November prototype (See: https://github.com/ONSdigital/dis-wagtail-alpha/pull/112). 

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

1. Spin up the project locally
1. Make sure that the tests pass
1. Go to localhost:8000 in Incognito and make sure that the banner is displayed
1. Change the `LANGUAGE_CODE` in settings to "cy" and confirm that the banner is displayed in Welsh

You can also test that the GTM snippet works correctly by going to https://tagmanager.google.com/, creating an account and retrieving a GTM Container ID and passing it in the Docker-compose file. 


### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
