### PR TITLE
Ignore vscode workspace settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# VSCode workspace settings
+.vscode/
+
 # Ruff
 .ruff_cache/
 


### PR DESCRIPTION
### What is the context of this PR?

VS code and Cursor allow you to override your global settings on a workspace-specific basis, but it involves creating a directory called `.vscode`. This change just ensures that directory doesn't get committed.

### How to review

You could try creating the folder locally and ensuring it doesn't get picked up by git.

### Follow-up Actions

None.
