### PR TITLE
Small delighter: Use the ONS logo in the Wagtail admin

### DIFF
--- a/cms/core/templates/wagtailadmin/admin_base.html
+++ b/cms/core/templates/wagtailadmin/admin_base.html
@@ -1,0 +1,3 @@
+{% extends "wagtailadmin/admin_base.html" %}
+{% load i18n %}
+{% block branding_title %}{%  trans "ONS Wagtail CMS" %}{% endblock %}

--- a/cms/core/templates/wagtailadmin/base.html
+++ b/cms/core/templates/wagtailadmin/base.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/base.html" %}
+{% block branding_logo %}
+    <a class="sidebar-wagtail-branding w-transition-all w-duration-150 w-m-0" href="/admin/" aria-label="Dashboard" aria-current="page">
+        <svg aria-hidden="true" class="w-bg-white" style="border-radius: 10px; padding: .25em; max-width: 90%;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="enable-background:new 0 0 139.2 138.9" viewBox="0 0 139.2 138.9"><path d="M0 84.1c2-4.3 4.3-8.5 6.7-12.7C4 64.7 1.7 57.7 0 50.5v33.6zM13.2 0S.2 0 .2 16.1v8.5c1.3 14.6 4.3 28.9 9.5 42 7.2-11.4 15.7-21.9 26.6-30.8C57.2 17.9 85.5 5.5 123.8 0H13.2z" style="fill:#a8bd3a"/><path d="M138.3 8.9c-43.7 4.3-73.9 16.9-95.2 35-11.5 10-20.9 21.6-28.1 34.6 16.7 33 49 56.7 102.4 60.4h5.2s16.6.7 16.6-17.7V8.5c-.2.4-.5.4-.9.4zM25.6 102c-5-6-9.4-12.4-13-19.2-4.5 8.9-8.7 18.2-12 28.4v27.1h87.6C60.7 132.1 40 119.1 25.6 102z" style="fill:#003c57"/></svg>
+    </a>
+{% endblock %}

--- a/cms/core/templates/wagtailadmin/login.html
+++ b/cms/core/templates/wagtailadmin/login.html
@@ -1,0 +1,8 @@
+{% extends "wagtailadmin/login.html" %}
+{% load i18n %}
+{% block branding_login %}{% trans "Sign in to the ONS Wagtail CMS" %}{% endblock %}
+{% block branding_logo %}
+    <div class="login-logo">
+        <svg role="img" aria-label="ONS" style="width:80px; margin-left: 20px;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="enable-background:new 0 0 139.2 138.9" viewBox="0 0 139.2 138.9"><path d="M0 84.1c2-4.3 4.3-8.5 6.7-12.7C4 64.7 1.7 57.7 0 50.5v33.6zM13.2 0S.2 0 .2 16.1v8.5c1.3 14.6 4.3 28.9 9.5 42 7.2-11.4 15.7-21.9 26.6-30.8C57.2 17.9 85.5 5.5 123.8 0H13.2z" style="fill:#a8bd3a"/><path d="M138.3 8.9c-43.7 4.3-73.9 16.9-95.2 35-11.5 10-20.9 21.6-28.1 34.6 16.7 33 49 56.7 102.4 60.4h5.2s16.6.7 16.6-17.7V8.5c-.2.4-.5.4-.9.4zM25.6 102c-5-6-9.4-12.4-13-19.2-4.5 8.9-8.7 18.2-12 28.4v27.1h87.6C60.7 132.1 40 119.1 25.6 102z" style="fill:#003c57"/></svg>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### What is the context of this PR?

A "small delighter" - uses the ONS logo on the login form and the Wagtail admin. https://docs.wagtail.org/en/stable/advanced_topics/customisation/admin_templates.html

### How to review

Check out the branch, check the login page / Wagtail admin

### Follow-up Actions

N/A

<details>
<summary>Screenshots</summary>

![login-form](https://github.com/user-attachments/assets/b346efae-e155-42f0-b583-89484f4c3d35)
![admin-full-sidebar](https://github.com/user-attachments/assets/35e5ca1a-9b9c-4489-a25d-09d7b0c1a26b)
![admin-slim-sidebar](https://github.com/user-attachments/assets/b0c5ce83-b760-40ab-bdcc-9f7102e374a1)
</details>
