### PR TITLE
Improve the user chooser queries, reducing N+1

### DIFF
--- a/cms/users/tests/test_viewsets.py
+++ b/cms/users/tests/test_viewsets.py
@@ -23,7 +23,10 @@ class TestUserChooserViewSet(WagtailTestUtils, TestCase):
         self.login(user=self.user_with_full_name)
 
     def test_chooser_viewset(self):
-        response = self.client.get(self.chooser_url)
+        with self.assertNumQueries(5):
+            # admin (3): session, admin user, admin userprofile
+            # chooser (2): user count + user list
+            response = self.client.get(self.chooser_url)
 
         self.assertContains(response, self.user_without_name.username, 2)  # Name and username
         self.assertContains(response, self.user_with_first_name.username)

--- a/cms/users/viewsets.py
+++ b/cms/users/viewsets.py
@@ -67,6 +67,9 @@ class UserChooserMixin:
             ),
         ]
 
+    def get_object_list(self) -> "QuerySet[User]":
+        return User.objects.select_related("wagtail_userprofile")
+
 
 class UserChooseView(UserChooserMixin, ChooseView): ...
 


### PR DESCRIPTION
### What is the context of this PR?

A follow up to #113 that reduces a number of N+1 queries as the "name" column also tries to pull in the user's profile pic. 

Inspired by 816bfd00664

Before: 15
After: 5

### How to review

You can use Django Debug Toolbar's request history:
- go to `/admin/user_chooser/`
- go to /admin
- open DDT, click the "History" panel and find the `/admin/user_chooser/` request, click "switch" and check the SQL panel