### PR TITLE
Update CODEOWNERS to be .github only

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @ONSdigital/dissemination-cms
+# The line below indicates the code owners of this repo without auto-assigning PRs to the team
+
+.github/* @ONSdigital/dissemination-cms


### PR DESCRIPTION
### What is the context of this PR?

Switched to .github folder only. Should avoid unnecessary noise while preserving code ownership.

This follows the pattern used in other DIS repositories

### How to review

Check that is looks OK and in line with approach to codeowners for multiple teams

### Follow-up Actions

N/A