### PR TITLE
Don't show an full-screen overlay for warnings - only for errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -199,7 +199,10 @@ const webpackConfig = (environment, argv) => {
       },
       client: {
         // Shows a full-screen overlay in the browser when there are compiler errors.
-        overlay: true,
+        overlay: {
+          warnings: false,
+          errors: true,
+        },
         logging: 'error',
       },
       devMiddleware: {


### PR DESCRIPTION
### What is the context of this PR?

When running `honcho start` I noticed that a full-screen overlay *in the browser* (from webpack dev server) was appearing for warning messagess in the font-end tooling. This is obstructive if there are warnings appearing all the time, so this updates the config to only show the overlay message for errors.

### How to review

Run your local build, and use `honcho start` to start the dev server and the front-end tooling. Although there is a warning about a deprecated package, this should not appear in a full-screen overlay. Compare with the `main` branch where you should see the overlay.

See screenshot in the comment below for how the full-screen overlay appears with warnings on the main branch.

### Follow-up Actions

None
