### PR TITLE
Ensure the highlighting works correctly for the table of contents

### DIFF
--- a/cms/jinja2/templates/pages/methodology_page.html
+++ b/cms/jinja2/templates/pages/methodology_page.html
@@ -45,7 +45,7 @@
 {% endblock %}
 
 {% block main %}
-    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
+    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32 ons-js-toc-container">
         <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
             {% with toc_title=_("Contents"), toc_aria_label=_("Sections in this page") %}
                 {# fmt:off #}

--- a/cms/jinja2/templates/pages/statistical_article_page.html
+++ b/cms/jinja2/templates/pages/statistical_article_page.html
@@ -73,7 +73,7 @@
 {% endblock %}
 
 {% block main %}
-    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
+    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32 ons-js-toc-container">
         <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
             {% with toc_title=_("Contents"), toc_aria_label=_("Sections in this page") %}
                 {# fmt:off #}


### PR DESCRIPTION
### What is the context of this PR?

A ticket was raised regarding the highlighting of the current section in the table of contents for the November prototype, but a similar fix was also needed in beta. See https://jira.ons.gov.uk/browse/NWP-580

In the case of the beta build, we just needed to add a necessary class to the parent element for the statistical article and methodology pages

### How to review

On your local build, test a statistical article and a methodology page, ensuring you have added a few sections to the content. Check that as you scroll or click on those sections, the underline becomes thicker and darker to highlight it, as per the [design system example here](https://service-manual.ons.gov.uk/design-system/components/table-of-contents/example-table-of-contents-sticky#section5). Note that as per that example, the last section or two may not highlight, as it depends on the height of the content in the section relative to the viewport.

### Follow-up Actions

None.
