### PR TITLE
Use HTML text inputs in numeric mode

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -7,12 +7,13 @@ from wagtail import blocks
 from wagtail.blocks.struct_block import StructValue
 
 from cms.datavis.blocks.table import SimpleTableBlock
+from cms.datavis.blocks.utils import TextInputCharBlock, TextInputFloatBlock
 
 
 class PointAnnotationBlock(blocks.StructBlock):
     label = blocks.CharBlock(required=True)
-    x_position = blocks.IntegerBlock(label="x-position", required=True)
-    y_position = blocks.IntegerBlock(label="y-position", required=True)
+    x_position = TextInputCharBlock(label="x-position", required=True)
+    y_position = TextInputFloatBlock(label="y-position", required=True)
 
 
 class BaseVisualisationBlock(blocks.StructBlock):
@@ -36,9 +37,12 @@ class BaseVisualisationBlock(blocks.StructBlock):
     x_axis = blocks.StructBlock(
         [
             ("label", blocks.CharBlock(label="Label", required=False)),
-            ("min", blocks.FloatBlock(label="Minimum", required=False)),
-            ("max", blocks.FloatBlock(label="Maximum", required=False)),
-            ("tick_interval", blocks.FloatBlock(label="Tick interval", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            (
+                "tick_interval",
+                TextInputFloatBlock(label="Tick interval", required=False),
+            ),
         ]
     )
 
@@ -46,9 +50,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
     y_axis = blocks.StructBlock(
         [
             ("label", blocks.CharBlock(required=False)),
-            ("min", blocks.FloatBlock(label="Minimum", required=False)),
-            ("max", blocks.FloatBlock(label="Maximum", required=False)),
-            ("tick_interval", blocks.FloatBlock(required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("tick_interval", TextInputFloatBlock(required=False)),
             # TODO: implement non-stripping charblock
             ("value_suffix", blocks.CharBlock(required=False)),
             ("tooltip_suffix", blocks.CharBlock(required=False)),

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -7,12 +7,12 @@ from wagtail import blocks
 from wagtail.blocks.struct_block import StructValue
 
 from cms.datavis.blocks.table import SimpleTableBlock
-from cms.datavis.blocks.utils import TextInputCharBlock, TextInputFloatBlock
+from cms.datavis.blocks.utils import TextInputFloatBlock, TextInputIntegerBlock
 
 
 class PointAnnotationBlock(blocks.StructBlock):
     label = blocks.CharBlock(required=True)
-    x_position = TextInputCharBlock(label="x-position", required=True)
+    x_position = TextInputIntegerBlock(label="x-position", required=True)
     y_position = TextInputFloatBlock(label="y-position", required=True)
 
 

--- a/cms/datavis/blocks/utils.py
+++ b/cms/datavis/blocks/utils.py
@@ -1,0 +1,24 @@
+from django.forms import TextInput
+from wagtail import blocks
+
+
+class TextInputCharBlock(blocks.IntegerBlock):
+    """A text input widget that only allows numeric input.
+
+    See https://design-system.service.gov.uk/components/text-input/#numbers
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.field.widget = TextInput(attrs={"inputmode": "numeric", "pattern": "[0-9]*"})
+
+
+class TextInputFloatBlock(blocks.FloatBlock):
+    """A text input widget that only allows decimal input.
+
+    See https://design-system.service.gov.uk/components/text-input/#numbers
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.field.widget = TextInput(attrs={"inputmode": "decimal", "pattern": "[0-9]*\\.?[0-9]*"})

--- a/cms/datavis/blocks/utils.py
+++ b/cms/datavis/blocks/utils.py
@@ -21,4 +21,5 @@ class TextInputFloatBlock(blocks.FloatBlock):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.field.widget = TextInput(attrs={"inputmode": "decimal", "pattern": "[0-9]*\\.?[0-9]*"})
+        # NB inputmode is not "decimal" as per the guidance linked in the docstring above
+        self.field.widget = TextInput(attrs={"inputmode": "text", "pattern": "[0-9]*\\.?[0-9]*"})

--- a/cms/datavis/blocks/utils.py
+++ b/cms/datavis/blocks/utils.py
@@ -2,7 +2,7 @@ from django.forms import TextInput
 from wagtail import blocks
 
 
-class TextInputCharBlock(blocks.IntegerBlock):
+class TextInputIntegerBlock(blocks.IntegerBlock):
     """A text input widget that only allows numeric input.
 
     See https://design-system.service.gov.uk/components/text-input/#numbers
@@ -10,16 +10,17 @@ class TextInputCharBlock(blocks.IntegerBlock):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.field.widget = TextInput(attrs={"inputmode": "numeric", "pattern": "[0-9]*"})
+        self.field.widget = TextInput(attrs={"inputmode": "numeric"})
 
 
 class TextInputFloatBlock(blocks.FloatBlock):
     """A text input widget that only allows decimal input.
 
-    See https://design-system.service.gov.uk/components/text-input/#numbers
+    See https://design-system.service.gov.uk/components/text-input/#asking-for-decimal-numbers
     """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # NB inputmode is not "decimal" as per the guidance linked in the docstring above
-        self.field.widget = TextInput(attrs={"inputmode": "text", "pattern": "[0-9]*\\.?[0-9]*"})
+        # NB inputmode is intentionally not "decimal" as per the guidance linked
+        # in the docstring above
+        self.field.widget = TextInput(attrs={"inputmode": "text"})


### PR DESCRIPTION
### What is the context of this PR?

This converts several numeric fields in the charts editor to use Django TextInput widgets, which render as `<input type="text">`, and then specify validation.

### How to review

1. Check out the branch.
2. Create an InformationPage.
3. Add a chart.
4. Add an annotation block (these inputs are used elsewhere, but this is the only place to see an integer input).
5. Observe the inputs, minus the unhelpful up/down increment buttons.
6. Try to enter bad data (a float in the x-position integer input, or some non-numeric text in the y-position float input).
7. View the inputs on a mobile device, and see an appropriate keyboard in use for integer fields (x-position), though not for float inputs (y-position).

### Follow-up Actions

Sort out the merge target. This is targeting `feature/streamfield-charts` for now, to keep the diff small.