### PR TITLE
Charts: pass config and annotations to the macro as json

### DIFF
--- a/cms/datavis/models/charts.py
+++ b/cms/datavis/models/charts.py
@@ -1,8 +1,6 @@
-import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
 
-from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.forms import Media
 from django.utils.functional import cached_property, classproperty
@@ -99,12 +97,8 @@ class Chart(Visualisation):
 
     def get_context(self, request: Optional["HttpRequest"] = None, **kwargs: Any) -> dict[str, Any]:
         config = self.get_component_config(self.primary_data_source.headers, self.primary_data_source.rows)
-        encoded_config = json.dumps(config, cls=DjangoJSONEncoder)
         annotations_values = self.get_annotations_values()
-        encoded_annotations_values = json.dumps(annotations_values, cls=DjangoJSONEncoder)
-        return super().get_context(
-            request, config=encoded_config, annotations_values=encoded_annotations_values, **kwargs
-        )
+        return super().get_context(request, config=config, annotations_values=annotations_values, **kwargs)
 
     general_panels: ClassVar[Sequence["Panel"]] = [
         FieldPanel("name"),

--- a/cms/datavis/models/charts.py
+++ b/cms/datavis/models/charts.py
@@ -1,6 +1,8 @@
+import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.forms import Media
 from django.utils.functional import cached_property, classproperty
@@ -97,8 +99,12 @@ class Chart(Visualisation):
 
     def get_context(self, request: Optional["HttpRequest"] = None, **kwargs: Any) -> dict[str, Any]:
         config = self.get_component_config(self.primary_data_source.headers, self.primary_data_source.rows)
+        encoded_config = json.dumps(config, cls=DjangoJSONEncoder)
         annotations_values = self.get_annotations_values()
-        return super().get_context(request, config=config, annotations_values=annotations_values, **kwargs)
+        encoded_annotations_values = json.dumps(annotations_values, cls=DjangoJSONEncoder)
+        return super().get_context(
+            request, config=encoded_config, annotations_values=encoded_annotations_values, **kwargs
+        )
 
     general_panels: ClassVar[Sequence["Panel"]] = [
         FieldPanel("name"),

--- a/cms/jinja2/templates/datavis/_macro.njk
+++ b/cms/jinja2/templates/datavis/_macro.njk
@@ -34,13 +34,13 @@
 
         {# script tags to pass json data to the javascript component #}
         <script type="application/json" data-highcharts-config="{{ params.uuid }}">
-            {# Note that in the design system this may need to be a custom filter #}
-            {{ params.config|safe }}
+            {# Note that in the design system this will need to be a custom filter #}
+            {{ params.config|tojson }}
         </script>
         {% if params.annotations_values %}
             <script type="application/json" data-highcharts-annotations-values="{{ params.uuid }}">
-                {# Note that in the design system this may need to be a custom filter #}
-                {{ params.annotations_values|safe }}
+                {# Note that in the design system will may need to be a custom filter #}
+                {{ params.annotations_values|tojson }}
             </script>
         {% endif %}
     </div>

--- a/cms/jinja2/templates/datavis/_macro.njk
+++ b/cms/jinja2/templates/datavis/_macro.njk
@@ -1,23 +1,22 @@
 {% macro onsChart(params) %}
-    <div data-highcharts-base-chart data-highcharts-type="{{ params.chartType }}" data-highcharts-theme="{{ params.theme }}" data-highcharts-title="{{ params.title }}" {% if params.use_stacked_layout %}data-highcharts-use-stacked-layout{% endif %}>
-        <figure id="{{ params.domId }}">
+    <div
+        data-highcharts-base-chart
+        data-highcharts-type="{{ params.chartType }}"
+        data-highcharts-theme="{{ params.theme }}"
+        data-highcharts-config="{{ params.config }}"
+        data-highcharts-title="{{ params.title }}"
+        {% if params.annotations_values %}data-highcharts-annotations-values="{{ params.annotations_values }}"{% endif %}
+        {% if params.use_stacked_layout %}data-highcharts-use-stacked-layout{% endif %}
+    >
+        <figure>
             {# Heading levels will need to be configurable depending on page surroundings #}
             <h3>{{ params.title }}</h3>
             <h4>{{ params.subtitle }}</h4>
-            <div data-highcharts-chart data-highcharts-id="{{ params.uuid }}"></div>
+            <div data-highcharts-chart></div>
             {% if params.caption %}
                 <figcaption>{{ params.caption }}</figcaption>
             {% endif %}
         </figure>
-
-        <!-- Set scripts to pass the config and annotations values as json to the javascript -->
-        {% set config_scriptid = ["config--", params.uuid] | join %}
-        {{ params.config|json_script(config_scriptid) }}
-
-        {% if params.annotations_values %}
-            {% set annotations_values_scriptid = ["annotations-values--", params.uuid] | join %}
-            {{ params.annotations_values|json_script(annotations_values_scriptid) }}
-        {% endif %}
 
         {% if params.download_title and (params.download_image or params.download_csv or params.download_excel) %}
             {% if params.download_title %}<h4>{{ params.download_title }}</h4>{% endif %}

--- a/cms/jinja2/templates/datavis/_macro.njk
+++ b/cms/jinja2/templates/datavis/_macro.njk
@@ -3,9 +3,8 @@
         data-highcharts-base-chart
         data-highcharts-type="{{ params.chartType }}"
         data-highcharts-theme="{{ params.theme }}"
-        data-highcharts-config="{{ params.config }}"
         data-highcharts-title="{{ params.title }}"
-        {% if params.annotations_values %}data-highcharts-annotations-values="{{ params.annotations_values }}"{% endif %}
+        data-highcharts-uuid="{{ params.uuid }}"
         {% if params.use_stacked_layout %}data-highcharts-use-stacked-layout{% endif %}
     >
         <figure>
@@ -31,6 +30,16 @@
                     <li><a href="{{ params.download_image }}">Image (PNG format{% if params.download_image_size %}, {{ params.download_image_size }}{% endif %})</a></li>
                 {% endif %}
             </ol>
+        {% endif %}
+
+        <!-- script tags to pass json data to the javascript component -->
+        <script type="application/json" data-highcharts-config--{{ params.uuid }}>
+            {{ params.config|safe }}
+        </script>
+        {% if params.annotations_values %}
+            <script type="application/json" data-highcharts-annotations-values--{{ params.uuid }}>
+                {{ params.annotations_values|safe }}
+            </script>
         {% endif %}
     </div>
 {% endmacro %}

--- a/cms/jinja2/templates/datavis/_macro.njk
+++ b/cms/jinja2/templates/datavis/_macro.njk
@@ -32,12 +32,14 @@
             </ol>
         {% endif %}
 
-        <!-- script tags to pass json data to the javascript component -->
-        <script type="application/json" data-highcharts-config--{{ params.uuid }}>
+        {# script tags to pass json data to the javascript component #}
+        <script type="application/json" data-highcharts-config="{{ params.uuid }}">
+            {# Note that in the design system this may need to be a custom filter #}
             {{ params.config|safe }}
         </script>
         {% if params.annotations_values %}
-            <script type="application/json" data-highcharts-annotations-values--{{ params.uuid }}>
+            <script type="application/json" data-highcharts-annotations-values="{{ params.uuid }}">
+                {# Note that in the design system this may need to be a custom filter #}
                 {{ params.annotations_values|safe }}
             </script>
         {% endif %}

--- a/cms/static_src/javascript/components/highcharts-base-chart.js
+++ b/cms/static_src/javascript/components/highcharts-base-chart.js
@@ -20,10 +20,10 @@ class HighchartsBaseChart {
     // This gets some further modifications
     this.uuid = this.node.dataset.highchartsUuid;
     this.apiConfig = JSON.parse(
-      this.node.querySelector(`[data-highcharts-config--${this.uuid}]`).textContent,
+      this.node.querySelector(`[data-highcharts-config="${this.uuid}"]`).textContent,
     );
     this.annotationsValues = JSON.parse(
-      this.node.querySelector(`[data-highcharts-annotations-values--${this.uuid}]`).textContent,
+      this.node.querySelector(`[data-highcharts-annotations-values="${this.uuid}"]`).textContent,
     );
 
     // Hide data labels for clustered bar charts with more than 2 series, and also for stacked bar charts

--- a/cms/static_src/javascript/components/highcharts-base-chart.js
+++ b/cms/static_src/javascript/components/highcharts-base-chart.js
@@ -53,7 +53,6 @@ class HighchartsBaseChart {
 
     // Configure any annotations that have been specified (will be an empty array if no annotations are specified)
     if (this.annotationsValues) {
-      console.log('annotations found');
       this.configureAnnotations();
     }
 

--- a/cms/static_src/javascript/components/highcharts-base-chart.js
+++ b/cms/static_src/javascript/components/highcharts-base-chart.js
@@ -16,15 +16,10 @@ class HighchartsBaseChart {
     this.title = this.node.dataset.highchartsTitle;
     this.useStackedLayout = this.node.hasAttribute('data-highcharts-use-stacked-layout');
     const chartNode = this.node.querySelector('[data-highcharts-chart]');
-    const chartId = chartNode.dataset.highchartsId;
     // We start with some config in the correct Highcharts format supplied by Wagtail
     // This gets some further modifications
-    this.apiConfig = JSON.parse(this.node.querySelector(`#config--${chartId}`).textContent);
-    if (this.node.querySelector(`#annotations-values--${chartId}`)) {
-      this.annotationsValues = JSON.parse(
-        this.node.querySelector(`#annotations-values--${chartId}`).textContent,
-      );
-    }
+    this.apiConfig = JSON.parse(this.node.dataset.highchartsConfig);
+    this.annotationsValues = JSON.parse(this.node.dataset.highchartsAnnotationsValues);
 
     // Hide data labels for clustered bar charts with more than 2 series, and also for stacked bar charts
     const hideDataLabels =
@@ -48,8 +43,8 @@ class HighchartsBaseChart {
     // Will only run once per page load
     this.setCommonChartOptions();
 
-    // Configure any annotations that have been specified
-    if (this.annotationsValues) {
+    // Configure any annotations that have been specified (will be an empty array if no annotations are specified)
+    if (this.annotationsValues.length) {
       this.configureAnnotations();
     }
 

--- a/cms/static_src/javascript/components/highcharts-base-chart.js
+++ b/cms/static_src/javascript/components/highcharts-base-chart.js
@@ -18,8 +18,13 @@ class HighchartsBaseChart {
     const chartNode = this.node.querySelector('[data-highcharts-chart]');
     // We start with some config in the correct Highcharts format supplied by Wagtail
     // This gets some further modifications
-    this.apiConfig = JSON.parse(this.node.dataset.highchartsConfig);
-    this.annotationsValues = JSON.parse(this.node.dataset.highchartsAnnotationsValues);
+    this.uuid = this.node.dataset.highchartsUuid;
+    this.apiConfig = JSON.parse(
+      this.node.querySelector(`[data-highcharts-config--${this.uuid}]`).textContent,
+    );
+    this.annotationsValues = JSON.parse(
+      this.node.querySelector(`[data-highcharts-annotations-values--${this.uuid}]`).textContent,
+    );
 
     // Hide data labels for clustered bar charts with more than 2 series, and also for stacked bar charts
     const hideDataLabels =

--- a/cms/static_src/javascript/components/highcharts-base-chart.js
+++ b/cms/static_src/javascript/components/highcharts-base-chart.js
@@ -19,12 +19,15 @@ class HighchartsBaseChart {
     // We start with some config in the correct Highcharts format supplied by Wagtail
     // This gets some further modifications
     this.uuid = this.node.dataset.highchartsUuid;
+
     this.apiConfig = JSON.parse(
       this.node.querySelector(`[data-highcharts-config="${this.uuid}"]`).textContent,
     );
-    this.annotationsValues = JSON.parse(
-      this.node.querySelector(`[data-highcharts-annotations-values="${this.uuid}"]`).textContent,
-    );
+    if (this.node.querySelector(`[data-highcharts-annotations-values="${this.uuid}"]`)) {
+      this.annotationsValues = JSON.parse(
+        this.node.querySelector(`[data-highcharts-annotations-values="${this.uuid}"]`).textContent,
+      );
+    }
 
     // Hide data labels for clustered bar charts with more than 2 series, and also for stacked bar charts
     const hideDataLabels =
@@ -49,7 +52,8 @@ class HighchartsBaseChart {
     this.setCommonChartOptions();
 
     // Configure any annotations that have been specified (will be an empty array if no annotations are specified)
-    if (this.annotationsValues.length) {
+    if (this.annotationsValues) {
+      console.log('annotations found');
       this.configureAnnotations();
     }
 


### PR DESCRIPTION
### What is the context of this PR?

After a discussion with the design system team, they don't want to encode json themselves in the macro - they'd rather receive the config directly as json.

This updates both the annotations and the config to be encoded as json before they are passed to the template.
Instead of using a script tag, the macro passes a json encoded string as a data attribute.

### How to review

Test that creating charts in an information page all still works as expected.

### Follow-up Actions

Update the macro parameters documentation in the charts spec
Potentially remove the custom version of `json_script` from the repo, although TBC as this could still be a useful addition.
