### PR TITLE
Allow rendering a bundle without a "created by" user

### DIFF
--- a/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
@@ -47,7 +47,7 @@
                                 {{ bundle.scheduled_publication_date|default_if_none:"" }}
                             </td>
                             <td>{% human_readable_date bundle.created_at %}</td>
-                            <td>{% include "wagtailadmin/shared/user_avatar.html" with user=bundle.created_by username=bundle.created_by.get_full_name|default:bundle.created_by.get_username %}</td>
+                            <td>{% if bundle.created_by %}{% include "wagtailadmin/shared/user_avatar.html" with user=bundle.created_by username=bundle.created_by.get_full_name|default:bundle.created_by.get_username %}{% endif %}</td>
                         </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
### What is the context of this PR?

If the user who created a bundle is deleted, `created_by` is `None`, and the admin site can't be rendered.

### How to review

Delete the user who created a bundle.

### Follow-up Actions

This will need cherry-picking into `feature/datavis`, too.
