### PR TITLE
Fix: Only ignore the root/automatically-compiled 'static' dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,7 @@ copier_scripts/
 /cms/jinja2/layout
 /cms/static_compiled
 
-/node_modules/
+node_modules/
 /static/
 
 # mkdocs

--- a/.gitignore
+++ b/.gitignore
@@ -185,8 +185,8 @@ copier_scripts/
 /cms/jinja2/layout
 /cms/static_compiled
 
-node_modules/
-static/
+/node_modules/
+/static/
 
 # mkdocs
 /site


### PR DESCRIPTION
### What is the context of this PR?

The .gitignore file is currently a little bit too overbearing, and doesn't account for when apps that have their own staticfiles. This caused pain most recently on https://github.com/ONSdigital/dis-wagtail/pull/80, where it worked fine locally, but not on anybody Helen's machine. But, as the project grows, it's likely to trip developers up unnecessarily on other threads of work too.

### How to review

Add a `static` folder to an existing app and plonk a random file in it. `git status` should reflect the addition of that file.
