### PR TITLE
Fix assignment of revisions to corrections

### DIFF
--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -1,0 +1,179 @@
+from wagtail.test.utils import WagtailPageTestCase
+
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+
+
+class StatisticalArticlePageTests(WagtailPageTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.page = StatisticalArticlePageFactory()
+
+    def test_default_route(self):
+        self.assertPageIsRoutable(self.page)
+
+    def test_default_route_rendering(self):
+        self.assertPageIsRenderable(self.page)
+
+    def test_page_content(self):
+        response = self.client.get(self.page.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.page.title)
+        self.assertContains(response, self.page.summary)
+
+    def test_correction_routes(self):
+        self.assertPageIsRoutable(self.page, "previous/v1/")
+        self.assertPageIsRoutable(self.page, "previous/v2/")
+        self.assertPageIsRoutable(self.page, "previous/v3/")
+
+    def test_can_add_correction(self):  # pylint: disable=too-many-statements # noqa
+        response = self.client.get(self.page.url)
+        self.assertNotContains(response, "Corrections")
+        self.assertNotContains(response, "Notices")
+        self.assertNotContains(response, "View superseded version")
+
+        self.page.save_revision().publish()
+
+        original_revision_id = self.page.get_latest_revision().id
+
+        original_summary = self.page.summary
+
+        self.page.summary = "Corrected summary"
+
+        first_correction = {
+            "version_id": 1,
+            "previous_version": original_revision_id,
+            "when": "2025-01-11",
+            "frozen": True,
+            "text": "First correction text",
+        }
+
+        self.page.corrections = [
+            (
+                "correction",
+                first_correction,
+            )
+        ]
+
+        self.page.save_revision().publish()
+
+        second_revision_id = self.page.get_latest_revision().id
+
+        response = self.client.get(self.page.url)
+
+        self.assertContains(response, "Corrections")
+        self.assertContains(response, "First correction text")
+        self.assertNotContains(response, "Notices")
+        self.assertContains(response, "View superseded version")
+        self.assertNotContains(response, original_summary)
+        self.assertContains(response, "Corrected summary")
+
+        v1_response = self.client.get(self.page.url + "previous/v1/")
+
+        # The old version should not contain corrections
+        self.assertNotContains(v1_response, "Corrections")
+        self.assertNotContains(v1_response, "View superseded version")
+        self.assertContains(v1_response, original_summary)
+
+        # V2 doesn't exist yet, should return 404
+        v2_response = self.client.get(self.page.url + "previous/v2/")
+        self.assertEqual(v2_response.status_code, 404)
+
+        second_correction = {
+            "version_id": 2,
+            "previous_version": second_revision_id,
+            "when": "2025-01-12",
+            "frozen": True,
+            "text": "Second correction text",
+        }
+
+        self.page.summary = "Second corrected summary"
+
+        self.page.corrections = [
+            (
+                "correction",
+                second_correction,
+            ),
+            (
+                "correction",
+                first_correction,
+            ),
+        ]
+
+        self.page.save_revision().publish()
+
+        third_revision_id = self.page.get_latest_revision().id
+
+        response = self.client.get(self.page.url)
+
+        self.assertContains(response, "Corrections")
+        self.assertContains(response, "First correction text")
+        self.assertContains(response, "Second correction text")
+        self.assertContains(response, "Second corrected summary")
+
+        # V2 now exists
+        v2_response = self.client.get(self.page.url + "previous/v2/")
+        self.assertEqual(v2_response.status_code, 200)
+
+        self.assertContains(v2_response, "Corrections")
+        self.assertContains(v2_response, "First correction text")
+        self.assertNotContains(v2_response, "Second correction text")
+
+        # V3 doesn't exist yet, should return 404
+        v3_response = self.client.get(self.page.url + "previous/v3/")
+        self.assertEqual(v3_response.status_code, 404)
+
+        third_correction = {
+            "version_id": 3,
+            "previous_version": third_revision_id,
+            "when": "2025-01-13",
+            "frozen": True,
+            "text": "Third correction text",
+        }
+
+        self.page.summary = "Third corrected summary"
+
+        self.page.corrections = [
+            (
+                "correction",
+                third_correction,
+            ),
+            (
+                "correction",
+                second_correction,
+            ),
+            (
+                "correction",
+                first_correction,
+            ),
+        ]
+
+        self.page.save_revision().publish()
+
+        response = self.client.get(self.page.url)
+
+        self.assertContains(response, "Corrections")
+        self.assertContains(response, "First correction text")
+        self.assertContains(response, "Second correction text")
+        self.assertContains(response, "Third correction text")
+        self.assertContains(response, "Third corrected summary")
+
+        # V3 now exists
+        v3_response = self.client.get(self.page.url + "previous/v3/")
+        self.assertEqual(v3_response.status_code, 200)
+
+        self.assertContains(v3_response, "Corrections")
+        self.assertContains(v3_response, "First correction text")
+        self.assertContains(v3_response, "Second correction text")
+        self.assertNotContains(v3_response, "Third correction text")
+
+        # Check that at this stage all other versions are still correct
+
+        v1_response = self.client.get(self.page.url + "previous/v1/")
+        self.assertNotContains(v1_response, "Corrections")
+        self.assertNotContains(v1_response, "View superseded version")
+        self.assertContains(v1_response, original_summary)
+
+        v2_response = self.client.get(self.page.url + "previous/v2/")
+        self.assertContains(v2_response, "Corrections")
+        self.assertContains(v2_response, "First correction text")
+        self.assertNotContains(v2_response, "Second correction text")

--- a/cms/core/forms.py
+++ b/cms/core/forms.py
@@ -76,11 +76,11 @@ class PageWithCorrectionsAdminForm(DeduplicateTopicsAdminForm):
             ):
                 # Prevent tampering
                 self.add_error("corrections", ValidationError("The chosen revision is not valid for the current page"))
-            elif latest_published_revision_id is not None:
-                # If there's no value, set it to the latest revision
-                correction.value["previous_version"] = latest_published_revision_id
 
-        if new_correction and not new_correction.value["version_id"]:
-            new_correction.value["version_id"] = latest_correction_version + 1
+        if new_correction:
+            if not new_correction.value["version_id"]:
+                new_correction.value["version_id"] = latest_correction_version + 1
+            if not new_correction.value["previous_version"]:
+                new_correction.value["previous_version"] = latest_published_revision_id
 
         return corrections

--- a/cms/core/static/js/blocks/previous-version-block.js
+++ b/cms/core/static/js/blocks/previous-version-block.js
@@ -8,12 +8,13 @@ class PreviousVersionBlock {
 
     placeholder.replaceWith(this.element);
 
-    this.renderContent(initialState);
+    this.renderContent(initialState, prefix);
   }
 
-  renderContent(state) {
+  renderContent(state, prefix) {
     if (state) {
       this.element.innerHTML = `
+                <input type="hidden" name="${prefix}" value="${state}">
                 <a class="button button-small button-secondary" target="_blank" href="../revisions/${state}/view/">Preview revision</a>
             `;
     } else {


### PR DESCRIPTION
### What is the context of this PR?

This PR fixes an issue related to #122. The revision ID was not assigned and persisted correctly.

It also adds an integration test for `StatisticalArticlePage` and `corrections`.

### How to review

* Checkout branch
* Create a statistical article page
* Publish it
* Create multiple corrections by making a change and publishing a correction
* Check that all versions work and contain content tied to the correct revision

### Follow-up Actions

N/A
