### PR TITLE
Disable pylint's `django-manager-missing` globally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -438,6 +438,7 @@ disable=raw-checker-failed,
         too-few-public-methods,
         missing-class-docstring,
         missing-function-docstring,
+        django-manager-missing,
         fixme
 
 # note:
@@ -447,6 +448,7 @@ disable=raw-checker-failed,
 # - too-few-public-methods: because of Django Meta classes
 # - missing-class-docstring: mostly because of Django classes.
 # - missing-function-docstring: because we can't disable it for trivial functions.
+# - django-manager-missing: because pylint doesn't know what to do with Wagtail models.
 # - fixme: because we want to leave TODO notes for future features.
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/cms/analysis/models.py
+++ b/cms/analysis/models.py
@@ -76,7 +76,7 @@ class AnalysisSeries(RoutablePageMixin, Page):
         return response
 
 
-class AnalysisPage(BundledPageMixin, BasePage):  # type: ignore[django-manager-missing]
+class AnalysisPage(BundledPageMixin, BasePage):
     """The analysis page model."""
 
     parent_page_types: ClassVar[list[str]] = ["AnalysisSeries"]

--- a/cms/bundles/models.py
+++ b/cms/bundles/models.py
@@ -59,7 +59,7 @@ class BundleManager(models.Manager.from_queryset(BundlesQuerySet)):  # type: ign
         return queryset  # note: not returning directly to placate no-any-return
 
 
-class Bundle(index.Indexed, ClusterableModel, models.Model):  # type: ignore[django-manager-missing]
+class Bundle(index.Indexed, ClusterableModel, models.Model):
     base_form_class = BundleAdminForm
 
     name = models.CharField(max_length=255, unique=True)

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -21,7 +21,7 @@ __all__ = [
 
 # Apply default cache headers on this page model's serve method.
 @method_decorator(get_default_cache_control_decorator(), name="serve")
-class BasePage(ListingFieldsMixin, SocialFieldsMixin, Page):  # type: ignore[django-manager-missing]
+class BasePage(ListingFieldsMixin, SocialFieldsMixin, Page):
     """Base page class with listing and social fields additions as well as cache decorators."""
 
     show_in_menus_default = True

--- a/cms/home/models.py
+++ b/cms/home/models.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 from cms.core.models import BasePage
 
 
-class HomePage(BasePage):  # type: ignore[django-manager-missing]
+class HomePage(BasePage):
     """The homepage model. Currently, only a placeholder."""
 
     template = "templates/pages/home_page.html"

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
 
-class ReleaseCalendarIndex(BasePage):  # type: ignore[django-manager-missing]
+class ReleaseCalendarIndex(BasePage):
     """The release calendar index page placeholder."""
 
     template = "templates/pages/release_index.html"
@@ -35,7 +35,7 @@ class ReleaseCalendarIndex(BasePage):  # type: ignore[django-manager-missing]
     max_count_per_parent = 1
 
 
-class ReleaseCalendarPage(BasePage):  # type: ignore[django-manager-missing]
+class ReleaseCalendarPage(BasePage):
     """The calendar release page model."""
 
     base_form_class = ReleaseCalendarPageAdminForm

--- a/cms/standard_pages/models.py
+++ b/cms/standard_pages/models.py
@@ -9,7 +9,7 @@ from cms.core.fields import StreamField
 from cms.core.models import BasePage
 
 
-class InformationPage(BasePage):  # type: ignore[django-manager-missing]
+class InformationPage(BasePage):
     """A generic information page model."""
 
     template = "templates/pages/information_page.html"

--- a/cms/themes/models.py
+++ b/cms/themes/models.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from wagtail.admin.panels import Panel
 
 
-class ThemePage(BasePage):  # type: ignore[django-manager-missing]
+class ThemePage(BasePage):
     """The Theme page model."""
 
     template = "templates/pages/theme_page.html"

--- a/cms/topics/models.py
+++ b/cms/topics/models.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from wagtail.admin.panels import Panel
 
 
-class TopicPage(BasePage):  # type: ignore[django-manager-missing]
+class TopicPage(BasePage):
     """The Topic page model."""
 
     template = "templates/pages/topic_page.html"

--- a/cms/users/models.py
+++ b/cms/users/models.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import AbstractUser
 
 
-class User(AbstractUser):  # type: ignore[django-manager-missing]
+class User(AbstractUser):
     """Barebones custom user model."""


### PR DESCRIPTION
Tentative global disable for `django-manager-missing`.
Technically this is pylint-django, not pylint, but still.

IMHO this is adding loads of noise, but folk may deem it needed hence "tentative"