### PR TITLE
Add default heading 1 and breadcrumbs for templates that haven't yet had a banner added

### DIFF
--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -35,8 +35,14 @@
     {# Changes the location of the <main> tag from the base template - ensures it surrounds the header area #}
     {# This change should be adopted by the design system soon #}
     <main id="main-content">
-        {# This will contain the breadcrumbs on individual templates #}
+        {# This block should be overriden on individual page templates and include the breadcrumbs and page heading. This is default content while the build is in progress. #}
         {% block header_area %}
+            <div class="ons-container">
+                {% include "templates/components/navigation/breadcrumbs.html" %}
+                <h1 class="ons-u-fs-3xl analysis-header__heading">
+                    {{ page.title }}
+                </h1>
+            </div>
         {% endblock %}
         <div class="ons-page__container ons-container{{ containerClasses }}">
             <div class="ons-grid">

--- a/cms/jinja2/templates/pages/analysis_page.html
+++ b/cms/jinja2/templates/pages/analysis_page.html
@@ -72,8 +72,6 @@
         {% include_block page.headline_figures %}
     {% endif %}
 
-    {{ super() }}
-
 {% endblock %}
 
 {% block main %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
@@ -2,6 +2,8 @@
 
 {% from "components/table-of-contents/_macro.njk" import onsTableOfContents %}
 
+{% block header_area %}{% endblock %}
+
 {% block main %}
     <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-3xs release__document-type">Release</div>
     <h1 class="ons-u-fs-3xl ons-u-mb-l">

--- a/cms/jinja2/templates/pages/theme_page.html
+++ b/cms/jinja2/templates/pages/theme_page.html
@@ -16,6 +16,4 @@
             </div>
         </div>
     </div>
-
-    {{ super() }}
 {% endblock %}

--- a/cms/jinja2/templates/pages/topic_page.html
+++ b/cms/jinja2/templates/pages/topic_page.html
@@ -26,6 +26,4 @@
         {% include_block page.headline_figures %}
     {% endif %}
 
-    {{ super() }}
-
 {% endblock %}


### PR DESCRIPTION
### What is the context of this PR?

@AdamHawtin is writing tests, and spotted that the heading 1 was missing on some page types after the front-end set-up work had been merged in. This is because in the new template structure, we defined a `header_area` block to contain the full-width header with page title and breadcrumbs, but this has only been implemented on some templates so far.

This PR addresses the problem of the missing content, by adding an un-styled default page title, and the breadcrumb. This is then overridden on pages that already have the banners set up.

### How to review

On a local build, check that the analysis and topic pages still display custom headers. Then check that other page types, such as the information page, display a page title and breadcrumbs.

### Follow-up Actions

None.
