### PR TITLE
Bring in styles and custom markup from the prototype

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,4 +2,10 @@ module.exports = {
   root: true,
   // See https://github.com/wagtail/eslint-config-wagtail for rules.
   extends: ['@wagtail/eslint-config-wagtail', 'plugin:@typescript-eslint/recommended'],
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
+    jest: true,
+  },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,4 +1,53 @@
 module.exports = {
   // See https://github.com/wagtail/stylelint-config-wagtail for rules.
   extends: '@wagtail/stylelint-config-wagtail',
+  // overrides to the wagtail config
+  rules: {
+    // Allow union class names in selectors e.g. &__header
+    'scss/selector-no-union-class-name': null,
+    // Override some wagtail specific rules relating to design tokens
+    'scale-unlimited/declaration-strict-value': [
+      ['color', 'fill', 'stroke', '/-color/'],
+      {
+        // The following are as per the wagtail config but need to be reset here
+        ignoreValues: [
+          'currentColor',
+          'inherit',
+          'initial',
+          'none',
+          'unset',
+          'transparent',
+          'Canvas',
+          'CanvasText',
+          'LinkText',
+          'VisitedText',
+          'ActiveText',
+          'ButtonFace',
+          'ButtonText',
+          'ButtonBorder',
+          'Field',
+          'FieldText',
+          'Highlight',
+          'HighlightText',
+          'SelectedItem',
+          'SelectedItemText',
+          'Mark',
+          'MarkText',
+          'GrayText',
+          'AccentColor',
+          'AccentColorText',
+        ],
+      },
+    ],
+    // Ensure that @include statements are at the top of the declaration block but not nested ones such as the media-query include
+    'order/order': [{ name: 'include', type: 'at-rule', hasBlock: false }, 'declarations'],
+    // Allow positioning with physical properties as right to left languages are not supported
+    'property-disallowed-list': [
+      // The following rules are as per the wagtail config
+      '/forced-color-adjust/',
+      'text-transform',
+    ],
+    // Allow physical values for clear, float and text-align, as right to left languages are not supported
+    'declaration-property-value-allowed-list': {},
+  },
 };

--- a/cms/jinja2/assets/js/blocks/embeddable.js
+++ b/cms/jinja2/assets/js/blocks/embeddable.js
@@ -1,8 +1,0 @@
-// required to set height of pym iframes used in ONSEmbeddable block
-document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('div.pym-interactive').forEach(function (element) {
-        return new pym.Parent(element.getAttribute('id'), element.dataset.url, {
-            title: element.dataset.title
-        });
-    });
-});

--- a/cms/jinja2/component_overrides/header/_macro.njk
+++ b/cms/jinja2/component_overrides/header/_macro.njk
@@ -151,7 +151,7 @@
                         <div class="ons-container">
                             <ul class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40  navigation__key-links ons-list ons-list--bare">
                                 {% for item in params.navLinks.keyLinksList %}
-                                    {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
+                                    {# In the new header, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
                                     {% if item.text %}
                                         <li class="ons-grid__col ons-col-4@m ons-u-mb-no">
                                             {% if item.url %}
@@ -176,7 +176,7 @@
                                 {% for item in params.navLinks.itemsList %}
                                     <li class="ons-grid__col ons-col-4@m ons-u-mb-no">
                                         {% for link in item.linksList %}
-                                            {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting a heading link #}
+                                            {# In the new header, nav items can have text and no link - later we would want to test that both are present before outputting a heading link #}
                                             {% if link.text %}
                                                 {% if link.url %}
                                                     <a
@@ -194,7 +194,7 @@
                                             {% if link.children %}
                                                 <ul class="ons-list ons-list--bare navigation__child-list">
                                                     {% for child in link.children %}
-                                                        {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
+                                                        {# In the new header, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
                                                         {% if child.text %}
                                                             <li class="ons-u-mb-no">
                                                                 {% if child.url %}

--- a/cms/jinja2/component_overrides/header/_macro.njk
+++ b/cms/jinja2/component_overrides/header/_macro.njk
@@ -1,0 +1,230 @@
+{% macro onsHeaderNew(params) %}
+    {#
+        This is an override of ONS "components/header/_macro.njk"
+        It is customised for the following reasons:
+        - Addition of custom classes to create a flex layout using 'gap' - see static_src/sass/components/design_system_overrides/_grid.scss
+        - Overrides to the button classes to accommodate a text button that is visible at desktop (for the new navigation menu button) - see static_src/sass/components/design_system_overrides/_button.scss
+        - Addition of custom styles for the new navigation menu button - see static_src/sass/components/_button-nav.scss
+        - Replace the serviceLinks option with a new navLinks option that creates the drop down menu - it may be possible in the design system to accommodate both
+        - See base.html for the structure needed for navLinks
+        - See static_src/sass/compnents/design_system_overrides/_header.scss for styling customisations
+    #}
+    {% from "components/button/_macro.njk" import onsButton %}
+    {% from "components/icon/_macro.njk" import onsIcon %}
+    {% from "components/navigation/_macro.njk" import onsNavigation %}
+    {% from "components/browser-banner/_macro.njk" import onsBrowserBanner %}
+    {% set titleTag = "h1" if params.titleAsH1 else "div" %}
+    {% set openingTag = "<" + titleTag %}
+    {% set closingTag = "</" + titleTag + ">" %}
+    {% set currentLanguageIsoCode = "en" %}
+
+    {% if params.language and params.language.languages %}
+        {% set currentLanguage = params.language.languages | selectattr("current") | first %}
+        {% set currentLanguageIsoCode = currentLanguage.isoCode %}
+    {% endif %}
+
+    <header
+        class="ons-header{{ ' '+ params.classes if params.classes }}{% if params.variants is not string %}{% for variant in params.variants %}{{ ' ' }}ons-header--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-header--{{ params.variants }}{% endif %}"
+        role="banner"
+    >
+        {{
+            onsBrowserBanner({
+                "lang": currentLanguageIsoCode,
+                "wide": params.wide,
+                "fullWidth": params.fullWidth
+            })
+        }}
+        {% if params.phase %}
+            {% from "components/phase-banner/_macro.njk" import onsPhaseBanner %}
+            {{
+                onsPhaseBanner({
+                    "fullWidth": params.fullWidth,
+                    "wide": params.wide,
+                    "hideBadge": params.phase.hideBadge,
+                    "badge": params.phase.badge,
+                    "html": params.phase.html
+                })
+            }}
+        {% endif %}
+        <div class="ons-header__top">
+            <div class="ons-container{{ ' ons-container--full-width' if params.fullWidth }}{{ ' ons-container--wide' if params.wide }}">
+                <div
+                    class="ons-header__grid-top ons-grid ons-grid-flex ons-grid-flex--between{{ ' '+ params.mastheadLogo.classes if params.mastheadLogo.classes }}{{ ' ons-grid-flex--no-wrap ons-grid--gutterless' if not params.mastheadLogo.multipleLogos }}"
+                >
+                    <div class="ons-grid__col ons-col-auto">
+                        {%- if not params.mastheadLogo.multipleLogos -%}
+
+                            {% set mastheadLogo %}
+                                <div class="ons-header__org-logo ons-header__org-logo--large">
+                                    {% if params.mastheadLogo.large %}
+                                        {{ params.mastheadLogo.large | safe }}
+                                    {% else %}
+                                        {{-
+                                            onsIcon({
+                                                "iconType": 'ons-logo-' + currentLanguageIsoCode,
+                                                "altText": 'Office for National Statistics homepage'
+                                            })
+                                        -}}
+                                    {% endif %}
+                                </div>
+                                <div class="ons-header__org-logo ons-header__org-logo--small">
+                                    {% if params.mastheadLogo.small %}
+                                        {{ params.mastheadLogo.small | safe }}
+                                    {% elif params.mastheadLogo.large %}
+                                        {{ params.mastheadLogo.large | safe }}
+                                    {% else %}
+                                        {{-
+                                            onsIcon({
+                                                "iconType": 'ons-logo-stacked-' + currentLanguageIsoCode,
+                                                "altText": 'Office for National Statistics logo'
+                                            })
+                                        -}}
+                                    {% endif %}
+                                </div>
+                            {% endset %}
+
+                            {%- if params.mastheadLogoUrl -%}
+                                <a class="ons-header__org-logo-link" href="{{ params.mastheadLogoUrl }}">{{ mastheadLogo | safe }}</a>
+                            {% else %}
+                                {{ mastheadLogo | safe }}
+                            {% endif %}
+                        {% else %}
+                            <div class="ons-header__org-logo ons-header__org-logo--multi">
+                                {% set logos = [params.mastheadLogo.multipleLogos.logo1, params.mastheadLogo.multipleLogos.logo2, params.mastheadLogo.multipleLogos.logo3] %}
+                                {% for logo in logos %}
+                                    {% set mastheadLogo %}
+                                        {% if logo.image != "ONS Logo" %}
+                                            {{ logo.image | safe }}
+                                        {% else %}
+                                            {{-
+                                                onsIcon({
+                                                    "iconType": 'ons-logo-stacked-' + currentLanguageIsoCode,
+                                                    "altText": 'Office for National Statistics logo'
+                                                })
+                                            -}}
+                                        {% endif %}
+                                    {% endset %}
+                                    {% if logo.url %}
+                                        <a class="ons-header__org-logo-link" href="{{ logo.url }}">{{ mastheadLogo | safe }}</a>
+                                    {% else %}
+                                        {{ mastheadLogo | safe }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {%- endif -%}
+                    </div>
+                    {# Note that navLinks replaces the previous serviceLinks #}
+                    {% if params.navLinks %}
+                        <div class="ons-header__links ons-grid__col ons-u-ml-auto">
+                            {% if params.navLinks %}
+                                {# May need to be replaced with a custom button - for now use the design system one with some modifications #}
+                                {% set buttonVariant = ["text-link"] %}
+                                <div class="ons-grid__col ons-col-auto">
+                                    {{
+                                        onsButton({
+                                            "text": params.navLinks.toggleNavButton.text | default("Menu"),
+                                            "classes": "ons-u-fs-s--b ons-js-toggle-services button-nav",
+                                            "type": "button",
+                                            "variants": "text-link",
+                                            "iconType": "chevron",
+                                            "iconPosition": "before",
+                                            "attributes": {
+                                                "aria-label": params.navLinks.toggleNavButton.ariaLabel | default("Toggle menu"),
+                                                "aria-controls": params.navLinks.id,
+                                                "aria-expanded": "false"
+                                            }
+                                        })
+                                    }}
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% if params.navLinks %}
+                <nav
+                    class="ons-u-d-no ons-js-services-mobile-nav navigation"
+                    id="{{ params.navLinks.id }}"
+                    aria-label="{{ params.navLinks.ariaLabel | default("Main navigation") }}"
+                >
+                    {% if params.navLinks.keyLinksList %}
+                        <div class="ons-container">
+                            <ul class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40  navigation__key-links ons-list ons-list--bare">
+                                {% for item in params.navLinks.keyLinksList %}
+                                    {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
+                                    {% if item.text %}
+                                        <li class="ons-grid__col ons-col-4@m ons-u-mb-no">
+                                            {% if item.url %}
+                                                <a href="{{ item.url }}" class="navigation__link">
+                                            {% endif %}
+                                                    <h2 class="ons-u-fs-s--b ons-u-mb-no navigation__heading avigation__heading--key-link">{{ item.text }}</h2>
+                                            {% if item.url %}
+                                                </a>
+                                            {% endif %}
+                                            {% if item.description %}
+                                                <p class="ons-u-fs-s ons-u-mb-no navigation__paragraph navigation__paragraph--key-link">{{ item.description }}</p>
+                                            {% endif %}
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+                    {% if params.navLinks.itemsList %}
+                        <div class="ons-container">
+                            <ul class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 ons-list ons-list--bare">
+                                {% for item in params.navLinks.itemsList %}
+                                    <li class="ons-grid__col ons-col-4@m ons-u-mb-no">
+                                        {% for link in item.linksList %}
+                                            {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting a heading link #}
+                                            {% if link.text %}
+                                                {% if link.url %}
+                                                    <a
+                                                        href="{{ link.url }}"
+                                                        class="ons-header-service-nav__link navigation__link"
+                                                    >
+                                                {% endif %}
+                                                    <h2 class="ons-u-fs-s--b navigation__heading">
+                                                        {{ link.text }}
+                                                    </h2>
+                                                {% if link.url %}
+                                                    </a>
+                                                {% endif %}
+                                            {% endif %}
+                                            {% if link.children %}
+                                                <ul class="ons-list ons-list--bare navigation__child-list">
+                                                    {% for child in link.children %}
+                                                        {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
+                                                        {% if child.text %}
+                                                            <li class="ons-u-mb-no">
+                                                                {% if child.url %}
+                                                                    <a
+                                                                        href="{{ child.url }}"
+                                                                        class="ons-header-service-nav__link navigation__link"
+                                                                    >
+                                                                {% endif %}
+                                                                    <p class="ons-u-fs-s navigation__paragraph">
+                                                                        {{ child.text }}
+                                                                    </p>
+                                                                {% if child.url %}
+                                                                    </a>
+                                                                {% endif %}
+                                                            </li>
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </ul>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </li>
+                            {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+                </nav>
+            {% endif %}
+        </div>
+        {% if params.navigation %}
+            {{ onsNavigation(params) }}
+        {% endif %}
+    </header>
+{% endmacro %}

--- a/cms/jinja2/templates/base.html
+++ b/cms/jinja2/templates/base.html
@@ -1,5 +1,6 @@
 {% extends "layout/_template.njk" %}
 {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+{% from "component_overrides/header/_macro.njk" import onsHeaderNew %}
 
 {% set page_title %}
     {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title}}{% endif %}{% endblock %}{% block title_suffix %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} | {{ current_site.site_name }}{% endif %}{% endblock %}
@@ -22,15 +23,227 @@
 ])
 %}
 
+{% if page %}
+    {% set body_class = ["template-", page.get_verbose_name()| lower | replace(" ", "-")] | join %}
+{% else %}
+    {% set body_class = '' %}
+{% endif %}
+
+{%- set page_title -%}
+    {%- with current_site=wagtail_site() -%}
+        {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} - {% endif %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.display_title | default(page.title) }}{% endif %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} - {{ current_site.site_name }}{% endif %}
+    {%- endwith -%}
+{%- endset -%}
+
+{# navlinks are temporarily hard-coded until the back-end menu code is merged #}
 {% set pageConfig = {
+    "bodyClasses": body_class,
+    "title": page_title,
     "header": {
-        "title": page_title,
         "phase": {
             "badge": 'Beta',
             "html": 'This is a new service.'
         },
         "language": {
             "languages": languages
+        },
+        "mastheadLogoUrl": "/",
+        "navLinks": {
+            "id": "nav-links-external",
+            "ariaLabel": 'Main menu',
+            "ariaListLabel": 'Menu',
+            "toggleNavButton": {
+                "text": 'Menu',
+                "ariaLabel": 'Toggle main menu'
+            },
+            "keyLinksList": [
+                {
+                    'text': 'Taking part in a survey?',
+                    'description': 'It’s never been more important.',
+                    "url": False,
+                },
+                {
+                    'text': 'Release calendar',
+                    'description': 'View our latest and upcoming releases.',
+                    "url": False,
+                },
+                {
+                    'text': 'Explore local statistics',
+                    'description': 'Explore statistics across the UK.',
+                    "url": False,
+                }
+            ],
+            "itemsList": [
+                {
+                    "column": "1",
+                    "linksList": [
+                        {
+                            "text": "People, population and community",
+                            "url": False,
+                            "children": [
+                                {
+                                    "text": "Armed forces community",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Births, deaths and marriages",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Crime and justice",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Cultural identity",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Education and childcare",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Elections",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Health and social care",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Household characteristics",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Housing",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Leisure and tourism",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Personal and household finances",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Population and migration",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Well-being",
+                                    "url": False,
+                                }
+                            ]
+                        },
+                    ],
+                },
+                {
+                    "column": "2",
+                    "linksList": [
+                        {
+                            "text": "Business, industry and trade",
+                            "url": False,
+                            "children": [
+                                {
+                                    "text": "Business",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Changes to business",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Construction industry",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "International trade",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "IT and internet industry",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Manufacturing and production industry",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Retail industry",
+                                    "url": TOPIC_PAGE_URL,
+                                },
+                                {
+                                    "text": "Tourism industry",
+                                    "url": False,
+                                }
+                            ]
+                        },
+                        {
+                            "text": "Employment and labour market",
+                            "url": False,
+                            "children":
+                            [
+                                {
+                                    "text": "People in work",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "People not in work",
+                                    "url": False,
+                                }
+                            ]
+
+                        },
+                    ]
+                },
+                {
+                    "column": "3",
+                    "linksList": [
+                        {
+                            "text": "Economy",
+                            "url": False,
+                            "children": [
+                                {
+                                    "text": "Economic output and productivity",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Government, public sector and taxes",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Gross Value Added (GVA)",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Investments, pensions and trusts",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Regional accounts",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Environmental accounts",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Gross Domestic Product (GDP)",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "Inflation and price indices",
+                                    "url": False,
+                                },
+                                {
+                                    "text": "National accounts",
+                                    "url": False,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     },
     "footer": {
@@ -98,6 +311,32 @@
     {% if not IS_EXTERNAL_ENV %}
         {{ wagtailuserbar() }}
     {% endif %}
+{% endblock %}
+
+{% block header %}
+    {{
+    onsHeaderNew({
+    "wide": pageConfig.wide,
+    "fullWidth": pageConfig.fullWidth,
+    "language": pageConfig.header.language,
+    "button": pageConfig.header.signoutButton,
+    "toggleNavigationButton": pageConfig.header.toggleNavigationButton,
+    "navigation": pageConfig.header.navigation,
+    "siteSearchAutosuggest": pageConfig.header.siteSearchAutosuggest,
+    "browserBanner": pageConfig.header.browserBanner,
+    "phase": pageConfig.header.phase,
+    "navLinks": pageConfig.header.navLinks,
+    "variants": pageConfig.header.variants,
+    "classes": pageConfig.header.classes,
+    "mastheadLogo": pageConfig.header.mastheadLogo,
+    "mastheadLogoUrl": pageConfig.header.mastheadLogoUrl,
+    "titleUrl": pageConfig.header.titleUrl,
+    "title": pageConfig.header.title | default(pageConfig.title),
+    "description": pageConfig.header.description,
+    "titleAsH1": pageConfig.header.titleAsH1,
+    "titleLogo": pageConfig.header.titleLogo
+    })
+    }}
 {% endblock %}
 
 {% block scripts %}

--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -1,4 +1,5 @@
 {% extends "templates/base.html" %}
+{% from "components/back-to-top/_macro.njk" import onsBackToTop %}
 
 {% block meta %}
     {% with current_site=wagtail_site() %}
@@ -29,23 +30,21 @@
     {% endwith %}
 {% endblock meta %}
 
-{% block preMain %}
-    {{ super() }}
-    {% include "templates/components/navigation/breadcrumbs.html" %}
-{% endblock %}
-
 {% block pageContent %}
     {# Adds a full-width section for the header area before the main page content #}
     {# Changes the location of the <main> tag from the base template - ensures it surrounds the header area #}
+    {# This change should be adopted by the design system soon #}
     <main id="main-content">
-        {# This will contain the hero on individual templates #}
-        {% block header_area %}{% endblock %}
+        {# This will contain the breadcrumbs on individual templates #}
+        {% block header_area %}
+        {% endblock %}
         <div class="ons-page__container ons-container{{ containerClasses }}">
             <div class="ons-grid">
                 <div class="ons-grid__col ons-col-{{ pageColNumber }}@m {{ pageColClasses }}">
                     {# This is the main tag in the base template in the design system #}
                     <div class="ons-page__main {{ mainColClasses }}">
                         {% block main %}{% endblock %}
+                        {{ onsBackToTop() }}
                     </div>
                 </div>
             </div>

--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -44,7 +44,7 @@
                     {# This is the main tag in the base template in the design system #}
                     <div class="ons-page__main {{ mainColClasses }}">
                         {% block main %}{% endblock %}
-                        {{ onsBackToTop() }}
+                        {{ onsBackToTop() }}{# used in small viewports #}
                     </div>
                 </div>
             </div>

--- a/cms/jinja2/templates/components/accredited/accredited-logo.html
+++ b/cms/jinja2/templates/components/accredited/accredited-logo.html
@@ -1,3 +1,3 @@
-<a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/" class="national-statistics__link ons-u-ml-s">
-    <img src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/v2/uksa-kitemark-en.svg" alt="UK Statistics Authority Kitemark" class="osr__logo" width="90">
+<a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/" class="analysis-header__link">
+    <img src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/v2/uksa-kitemark-en.svg" alt="UK Statistics Authority Kitemark" class="analysis-header__accreditation-logo" width="90">
 </a>

--- a/cms/jinja2/templates/components/streamfield/analysis_section_block.html
+++ b/cms/jinja2/templates/components/streamfield/analysis_section_block.html
@@ -1,5 +1,5 @@
 <section id="{{ value.title|slugify() }}">
-    <h2 class="heading-2">{{ value.title }}</h2>
+    <h2 class="ons-u-fs-l">{{ value.title }}</h2>
 
     {% include_block value.content %}
 </section>

--- a/cms/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/cms/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -1,13 +1,13 @@
 <div class="ons-container headline-figures">
-    <h2 class="headline-figures__heading ons-u-fs-l">{{ _("Headline facts and figures") }}</h2>
+    <h2 class="headline-figures__heading ons-u-fs-m">{{ _("Headline facts and figures") }}</h2>
     <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--24 headline-figures__grid">
         {% for figure in value %}
             <div class="ons-grid__col">
                 <div class="headline-figures__block">
-                    <h3 class="headline-figures__title">
+                    <h3 class="headline-figures__title ons-u-fs-m">
                         {{ figure.title }}
                     </h3>
-                    <p class="headline-figures__figure">{{ figure.figure }}</p>
+                    <p class="headline-figures__figure ons-u-fs-2xl">{{ figure.figure }}</p>
 
                     <p class="headline-figures__supporting-text ons-u-fs-r">{{ figure.supporting_text }}</p>
                 </div>

--- a/cms/jinja2/templates/components/streamfield/ons_embed_block.html
+++ b/cms/jinja2/templates/components/streamfield/ons_embed_block.html
@@ -1,10 +1,11 @@
 <div class="ons-u-mb-s">
-    <div class="pym-interactive"
-         id="{{ block_id }}"
-         data-url="{{ value.url }}"
-         data-title="{{ value.title }}">
+    <div
+        data-chart-iframe
+        id="{{ block_id }}"
+        data-url="{{ value.url }}"
+        data-title="{{ value.title }}">
         <iframe src="{{ value.url }}"
-                title="{{ value.title }}">
+            title="{{ value.title }}">
         </iframe>
     </div>
 </div>

--- a/cms/jinja2/templates/components/streamfield/ons_embed_block.html
+++ b/cms/jinja2/templates/components/streamfield/ons_embed_block.html
@@ -5,7 +5,7 @@
         data-url="{{ value.url }}"
         data-title="{{ value.title }}">
         <iframe src="{{ value.url }}"
-            title="{{ value.title }}">
+                title="{{ value.title }}">
         </iframe>
     </div>
 </div>

--- a/cms/jinja2/templates/pages/analysis_page.html
+++ b/cms/jinja2/templates/pages/analysis_page.html
@@ -4,11 +4,12 @@
 {% from "components/table-of-contents/_macro.njk" import onsTableOfContents %}
 {% from "components/text-indent/_macro.njk" import onsTextIndent %}
 
+
 {% block header_area %}
-    <div class="analysis-header">
+    <div class="analysis-header {% if page.updates %}analysis-header--flush{% endif %}">
         <div class="ons-container">
             {% include "templates/components/navigation/breadcrumbs.html" %}
-            <p class="analysis-header__doc-type">{{ _("Analysis") }}</p>
+            <p class="analysis-header__doc-type ons-u-fs-l">{{ _("Analysis") }}</p>
 
             <div class="ons-grid ons-grid-flex-gap">
                 <div class="ons-grid__col ons-col-10@m ">
@@ -16,7 +17,7 @@
                         {{ page.display_title }}
                     </h1>
 
-                    <p class="analysis-header__summary">{{ page.summary|richtext() }}</p>
+                    <div class="analysis-header__summary">{{ page.summary|richtext() }}</div>
                 </div>
                 <div class="ons-grid__col ons-col-2@m analysis-header__kitemark">
                     {% if page.is_accredited %}
@@ -27,43 +28,45 @@
         </div>
 
         {% block release_meta %}
-            <div class="ons-container">
-                {% if page.is_census %}
+            {% if page.is_census %}
+                <div class="ons-container">
                     {% include "templates/components/census/census-logo.html" %}
+                </div>
+            {% endif %}
+            <div class="ons-container analysis-header__releases">
+                <div>
+                    <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Release date") }}:</span>
+                    <span class="ons-u-nowrap">{{ page.release_date|date("DATE_FORMAT") }}</span>
+                </div>
+                <div>
+                    <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Next release") }}:</span>
+                    <span class="ons-u-nowrap">{{ page.next_release_date|date("DATE_FORMAT") or _("To be announced") }}</span>
+                </div>
+                <div>
+                    <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Edition") }}:</span>
+                    <span class="ons-u-nowrap">{{ _("Latest") }}</span>
+                </div>
+                <div>
+                    <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Releases") }}:</span>
+                    {% if page.is_latest %}
+                        <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
+                    {% else %}
+                        <a href="{{ routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
+                    {% endif %}
+                </div>
+                {% if page.contact_details %}
+                    <div>
+                        <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Contact") }}:</span>
+                        <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
+                    </div>
                 {% endif %}
-                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 analysis-header__releases">
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Release date") }}:</span>
-                        <span class="ons-u-nowrap">{{ page.release_date|date("DATE_FORMAT") }}</span>
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Edition") }}:</span>
-                        <span class="ons-u-nowrap">{{ _("Latest") }}</span>
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        {% if page.contact_details %}
-                            <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Contact") }}:</span>
-                            <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 analysis-header__releases">
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b analysis-header__releases-label">{{ _("Next release") }}:</span>
-                        <span class="ons-u-nowrap">{{ page.next_release_date|date("DATE_FORMAT") or _("To be announced") }}</span>
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Releases") }}:</span>
-                        {% if page.is_latest %}
-                            <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
-                        {% else %}
-                            <a href="{{ routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
-                        {% endif %}
-                    </div>
-                </div>
             </div>
         {% endblock %}
     </div>
+
+    {% if page.updates %}
+        {% include_block page.updates %}
+    {% endif %}
 
     {% if page.headline_figures %}
         {% include_block page.headline_figures %}
@@ -103,7 +106,7 @@
 
                 {% if page.show_cite_this_page %}
                     <section id="cite-this-page">
-                        <h2 class="heading-2">{{ _("Cite this analysis") }}</h2>
+                        <h2 class="ons-u-fs-l">{{ _("Cite this analysis") }}</h2>
                         <p>
                             {%- set cite_link -%}
                                 <a href="{{ fullpageurl(page) }}">{{ page.display_title }}</a>
@@ -117,7 +120,7 @@
 
                 {% if page.contact_details %}
                     <section id="contact-details">
-                        <h2 class="heading-2">{{ _("Contact details") }}</h2>
+                        <h2 class="ons-u-fs-l">{{ _("Contact details") }}</h2>
 
                         {% call onsTextIndent() %}
                             <p class="contact-details__line">

--- a/cms/jinja2/templates/pages/theme_page.html
+++ b/cms/jinja2/templates/pages/theme_page.html
@@ -4,7 +4,7 @@
     <div class="theme-header">
         <div class="ons-container">
             {% include "templates/components/navigation/breadcrumbs.html" %}
-            <p class="theme-header__doc-type">{{ _("Theme") }}</p>
+            <p class="theme-header__doc-type ons-u-fs-l">{{ _("Theme") }}</p>
 
             <div class="ons-grid">
                 <div class="ons-grid__col ons-col-8@m">

--- a/cms/jinja2/templates/pages/topic_page.html
+++ b/cms/jinja2/templates/pages/topic_page.html
@@ -9,7 +9,7 @@
         </div>
         <div class="ons-container">
             {% include "templates/components/navigation/breadcrumbs.html" %}
-            <p class="topic-header__doc-type">Topic</p>
+            <p class="topic-header__doc-type">{{ _("Topic") }}</p>
 
             <div class="ons-grid">
                 <div class="ons-grid__col ons-col-8@m ">

--- a/cms/jinja2/templates/pages/topic_page.html
+++ b/cms/jinja2/templates/pages/topic_page.html
@@ -2,20 +2,30 @@
 
 {% block header_area %}
     <div class="topic-header">
+        <div class="topic-header__circles" aria-hidden="true">
+            <div class="topic-header__circle-one"></div>
+            <div class="topic-header__circle-two"></div>
+            <div class="topic-header__circle-three"></div>
+        </div>
         <div class="ons-container">
             {% include "templates/components/navigation/breadcrumbs.html" %}
-            <p class="topic-header__doc-type">{{ _("Topic") }}</p>
+            <p class="topic-header__doc-type">Topic</p>
 
             <div class="ons-grid">
-                <div class="ons-grid__col ons-col-8@m">
+                <div class="ons-grid__col ons-col-8@m ">
                     <h1 class="ons-u-fs-3xl topic-header__heading">
                         {{ page.title }}
                     </h1>
-                    <p class="topic-header__summary">{{ page.summary|richtext() }}</p>
+                    <div class="topic-header__summary">{{ page.summary|richtext }}</div>
                 </div>
             </div>
         </div>
     </div>
 
+    {% if page.headline_figures %}
+        {% include_block page.headline_figures %}
+    {% endif %}
+
     {{ super() }}
+
 {% endblock %}

--- a/cms/static_src/javascript/components/iframe-resize.js
+++ b/cms/static_src/javascript/components/iframe-resize.js
@@ -1,0 +1,18 @@
+/* global pym */
+
+class IframeResize {
+  static selector() {
+    return '[data-chart-iframe]';
+  }
+
+  constructor(node) {
+    this.node = node;
+    /* eslint-disable no-new */
+    new pym.Parent(this.node.getAttribute('id'), this.node.dataset.url, {
+      title: this.node.dataset.title,
+    });
+    /* eslint-enable no-new */
+  }
+}
+
+export default IframeResize;

--- a/cms/static_src/javascript/main.js
+++ b/cms/static_src/javascript/main.js
@@ -1,1 +1,12 @@
+import IframeResize from './components/iframe-resize';
+
 import '../sass/main.scss';
+
+function initComponent(ComponentClass) {
+  const items = document.querySelectorAll(ComponentClass.selector());
+  items.forEach((item) => new ComponentClass(item));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initComponent(IframeResize);
+});

--- a/cms/static_src/sass/components/_analysis-header.scss
+++ b/cms/static_src/sass/components/_analysis-header.scss
@@ -1,0 +1,93 @@
+@use 'config' as *;
+
+.analysis-header {
+    // this colour is in figma but not in the design system
+    background-color: $color--pale-grey;
+    position: relative;
+    padding-bottom: rem-sizing(64);
+    margin-bottom: rem-sizing(24);
+
+    @include media-query('m') {
+        margin-bottom: rem-sizing(40);
+    }
+
+    &--flush {
+        margin-bottom: 0;
+    }
+
+    &::before {
+        position: absolute;
+        inset: 0;
+        width: 150%;
+        height: 100%;
+        left: -40%;
+        border-radius: 0 0 50% 50%;
+        background-color: var(--ons-color-grey-5);
+        content: '';
+
+        @include media-query('l') {
+            border-radius: 0 0 80% 50%;
+            left: -25%;
+            width: 130%;
+        }
+    }
+
+    &__doc-type {
+        font-weight: 700;
+        color: var(--ons-color-ocean-blue);
+        margin-bottom: 0;
+    }
+
+    &__heading {
+        margin-bottom: rem-sizing(40);
+
+        @include media-query('m') {
+            margin-bottom: rem-sizing(16);
+        }
+    }
+
+    &__kitemark {
+        margin-bottom: rem-sizing(16);
+
+        @include media-query('l') {
+            text-align: right;
+        }
+    }
+
+    &__accreditation-link {
+        display: inline-block;
+    }
+
+    &__accreditation-logo {
+        // compensates for whitespace in logo
+        position: relative;
+        right: rem-sizing(10);
+
+        @include media-query('l') {
+            right: rem-sizing(-10);
+        }
+    }
+
+    &__summary {
+        margin-bottom: rem-sizing(16);
+
+        @include media-query('l') {
+            margin-bottom: rem-sizing(40);
+        }
+    }
+
+    &__releases {
+        display: grid;
+        gap: rem-sizing(8) rem-sizing(40);
+
+        @include media-query('l') {
+            grid-template-rows: 1fr 1fr;
+            grid-template-columns: 1fr 1fr 1fr;
+            grid-auto-flow: column;
+        }
+    }
+
+    &__releases-label {
+        margin-right: 16px;
+    }
+}

--- a/cms/static_src/sass/components/_button-nav.scss
+++ b/cms/static_src/sass/components/_button-nav.scss
@@ -1,0 +1,33 @@
+@use 'config' as *;
+
+.button-nav {
+    padding: 0 rem-sizing(24);
+    height: 67px;
+    display: flex;
+    align-items: center;
+
+    @include media-query('l') {
+        height: 72px;
+    }
+
+    &:focus {
+        background-color: var(--ons-color-focus);
+    }
+
+    /* stylelint-disable selector-max-specificity */
+    &[aria-expanded='true'],
+    &:focus &:active {
+        background-color: var(--ons-color-branded-tint);
+    }
+
+    // override design system focus styles
+    &:focus .ons-btn__inner,
+    &:active:focus .ons-btn__inner,
+    &.active:focus .ons-btn__inner {
+        /* stylelint-disable declaration-no-important */
+        box-shadow: none !important;
+        background-color: transparent !important;
+        /* stylelint-enable declaration-no-important */
+    }
+    /* stylelint-enable selector-max-specificity */
+}

--- a/cms/static_src/sass/components/_chart-embed.scss
+++ b/cms/static_src/sass/components/_chart-embed.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+.chart-embed {
+    padding: rem-sizing(24) 0;
+    border-top: 1px solid var(--ons-color-grey-75);
+    border-bottom: 1px solid var(--ons-color-grey-75);
+
+    &__heading {
+        margin-bottom: rem-sizing(32);
+    }
+}

--- a/cms/static_src/sass/components/_contact-details.scss
+++ b/cms/static_src/sass/components/_contact-details.scss
@@ -1,0 +1,7 @@
+@use 'config' as *;
+
+.contact-details {
+    &__line {
+        margin-bottom: 0;
+    }
+}

--- a/cms/static_src/sass/components/_corrections.scss
+++ b/cms/static_src/sass/components/_corrections.scss
@@ -1,0 +1,142 @@
+@use 'config' as *;
+
+.corrections {
+    $root: &;
+    background-color: var(--ons-color-info-tint);
+    // for high contrast mode
+    border: 1px solid var(--ons-color-info-tint);
+
+    &__info-icon {
+        width: 32px;
+        height: 32px;
+        color: var(--ons-color-white);
+        margin-right: rem-sizing(8);
+
+        #{$root}__summary:focus & {
+            color: var(--ons-color-night-blue);
+        }
+
+        @media (forced-colors: active) and (prefers-color-scheme: dark) {
+            color: var(--ons-color-white);
+
+            #{$root}__summary:focus & {
+                color: var(--ons-color-white);
+            }
+        }
+
+        @media (forced-colors: active) and (prefers-color-scheme: light) {
+            color: var(--ons-color-night-blue);
+
+            #{$root}__summary:focus & {
+                color: var(--ons-color-night-blue);
+            }
+        }
+    }
+
+    &__summary::-webkit-details-marker {
+        // hide default details marker for safari
+        display: none;
+    }
+
+    &__summary {
+        // hide default details marker for most browsers
+        list-style: none;
+        background-color: var(--ons-color-ocean-blue);
+        color: var(--ons-color-white);
+        cursor: pointer;
+        // for high contrast mode
+        border: 1px solid var(--ons-color-ocean-blue);
+
+        &:focus {
+            // duplicate of ons focus styles
+            background-color: var(--ons-color-focus);
+            box-decoration-break: clone;
+            box-shadow:
+                0 -2px var(--ons-color-focus),
+                0 4px var(--ons-color-text-link-focus);
+            color: var(--ons-color-text-link-focus);
+            outline: 3px solid transparent;
+            outline-offset: 1px;
+            text-decoration: none;
+        }
+    }
+
+    &__summary-contents {
+        display: flex;
+        align-items: center;
+    }
+
+    &__summary-reveal,
+    &__summary-hide {
+        display: block;
+        padding-right: 20px;
+        text-decoration: underline;
+        justify-self: flex-end;
+        margin-left: auto;
+        padding-left: rem-sizing(8);
+
+        #{$root}__summary:hover &,
+        #{$root}__summary:focus & {
+            text-decoration-thickness: 2px;
+        }
+    }
+
+    &__summary-reveal {
+        #{$root}[open] & {
+            display: none;
+        }
+    }
+
+    &__summary-hide {
+        display: none;
+
+        #{$root}[open] & {
+            display: block;
+        }
+    }
+
+    &__summary-icon {
+        width: 16px;
+        height: 16px;
+    }
+
+    &__summary-details {
+        display: none;
+
+        @include media-query('l') {
+            display: block;
+            margin-left: rem-sizing(10);
+        }
+    }
+
+    &__item {
+        display: flex;
+        flex-direction: column;
+
+        @include media-query('m') {
+            flex-direction: row;
+            column-gap: rem-sizing(40);
+        }
+
+        &:not(:last-child) {
+            padding-bottom: rem-sizing(24);
+            border-bottom: 1px solid var(--ons-color-text-light);
+            margin-bottom: rem-sizing(24);
+        }
+    }
+
+    &__meta {
+        margin-bottom: rem-sizing(24);
+
+        @include media-query('m') {
+            flex-basis: 25%;
+            min-width: 200px;
+            margin-bottom: 0;
+        }
+    }
+
+    &__heading {
+        color: $color--full-black;
+        margin-bottom: 0;
+    }
+}

--- a/cms/static_src/sass/components/_document-list-block.scss
+++ b/cms/static_src/sass/components/_document-list-block.scss
@@ -1,0 +1,13 @@
+@use 'config' as *;
+
+.document-list-block {
+    margin-bottom: rem-sizing(64);
+
+    /* stylelint-disable selector-class-pattern */
+    .block-document_list:last-child & {
+        margin-bottom: 0;
+    }
+    /*
+    stylelint-enable selector-class-pattern
+    */
+}

--- a/cms/static_src/sass/components/_featured-chart.scss
+++ b/cms/static_src/sass/components/_featured-chart.scss
@@ -1,0 +1,41 @@
+@use 'config' as *;
+
+/* Uses similar styles to the featured document block
+ Does not use flex display as it messes up the iframe resize for pym */
+
+.featured-chart {
+    margin-bottom: rem-sizing(64);
+
+    &__item {
+        background-color: var(--ons-color-banner-bg);
+        outline: 2px solid transparent; // for high contrast mode
+        outline-offset: -2px;
+        padding: rem-sizing(32);
+    }
+
+    &__metadata {
+        padding: 0;
+        margin-bottom: rem-sizing(16);
+    }
+
+    &__item-attribute {
+        color: var(--ons-color-text-metadata);
+        display: inline-block;
+        margin: 0 1rem 0 0;
+    }
+
+    &__item-description {
+        margin-bottom: 0;
+        max-width: 660px;
+
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+
+    &__embed-container {
+        padding-top: rem-sizing(32);
+        border-bottom: 1px solid var(--ons-color-grey-35);
+        margin-bottom: rem-sizing(32);
+    }
+}

--- a/cms/static_src/sass/components/_headline-figures.scss
+++ b/cms/static_src/sass/components/_headline-figures.scss
@@ -1,0 +1,50 @@
+@use 'config' as *;
+
+.headline-figures {
+    //padding-top: rem-sizing(24);
+    padding-bottom: rem-sizing(40);
+
+    &__grid {
+        row-gap: rem-sizing(24);
+    }
+
+    &__block {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        height: 100%;
+        column-gap: rem-sizing(40);
+        background-color: var(--ons-color-grey-5);
+        padding: rem-sizing(24);
+
+        @include media-query('s') {
+            display: flex;
+            flex-direction: column;
+        }
+
+        @media (forced-colors: active) {
+            border: 1px solid var(--ons-color-grey-5);
+        }
+    }
+
+    &__heading {
+        margin-bottom: rem-sizing(16);
+    }
+
+    &__figure {
+        font-weight: 700;
+        margin-bottom: 0;
+
+        @include media-query('s') {
+            margin-bottom: rem-sizing(8);
+        }
+
+        @include media-query('l') {
+            margin-top: auto;
+        }
+    }
+
+    &__supporting-text {
+        margin-bottom: 0;
+        grid-column: 1 / span 2;
+    }
+}

--- a/cms/static_src/sass/components/_landing-header.scss
+++ b/cms/static_src/sass/components/_landing-header.scss
@@ -1,0 +1,248 @@
+@use 'config' as *;
+
+.landing-header {
+    // this colour is in figma but not in the design system
+    background-color: $color--deep-grey-blue;
+    color: var(--ons-color-white);
+    position: relative;
+    padding-bottom: rem-sizing(96);
+    margin-bottom: rem-sizing(40);
+    overflow: hidden;
+
+    @include media-query('l') {
+        padding-bottom: rem-sizing(64);
+    }
+
+    &::before {
+        position: absolute;
+        inset: 0;
+        width: 150%;
+        height: 100%;
+        left: -40%;
+        border-radius: 0 0 50% 50%;
+        // this colour is in figma but not in the design system
+        background-color: $color--midnight-blue;
+        content: '';
+
+        @include media-query('l') {
+            border-radius: 0 0 300% 80%;
+            width: 100%;
+            left: 0;
+        }
+    }
+
+    // home page has no breadcrumbs
+    .template-home-page & {
+        padding-top: rem-sizing(64);
+    }
+
+    &__circle-one {
+        @include media-query('l') {
+            position: absolute;
+            width: 59px;
+            height: 59px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            top: -11px;
+            right: 289px;
+        }
+    }
+
+    &__circle-two {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 11px;
+            right: 193px;
+        }
+    }
+
+    &__circle-three {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 25px;
+            right: 112px;
+        }
+    }
+
+    &__circle-four {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 80px;
+            right: 208px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-ocean-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.4;
+            }
+        }
+    }
+
+    &__circle-five {
+        @include media-query('l') {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 187px;
+            right: 222px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-sky-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__circle-six {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            top: 188px;
+            right: 135px;
+        }
+    }
+
+    &__circle-seven {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 188px;
+            right: 24px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-night-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__circle-eight {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: 27px;
+            right: 275px;
+        }
+    }
+
+    &__circle-nine {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            bottom: -4px;
+            right: 215px;
+        }
+    }
+
+    &__circle-ten {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: 20px;
+            right: 120px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-aqua-teal);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.4;
+            }
+        }
+    }
+
+    &__circle-eleven {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: -10px;
+            right: 75px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-sky-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__heading {
+        margin-bottom: rem-sizing(16);
+    }
+
+    &__summary {
+        margin-bottom: 0;
+    }
+}

--- a/cms/static_src/sass/components/_navigation.scss
+++ b/cms/static_src/sass/components/_navigation.scss
@@ -1,0 +1,61 @@
+@use 'config' as *;
+
+/*
+New navigation styling for beta
+*/
+
+.navigation {
+    background-color: var(--ons-color-branded-tint);
+    width: 100%;
+    margin-bottom: rem-sizing(16);
+    padding-top: rem-sizing(40);
+
+    &__key-links {
+        border-bottom: 1px solid var(--ons-color-ocean-blue);
+        row-gap: rem-sizing(16);
+        padding-bottom: rem-sizing(16);
+        margin-bottom: rem-sizing(20);
+
+        @include media-query('l') {
+            padding-bottom: rem-sizing(24);
+        }
+    }
+
+    &__child-list {
+        margin-bottom: rem-sizing(32);
+    }
+
+    &__link {
+        display: inline-block;
+
+        // override design system focus style
+        &:focus {
+            /* stylelint-disable declaration-no-important */
+            box-shadow: none !important;
+            text-decoration: underline !important;
+            color: var(--ons-color-text-link) !important;
+            /* stylelint-enable declaration-no-important */
+        }
+    }
+
+    &__heading,
+    &__paragraph {
+        line-height: 1.714;
+    }
+
+    &__heading {
+        margin-bottom: rem-sizing(16);
+
+        &--key-link {
+            margin-bottom: 0;
+        }
+    }
+
+    &__paragraph {
+        margin-bottom: rem-sizing(8);
+
+        &--key-link {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/_panel.scss
+++ b/cms/static_src/sass/components/_panel.scss
@@ -1,0 +1,7 @@
+@use 'config' as *;
+
+.panel {
+    @include media-query('l') {
+        padding: rem-sizing(24) rem-sizing(24) rem-sizing(24) rem-sizing(39);
+    }
+}

--- a/cms/static_src/sass/components/_responsive-object.scss
+++ b/cms/static_src/sass/components/_responsive-object.scss
@@ -1,0 +1,14 @@
+// // Custom CSS from Wagtail doc to enable responsive video embeds
+.responsive-object {
+    position: relative;
+}
+
+.responsive-object iframe,
+.responsive-object object,
+.responsive-object embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/cms/static_src/sass/components/_rich-text.scss
+++ b/cms/static_src/sass/components/_rich-text.scss
@@ -1,0 +1,40 @@
+@use 'config' as *;
+
+.rich-text {
+    // In the document block list styling from ONS, we don't want list items inside rich-text to have circle styling
+    .ons-document-list & {
+        ul {
+            list-style-type: disc;
+        }
+    }
+
+    hr {
+        margin-bottom: rem-sizing(32);
+    }
+
+    p {
+        margin-bottom: rem-sizing(32);
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    // Reduce bottom margin on elements in the corrections block
+    .corrections__item & {
+        p,
+        ul,
+        ol {
+            margin-bottom: rem-sizing(10);
+        }
+    }
+
+    // for the 'notice' corrections, remove the last element's bottom margin as there is no link below
+    .corrections__item--notice & {
+        p:last-child,
+        ul:last-child,
+        ol:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/_streamfield.scss
+++ b/cms/static_src/sass/components/_streamfield.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+.streamfield {
+    margin-bottom: rem-sizing(64);
+
+    &--last-flush {
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/_topic-header.scss
+++ b/cms/static_src/sass/components/_topic-header.scss
@@ -1,0 +1,115 @@
+@use 'config' as *;
+
+.topic-header {
+    // this colour is in figma but not in the design system
+    background-color: $color--grey-blue;
+    position: relative;
+    padding-bottom: rem-sizing(96);
+    margin-bottom: rem-sizing(40);
+    overflow: hidden;
+
+    &::before {
+        position: absolute;
+        inset: 0;
+        width: 150%;
+        height: 100%;
+        left: -40%;
+        border-radius: 0 0 50% 50%;
+        // this colour is in figma but not in the design system
+        background-color: $color--pale-blue;
+        content: '';
+
+        @include media-query('l') {
+            border-radius: 0 0 80% 50%;
+            left: -25%;
+            width: 130%;
+        }
+    }
+
+    @include media-query('l') {
+        padding-bottom: rem-sizing(64);
+    }
+
+    &__circle-one {
+        @include media-query('l') {
+            position: absolute;
+            width: 440px;
+            height: 440px;
+            // this colour is in figma but not in the design system
+            background-color: $color--grey-blue;
+            border-radius: 50%;
+            top: -339px;
+            right: 59px;
+        }
+    }
+
+    &__circle-two {
+        position: absolute;
+        width: 40px;
+        height: 40px;
+        // this colour is in figma but not in the design system
+        background-color: $color--buff;
+        border-radius: 50%;
+        // these are relative to the 'before' styled curve
+        bottom: 4%;
+        right: 15%;
+
+        @include media-query('m') {
+            bottom: 8%;
+            right: 10%;
+        }
+
+        @include media-query('l') {
+            width: 72px;
+            height: 72px;
+            bottom: 30%;
+            right: 25%;
+        }
+
+        @include media-query('xl') {
+            right: 346px;
+        }
+    }
+
+    &__circle-three {
+        position: absolute;
+        width: 80px;
+        height: 80px;
+        background-color: var(--ons-color-ocean-blue);
+        border-radius: 50%;
+        bottom: 7%;
+        right: -26px;
+
+        @include media-query('m') {
+            bottom: 9%;
+        }
+
+        @include media-query('l') {
+            width: 156px;
+            height: 156px;
+            right: 2%;
+        }
+
+        @include media-query('xl') {
+            right: 43px;
+        }
+    }
+
+    &__doc-type {
+        font-weight: 700;
+        color: var(--ons-color-ocean-blue);
+        margin-bottom: 0;
+    }
+
+    &__heading {
+        margin-bottom: rem-sizing(16);
+    }
+
+    &__summary {
+        margin-bottom: rem-sizing(24);
+
+        @include media-query('m') {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/design_system_overrides/_back-to-top.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_back-to-top.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+// overrides to ons back-to-top styles
+.ons-back-to-top {
+    margin-top: rem-sizing(64);
+
+    // hide at desktop
+    @include media-query('m') {
+        display: none;
+    }
+}

--- a/cms/static_src/sass/components/design_system_overrides/_button.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_button.scss
@@ -1,0 +1,21 @@
+@use 'config' as *;
+
+// overrides the ons button styles - used for the menu button in the header
+.ons-btn {
+    &--text-link {
+        // needs to be visible at desktop
+        @include media-query('l') {
+            display: inline-block;
+        }
+
+        .ons-btn__inner {
+            font-weight: 700;
+        }
+
+        .ons-icon {
+            width: rem-sizing(16);
+            height: rem-sizing(16);
+            margin-top: 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/design_system_overrides/_container.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_container.scss
@@ -1,0 +1,8 @@
+@use 'config' as *;
+
+// overrides to ons container styles
+.ons-container {
+    max-width: rem-sizing(
+        1056
+    ); // with 1rem padding either side, content is then 1024px wide to match the designs
+}

--- a/cms/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_grid.scss
@@ -1,0 +1,40 @@
+@use 'config' as *;
+
+/* Addition to ons grid to use 'gap' to set widths between columns
+ Adds custom gap values to match the designs */
+
+.ons-grid-flex-gap {
+    display: flex;
+    margin-left: 0;
+    flex-flow: column nowrap;
+
+    @include media-query('m') {
+        flex-direction: row;
+    }
+
+    &--40 {
+        column-gap: rem-sizing(40);
+    }
+
+    &--32 {
+        column-gap: rem-sizing(32);
+    }
+
+    &--24 {
+        column-gap: rem-sizing(24);
+    }
+}
+
+.ons-grid__col {
+    .ons-grid-flex-gap & {
+        padding-left: 0;
+    }
+
+    /* stylelint-disable selector-class-pattern */
+    &--sticky\@m {
+        .ons-grid-flex-gap & {
+            align-self: flex-start;
+        }
+    }
+    /* stylelint-enable selector-class-pattern */
+}

--- a/cms/static_src/sass/components/design_system_overrides/_header.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_header.scss
@@ -1,0 +1,21 @@
+@use 'config' as *;
+
+/*
+Overrides to ons header styles
+Padding is moved to the logo element in order to allow the menu button to fill the full
+height of .ons-header__grid-top
+*/
+
+.ons-header {
+    &__grid-top {
+        padding: 0;
+    }
+
+    &__org-logo {
+        padding: rem-sizing(20) 0;
+
+        @include media-query('l') {
+            padding: rem-sizing(24) 0;
+        }
+    }
+}

--- a/cms/static_src/sass/components/design_system_overrides/_page.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_page.scss
@@ -1,0 +1,8 @@
+@use 'config' as *;
+
+// overrides to ons page styles - to be discussed if these should be merged back to the design system
+.ons-page {
+    &__main {
+        margin-bottom: rem-sizing(80);
+    }
+}

--- a/cms/static_src/sass/components/design_system_overrides/_toc.scss
+++ b/cms/static_src/sass/components/design_system_overrides/_toc.scss
@@ -1,0 +1,8 @@
+@use 'config' as *;
+
+// overrides to ons table of contents styles - to be discussed if these should be merged back to the design system
+.ons-toc {
+    &-container {
+        border-bottom: 0;
+    }
+}

--- a/cms/static_src/sass/config.scss
+++ b/cms/static_src/sass/config.scss
@@ -1,0 +1,4 @@
+// Abstracts
+@forward 'config/functions';
+@forward 'config/mixins';
+@forward 'config/variables';

--- a/cms/static_src/sass/config/_functions.scss
+++ b/cms/static_src/sass/config/_functions.scss
@@ -1,0 +1,9 @@
+@use 'sass:math';
+
+@function rem-sizing($pxValue) {
+    $remValue: math.div($pxValue, 16);
+    @if $remValue == 0 {
+        @return 0;
+    }
+    @return $remValue * 1rem;
+}

--- a/cms/static_src/sass/config/_mixins.scss
+++ b/cms/static_src/sass/config/_mixins.scss
@@ -1,0 +1,19 @@
+@use 'sass:list';
+
+@use 'variables' as *;
+@use 'functions' as *;
+
+@mixin media-query($queries...) {
+    @each $query in $queries {
+        @each $breakpoint in $breakpoints {
+            $name: list.nth($breakpoint, 1);
+            $declaration: list.nth($breakpoint, 2);
+
+            @if $query == $name and $declaration {
+                @media only screen and #{$declaration} {
+                    @content;
+                }
+            }
+        }
+    }
+}

--- a/cms/static_src/sass/config/_variables.scss
+++ b/cms/static_src/sass/config/_variables.scss
@@ -1,0 +1,20 @@
+// Based on https://github.com/ONSdigital/design-system/blob/d3c30b9400c9f0bdfca21f838d82b8890bd1ec05/migration_guides/70.x.x-to-72.0.0-migration-guide.md?plain=1#L196
+$breakpoints: (
+    '2xs' '(min-width: 300px)',
+    'xs' '(min-width: 400px)',
+    's' '(min-width: 500px)',
+    'm' '(min-width: 740px)',
+    'l' '(min-width: 980px)',
+    'xl' '(min-width: 1300px)',
+    '2xl' '(min-width: 1600px)'
+);
+
+// These colour variables are set in the figma file but not in the design-system
+
+$color--buff: #e8bb9b;
+$color--pale-grey: #efeff0;
+$color--pale-blue: #e7eff4;
+$color--grey-blue: #dee7ee;
+$color--midnight-blue: #153b55;
+$color--deep-grey-blue: #194766;
+$color--full-black: #000;

--- a/cms/static_src/sass/main.scss
+++ b/cms/static_src/sass/main.scss
@@ -1,20 +1,28 @@
-// temporary css rule so the file is not empty
-body {
-    display: block;
-}
+/* The main scss file for the site, which imports all other scss files
+Don't add css code directly to this file, add it to the relevant component file instead */
 
-// Custom CSS from Wagtail doc to enable responsive video embeds
-.responsive-object {
-    position: relative;
-}
+// New components not yet in the design system
+@use 'components/analysis-header';
+@use 'components/button-nav';
+@use 'components/corrections';
+@use 'components/document-list-block';
+@use 'components/chart-embed';
+@use 'components/contact-details';
+@use 'components/featured-chart';
+@use 'components/headline-figures';
+@use 'components/landing-header';
+@use 'components/navigation';
+@use 'components/panel';
+@use 'components/responsive-object';
+@use 'components/rich-text';
+@use 'components/streamfield';
+@use 'components/topic-header';
 
-.responsive-object iframe,
-.responsive-object object,
-.responsive-object embed {
-    position: absolute;
-    top: 0;
-    /* stylelint-disable-next-line property-disallowed-list */
-    left: 0;
-    width: 100%;
-    height: 100%;
-}
+// ONS design system overrides (until these are no longer needed)
+@use 'components/design_system_overrides/back-to-top';
+@use 'components/design_system_overrides/button';
+@use 'components/design_system_overrides/container';
+@use 'components/design_system_overrides/grid';
+@use 'components/design_system_overrides/header';
+@use 'components/design_system_overrides/page';
+@use 'components/design_system_overrides/toc';

--- a/docs/design_system_overrides.md
+++ b/docs/design_system_overrides.md
@@ -8,23 +8,23 @@ Until the new styles needed for the beta site are ready to be used in the design
 
 ### Markup overrides
 
-In some cases it was necessary to duplicate and make changes to the nunjucks templates in the design system. These can be found in the `ons_alpha/jinja2/component_overrides` folder. Each component includes comments as to what has changed.
+In some cases it was necessary to duplicate and make changes to the nunjucks templates in the design system. These can be found in the `cms/jinja2/component_overrides` folder. Each component includes comments as to what has changed.
 
-The base page template (`ons_alpha/jinja2/templates/base_page.html`) has some important changes to the `pageContent` block in order to add the full width section for the new header areas - including relocating the `<main>` tag so that the new header area is nested inside it.
+The base page template (`cms/jinja2/templates/base_page.html`) has some important changes to the `pageContent` block in order to add the full width section for the new header areas - including relocating the `<main>` tag so that the new header area is nested inside it.
 
 ### Styling overrides
 
-In some cases we needed to extend or override design system styling. These changes can be found in `ons_alpha/static_src/sass/components/design_system_overrides`.
+In some cases we needed to extend or override design system styling. These changes can be found in `cms/static_src/sass/components/design_system_overrides`.
 
 ## New markup and styling
 
 ### Markup for new components
 
-Note that new markup can be found in the page templates for the topic, bulletin and information pages. These can be found in the `ons_alpha/jinja2/templates/pages` folder. Where new components are part of re-orderable streamfield blocks, they can be found in the `ons_alpha/jinja2/templates/components/streamfield` folder.
+Note that new markup can be found in the page templates for the topic, bulletin and information pages. These can be found in the `cms/jinja2/templates/pages` folder. Where new components are part of re-orderable streamfield blocks, they can be found in the `cms/jinja2/templates/components/streamfield` folder.
 
 ### Styling for new components
 
-Styling for new components can be found in `ons_alpha/static_src/sass/components/`.
+Styling for new components can be found in `cms/static_src/sass/components/`.
 
 ## Incorporation of new components into the design system
 

--- a/docs/design_system_overrides.md
+++ b/docs/design_system_overrides.md
@@ -1,0 +1,31 @@
+# Design System and Overrides
+
+The site front-end code extends the [ONS Design system](https://service-manual.ons.gov.uk/design-system/). We extend the [base template](https://service-manual.ons.gov.uk/design-system/foundations/base-page-template) and make use of design system utility classes, colours and typography.
+
+## Overrides
+
+Until the new styles needed for the beta site are ready to be used in the design system, we are using some temporary overrides to HTML markup and styling.
+
+### Markup overrides
+
+In some cases it was necessary to duplicate and make changes to the nunjucks templates in the design system. These can be found in the `ons_alpha/jinja2/component_overrides` folder. Each component includes comments as to what has changed.
+
+The base page template (`ons_alpha/jinja2/templates/base_page.html`) has some important changes to the `pageContent` block in order to add the full width section for the new header areas - including relocating the `<main>` tag so that the new header area is nested inside it.
+
+### Styling overrides
+
+In some cases we needed to extend or override design system styling. These changes can be found in `ons_alpha/static_src/sass/components/design_system_overrides`.
+
+## New markup and styling
+
+### Markup for new components
+
+Note that new markup can be found in the page templates for the topic, bulletin and information pages. These can be found in the `ons_alpha/jinja2/templates/pages` folder. Where new components are part of re-orderable streamfield blocks, they can be found in the `ons_alpha/jinja2/templates/components/streamfield` folder.
+
+### Styling for new components
+
+Styling for new components can be found in `ons_alpha/static_src/sass/components/`.
+
+## Incorporation of new components into the design system
+
+The customisations described above are in the process of being incorporated into the design system, so that they can be used without the need to duplicate and / or override code.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,24 +98,24 @@ const options = {
               implementation: sass,
               sassOptions: {
                 outputStyle: 'compressed',
+                includePaths: [path.resolve(`${projectRoot}/static_src/sass`)],
               },
             },
           },
         ],
       },
       {
-        // sync font files referenced by the css to the fonts directory
-        // the publicPath matches the path from the compiled css to the font file
-        // only looks in the fonts folder so pngs in the images folder won't get put in the fonts folder
+        // Copies font files referenced by CSS/JS to the fonts
+        // directory.
+        // Only files located in the static_src/fonts directory can be
+        // referenced in CSS/JS. Trying to reference a font outside of
+        // this directory will result in a build error. Make sure to
+        // store all fonts in this directory.
         test: /\.(woff|woff2)$/,
-        include: /fonts/,
-        use: {
-          loader: 'file-loader',
-          options: {
-            name: '[name].[ext]',
-            outputPath: 'fonts/',
-            publicPath: '../fonts',
-          },
+        include: path.resolve(`./${projectRoot}/static_src/fonts/`),
+        type: 'asset/resource',
+        generator: {
+          filename: 'fonts/[name][ext]',
         },
       },
       {


### PR DESCRIPTION
### What is the context of this PR?

Ticket:  https://jira.ons.gov.uk/browse/CMS-226

- Update the linting rules inherited from wagtail, and fix some linting issues not present in the prototype
- Remove any custom font-sizes and most line-heights from the imported css, and use design system classes instead
- Fix the display of charts in the ons-embed block for now - we need a separate embed block ultimately
- Don't import customisations to the document-list styling or template
- Update the headers on the analysis and topic pages

This also fixes the issue raised in https://jira.ons.gov.uk/browse/CMS-223

### How to review

Check out the branch on your local build, and ensure the front-end files have been compiled. To do this on your local machine run the following:

`nvm use` - to ensure you are using the correct node version
`npm ci` - if you need to install the node modules
`npm run build` - to compile the files

### Follow-up Actions

