### PR TITLE
Remove gettext_lazy calls from admin panel text

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -91,7 +91,7 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
     parent_page_types: ClassVar[list[str]] = ["ArticleSeriesPage"]
     subpage_types: ClassVar[list[str]] = []
     template = "templates/pages/statistical_article_page.html"
-    label = _("Article")
+    label = _("Article")  # type: ignore[assignment]
 
     # Fields
     news_headline = models.CharField(max_length=255, blank=True)

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -35,13 +35,13 @@ class ArticleSeriesPage(RoutablePageMixin, GenericTaxonomyMixin, BasePage):  # t
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     subpage_types: ClassVar[list[str]] = ["StatisticalArticlePage"]
     preview_modes: ClassVar[list[str]] = []  # Disabling the preview mode due to it being a container page.
-    page_description = _("A container for statistical article series.")
+    page_description = "A container for statistical article series."
     exclude_from_breadcrumbs = True
 
     content_panels: ClassVar[list["Panel"]] = [
         *Page.content_panels,
         HelpPanel(
-            content=_(
+            content=(
                 "This is a container for article series. It provides the <code>/latest</code>,"
                 "<code>/previous-releases</code> evergreen paths, as well as the actual statistical article pages. "
                 "Add a new Statistical article page under this container."
@@ -91,14 +91,14 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
     parent_page_types: ClassVar[list[str]] = ["ArticleSeriesPage"]
     subpage_types: ClassVar[list[str]] = []
     template = "templates/pages/statistical_article_page.html"
-    label = _("Article")
+    label = "Article"
 
     # Fields
     news_headline = models.CharField(max_length=255, blank=True)
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
 
     main_points_summary = RichTextField(
-        features=settings.RICH_TEXT_BASIC, help_text=_("Used when featured on a topic page.")
+        features=settings.RICH_TEXT_BASIC, help_text="Used when featured on a topic page."
     )
 
     # Fields: dates
@@ -115,17 +115,17 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
 
     # Fields: accredited/census. A bit of "about the data".
     is_accredited = models.BooleanField(
-        _("Accredited Official Statistics"),
+        "Accredited Official Statistics",
         default=False,
-        help_text=_(
+        help_text=(
             "If ticked, will display an information block about the data being accredited official statistics "
             "and include the accredited logo."
         ),
     )
     is_census = models.BooleanField(
-        _("Census"),
+        "Census",
         default=False,
-        help_text=_("If ticked, will display an information block about the data being related to the Census."),
+        help_text="If ticked, will display an information block about the data being related to the Census.",
     )
 
     # Fields: content
@@ -141,7 +141,7 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         *BundledPageMixin.panels,
         MultiFieldPanel(
             [
-                TitleFieldPanel("title", help_text=_("Also known as the release edition. e.g. 'November 2024'.")),
+                TitleFieldPanel("title", help_text="Also known as the release edition. e.g. 'November 2024'."),
                 FieldPanel(
                     "news_headline",
                     help_text=(
@@ -159,23 +159,23 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
             [
                 FieldRowPanel(
                     [
-                        FieldPanel("release_date", help_text=_("The actual release date")),
+                        FieldPanel("release_date", help_text="The actual release date"),
                         FieldPanel(
                             "next_release_date",
-                            help_text=_("If no next date is chosen, 'To be announced' will be displayed."),
+                            help_text="If no next date is chosen, 'To be announced' will be displayed.",
                         ),
                     ],
-                    heading=_("Dates"),
+                    heading="Dates",
                 ),
                 FieldRowPanel(
                     ["is_accredited", "is_census"],
-                    heading=_("About the data"),
+                    heading="About the data",
                 ),
                 "contact_details",
                 "show_cite_this_page",
                 "main_points_summary",
             ],
-            heading=_("Metadata"),
+            heading="Metadata",
             icon="cog",
         ),
         FieldPanel("headline_figures", icon="data-analysis"),
@@ -207,7 +207,7 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         super().clean()
 
         if self.next_release_date and self.next_release_date <= self.release_date:
-            raise ValidationError({"next_release_date": _("The next release date must be after the release date.")})
+            raise ValidationError({"next_release_date": "The next release date must be after the release date."})
 
     def get_context(self, request: "HttpRequest", *args: Any, **kwargs: Any) -> dict:
         """Additional context for the template."""

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -91,7 +91,7 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
     parent_page_types: ClassVar[list[str]] = ["ArticleSeriesPage"]
     subpage_types: ClassVar[list[str]] = []
     template = "templates/pages/statistical_article_page.html"
-    label = "Article"
+    label = _("Article")
 
     # Fields
     news_headline = models.CharField(max_length=255, blank=True)

--- a/cms/bundles/admin_forms.py
+++ b/cms/bundles/admin_forms.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext as _
 
 from .models import Bundle, BundledPageMixin
 from .viewsets import BundleChooserWidget
@@ -22,8 +21,8 @@ class AddToBundleForm(forms.Form):
         self.fields["bundle"] = forms.ModelChoiceField(
             queryset=Bundle.objects.editable(),
             widget=BundleChooserWidget(),
-            label=_("Bundle"),
-            help_text=_("Select a bundle for this page."),
+            label="Bundle",
+            help_text="Select a bundle for this page.",
         )
 
     def clean(self) -> None:
@@ -32,12 +31,9 @@ class AddToBundleForm(forms.Form):
         if not isinstance(self.page_to_add, BundledPageMixin):
             # While this form is used the "add to bundle" view which already checks for this,
             # it doesn't hurt to trust but verify.
-            raise ValidationError(_("Pages of this type cannot be added."))
+            raise ValidationError("Pages of this type cannot be added.")
 
         bundle = self.cleaned_data.get("bundle")
         if bundle and bundle.bundled_pages.filter(page=self.page_to_add).exists():
-            message = _("Page '%(page)s' is already in bundle '%(bundle)s'") % {
-                "page": self.page_to_add.get_admin_display_title(),  # type: ignore[attr-defined]
-                "bundle": bundle,
-            }
+            message = f"Page '{self.page_to_add.get_admin_display_title()}' is already in bundle '{bundle}'"
             raise ValidationError({"bundle": message})

--- a/cms/bundles/admin_forms.py
+++ b/cms/bundles/admin_forms.py
@@ -35,6 +35,6 @@ class AddToBundleForm(forms.Form):
 
         bundle = self.cleaned_data.get("bundle")
         if bundle and bundle.bundled_pages.filter(page=self.page_to_add).exists():
-            display_title = self.page_to_add.get_admin_display_title()
-            message = f"Page '{display_title}' is already in bundle '{bundle}'"  # type: ignore[attr-defined]
+            display_title = self.page_to_add.get_admin_display_title()  # type: ignore[attr-defined]
+            message = f"Page '{display_title}' is already in bundle '{bundle}'"
             raise ValidationError({"bundle": message})

--- a/cms/bundles/admin_forms.py
+++ b/cms/bundles/admin_forms.py
@@ -35,5 +35,5 @@ class AddToBundleForm(forms.Form):
 
         bundle = self.cleaned_data.get("bundle")
         if bundle and bundle.bundled_pages.filter(page=self.page_to_add).exists():
-            message = f"Page '{self.page_to_add.get_admin_display_title()}' is already in bundle '{bundle}'"
+            message = f"Page '{self.page_to_add.get_admin_display_title()}' is already in bundle '{bundle}'"  # type: ignore[attr-defined]
             raise ValidationError({"bundle": message})

--- a/cms/bundles/admin_forms.py
+++ b/cms/bundles/admin_forms.py
@@ -35,5 +35,6 @@ class AddToBundleForm(forms.Form):
 
         bundle = self.cleaned_data.get("bundle")
         if bundle and bundle.bundled_pages.filter(page=self.page_to_add).exists():
-            message = f"Page '{self.page_to_add.get_admin_display_title()}' is already in bundle '{bundle}'"  # type: ignore[attr-defined]
+            display_title = self.page_to_add.get_admin_display_title()
+            message = f"Page '{display_title}' is already in bundle '{bundle}'"  # type: ignore[attr-defined]
             raise ValidationError({"bundle": message})

--- a/cms/bundles/enums.py
+++ b/cms/bundles/enums.py
@@ -1,14 +1,13 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 
 
 class BundleStatus(models.TextChoices):
     """The bundle statuses."""
 
-    PENDING = "PENDING", _("Pending")
-    IN_REVIEW = "IN_REVIEW", _("In Review")
-    APPROVED = "APPROVED", _("Approved")
-    RELEASED = "RELEASED", _("Released")
+    PENDING = "PENDING", "Pending"
+    IN_REVIEW = "IN_REVIEW", "In Review"
+    APPROVED = "APPROVED", "Approved"
+    RELEASED = "RELEASED", "Released"
 
 
 ACTIVE_BUNDLE_STATUSES = [BundleStatus.PENDING, BundleStatus.IN_REVIEW, BundleStatus.APPROVED]

--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import timezone
-from django.utils.translation import gettext as _
 from wagtail.admin.forms import WagtailAdminModelForm
 
 from cms.bundles.enums import ACTIVE_BUNDLE_STATUS_CHOICES, EDITABLE_BUNDLE_STATUSES, BundleStatus
@@ -67,13 +66,7 @@ class BundleAdminForm(WagtailAdminModelForm):
             if not form.cleaned_data["DELETE"]:
                 page = page.specific
                 if page.in_active_bundle and page.active_bundle != self.instance:
-                    raise ValidationError(
-                        _("'%(page)s' is already in an active bundle (%(bundle)s)")
-                        % {
-                            "page": page,
-                            "bundle": page.active_bundle,
-                        }
-                    )
+                    raise ValidationError(f"'{page}' is already in an active bundle ({page.active_bundle})")
 
     def clean(self) -> dict[str, Any] | None:
         """Validates the form.
@@ -101,7 +94,7 @@ class BundleAdminForm(WagtailAdminModelForm):
                 cleaned_data["approved_by"] = None
 
         if self.cleaned_data["release_calendar_page"] and self.cleaned_data["publication_date"]:
-            error = _("You must choose either a Release Calendar page or a Publication date, not both.")
+            error = "You must choose either a Release Calendar page or a Publication date, not both."
             self.add_error("release_calendar_page", error)
             self.add_error("publication_date", error)
 

--- a/cms/bundles/models.py
+++ b/cms/bundles/models.py
@@ -5,7 +5,6 @@ from django.db.models import F, QuerySet
 from django.db.models.functions import Coalesce
 from django.utils.functional import cached_property
 from django.utils.timezone import now
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, FieldRowPanel, InlinePanel
@@ -109,11 +108,11 @@ class Bundle(index.Indexed, ClusterableModel, models.Model):  # type: ignore[dja
                 ),
                 FieldPanel("publication_date", heading="or Publication date"),
             ],
-            heading=_("Scheduling"),
+            heading="Scheduling",
             icon="calendar",
         ),
         "status",
-        InlinePanel("bundled_pages", heading=_("Bundled pages"), icon="doc-empty", label=_("Page")),
+        InlinePanel("bundled_pages", heading="Bundled pages", icon="doc-empty", label="Page"),
         # these are handled by the form
         FieldPanel("approved_by", classname="hidden w-hidden"),
         FieldPanel("approved_at", classname="hidden w-hidden"),

--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any, Union
 
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import gettext as _
 from wagtail.admin.panels import HelpPanel, PageChooserPanel
 
 if TYPE_CHECKING:
@@ -34,11 +33,9 @@ class BundleNotePanel(HelpPanel):
                     ),
                 )
 
-                content = format_html(
-                    "<p>{}</p><ul>{}</ul>", _("This page is in the following bundle(s):"), content_html
-                )
+                content = format_html("<p>{}</p><ul>{}</ul>", "This page is in the following bundle(s):", content_html)
             else:
-                content = format_html("<p>{}</p>", _("This page is not part of any bundles."))
+                content = format_html("<p>{}</p>", "This page is not part of any bundles.")
             return content
 
 

--- a/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Add {{ title }} to a bundle{% endblocktrans %}{% endblock %}
 {% block content %}
     {% include "wagtailadmin/shared/header.html" with title="Add" subtitle=page_to_move.specific_deferred.get_admin_display_title icon="boxes-stacked" %}

--- a/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Add {{ title }} to a bundle{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=_("Add") subtitle=page_to_move.specific_deferred.get_admin_display_title icon="boxes-stacked" %}
+    {% include "wagtailadmin/shared/header.html" with title="Add" subtitle=page_to_move.specific_deferred.get_admin_display_title icon="boxes-stacked" %}
 
     <div class="nice-padding">
         <form action="{% url 'bundles:add_to_bundle' page_to_add.id %}" method="post" novalidate>

--- a/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/add_to_bundle.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Add {{ title }} to a bundle{% endblocktrans %}{% endblock %}
 {% block content %}
     {% include "wagtailadmin/shared/header.html" with title="Add" subtitle=page_to_move.specific_deferred.get_admin_display_title icon="boxes-stacked" %}

--- a/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailcore_tags wagtailadmin_tags %}
 {% if is_shown %}
-    {% panel id="latest-bundles" heading"Latest active bundles" %}
+    {% panel id="latest-bundles" heading="Latest active bundles" %}
         {% help_block status="info" %}
             <p>Bundles are collections of pages and datasets to publish together.</p>
         {% endhelp_block %}

--- a/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
+++ b/cms/bundles/templates/bundles/wagtailadmin/panels/latest_bundles.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailcore_tags wagtailadmin_tags %}
 {% if is_shown %}
-    {% panel id="latest-bundles" heading=_("Latest active bundles") %}
+    {% panel id="latest-bundles" heading"Latest active bundles" %}
         {% help_block status="info" %}
             <p>Bundles are collections of pages and datasets to publish together.</p>
         {% endhelp_block %}
@@ -33,7 +33,7 @@
                                 </div>
                                 <ul class="actions">
                                     <li>
-                                        {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") %}
+                                        {% dropdown toggle_icon="dots-horizontal" toggle_aria_label="Actions" %}
                                             <a href="{% url 'bundle:edit' bundle.pk %}">{% trans "Edit" %}</a>
                                             <a href="{% url 'bundle:inspect' bundle.pk %}">{% trans "View" %}</a>
                                         {% enddropdown %}

--- a/cms/bundles/views.py
+++ b/cms/bundles/views.py
@@ -48,11 +48,14 @@ class AddToBundleView(FormView):
             self.goto_next = redirect_to
 
         if self.page_to_add.in_active_bundle:
+            text_list = get_text_list(
+                list(self.page_to_add.active_bundles.values_list("name", flat=True)),  # type: ignore[attr-defined]
+                last_word="and",
+            )
+
             messages.warning(
                 request,
-                f"Page {self.page_to_add.get_admin_display_title()} is already in a bundle ('{
-                    get_text_list(list(self.page_to_add.active_bundles.values_list('name', flat=True)), last_word='and')
-                }')",
+                f"Page {self.page_to_add.get_admin_display_title()} is already in a bundle ('{text_list}')",
             )
             if self.goto_next:
                 return redirect(self.goto_next)

--- a/cms/bundles/views.py
+++ b/cms/bundles/views.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import get_text_list
-from django.utils.translation import gettext as _
 from django.views.generic import FormView
 from wagtail.admin import messages
 from wagtail.models import Page
@@ -32,7 +31,7 @@ class AddToBundleView(FormView):
         )
 
         if not isinstance(self.page_to_add, BundledPageMixin):
-            raise Http404(_("Cannot add this page type to a bundle"))
+            raise Http404("Cannot add this page type to a bundle")
 
         page_perms = self.page_to_add.permissions_for_user(request.user)  # type: ignore[attr-defined]
         # TODO: add the relevant permission checks
@@ -51,13 +50,9 @@ class AddToBundleView(FormView):
         if self.page_to_add.in_active_bundle:
             messages.warning(
                 request,
-                _("Page %(title)s is already in a bundle ('%(bundles)s')")
-                % {
-                    "title": self.page_to_add.get_admin_display_title(),  # type: ignore[attr-defined]
-                    "bundles": get_text_list(
-                        list(self.page_to_add.active_bundles.values_list("name", flat=True)), last_word="and"
-                    ),
-                },
+                f"Page {self.page_to_add.get_admin_display_title()} is already in a bundle ('{
+                    get_text_list(list(self.page_to_add.active_bundles.values_list('name', flat=True)), last_word='and')
+                }')",
             )
             if self.goto_next:
                 return redirect(self.goto_next)
@@ -92,7 +87,7 @@ class AddToBundleView(FormView):
             buttons=[
                 messages.button(
                     reverse("wagtailadmin_pages:edit", args=(self.page_to_add.id,)),
-                    _("Edit"),
+                    "Edit",
                 )
             ],
         )

--- a/cms/bundles/views.py
+++ b/cms/bundles/views.py
@@ -49,13 +49,15 @@ class AddToBundleView(FormView):
 
         if self.page_to_add.in_active_bundle:
             text_list = get_text_list(
-                list(self.page_to_add.active_bundles.values_list("name", flat=True)),  # type: ignore[attr-defined]
+                list(self.page_to_add.active_bundles.values_list("name", flat=True)),
                 last_word="and",
             )
 
+            admin_display_title = self.page_to_add.get_admin_display_title()  # type: ignore[attr-defined]
+
             messages.warning(
                 request,
-                f"Page {self.page_to_add.get_admin_display_title()} is already in a bundle ('{text_list}')",
+                f"Page {admin_display_title} is already in a bundle ('{text_list}')",
             )
             if self.goto_next:
                 return redirect(self.goto_next)

--- a/cms/bundles/viewsets.py
+++ b/cms/bundles/viewsets.py
@@ -8,7 +8,6 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import gettext as _
 from wagtail.admin.ui.tables import Column, DateColumn, UpdatedAtColumn, UserColumn
 from wagtail.admin.views.generic import CreateView, EditView, IndexView, InspectView
 from wagtail.admin.views.generic.chooser import ChooseResultsView, ChooseView
@@ -151,11 +150,11 @@ class BundleInspectView(InspectView):
     def get_field_label(self, field_name: str, field: "Field") -> str:
         match field_name:
             case "approved":
-                return _("Approval status")
+                return "Approval status"
             case "scheduled_publication":
-                return _("Scheduled publication")
+                return "Scheduled publication"
             case "pages":
-                return _("Pages")
+                return "Pages"
             case _:
                 return super().get_field_label(field_name, field)  # type: ignore[no-any-return]
 
@@ -175,12 +174,12 @@ class BundleInspectView(InspectView):
         if self.object.status in [BundleStatus.APPROVED, BundleStatus.RELEASED]:
             if self.object.approved_by_id and self.object.approved_at:
                 return f"{self.object.approved_by} on {self.object.approved_at}"
-            return _("Unknown approval data")
-        return _("Pending approval")
+            return "Unknown approval data"
+        return "Pending approval"
 
     def get_scheduled_publication_display_value(self) -> str:
         """Displays the scheduled publication date, if set."""
-        return self.object.scheduled_publication_date or _("No scheduled publication")
+        return self.object.scheduled_publication_date or "No scheduled publication"
 
     def get_pages_display_value(self) -> "SafeString":
         """Returns formatted markup for Pages linked to the Bundle."""
@@ -245,11 +244,11 @@ class BundleIndexView(IndexView):
         return [
             self._get_title_column("__str__"),
             Column("scheduled_publication_date"),
-            Column("get_status_display", label=_("Status")),
+            Column("get_status_display", label="Status"),
             UpdatedAtColumn(),
-            DateColumn(name="created_at", label=_("Added"), sort_key="created_at"),
-            UserColumn("created_by", label=_("Added by")),
-            DateColumn(name="approved_at", label=_("Approved at"), sort_key="approved_at"),
+            DateColumn(name="created_at", label="Added", sort_key="created_at"),
+            UserColumn("created_by", label="Added by"),
+            DateColumn(name="approved_at", label="Approved at", sort_key="approved_at"),
             UserColumn("approved_by"),
         ]
 

--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Union
 from django.db.models import QuerySet
 from django.urls import include, path
 from django.utils.timezone import now
-from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
 from wagtail.admin.widgets import PageListingButton
@@ -40,9 +39,9 @@ def register_viewset() -> list:
 class PageAddToBundleButton(PageListingButton):
     """Defines the 'Add to Bundle' button to use in different contexts in the admin."""
 
-    label = _("Add to Bundle")
+    label = "Add to Bundle"
     icon_name = "boxes-stacked"
-    aria_label_format = _("Add '%(title)s' to a bundle")
+    aria_label_format = "Add '%(title)s' to a bundle"
     url_name = "bundles:add_to_bundle"
 
     @property
@@ -178,24 +177,24 @@ def register_bundle_log_actions(actions: "LogActionRegistry") -> None:
     class ChangeBundleStatus(LogFormatter):  # pylint: disable=unused-variable
         """LogFormatter class for the bundle status change actions."""
 
-        label = _("Change bundle status")
+        label = "Change bundle status"
 
         def format_message(self, log_entry: "ModelLogEntry") -> Any:
             """Returns the formatted log message."""
             try:
-                return _(f"Changed the bundle status from '{log_entry.data['old']}' to '{log_entry.data['new']}'")
+                return f"Changed the bundle status from '{log_entry.data['old']}' to '{log_entry.data['new']}'"
             except KeyError:
-                return _("Changed the bundle status")
+                return "Changed the bundle status"
 
     @actions.register_action("bundles.approve")
     class ApproveBundle(LogFormatter):  # pylint: disable=unused-variable
         """LogFormatter class for the bundle approval actions."""
 
-        label = _("Approve bundle")
+        label = "Approve bundle"
 
         def format_message(self, log_entry: "ModelLogEntry") -> Any:
             """Returns the formatted log message."""
             try:
-                return _(f"Approved the bundle. (Old status: '{log_entry.data['old']}')")
+                return f"Approved the bundle. (Old status: '{log_entry.data['old']}')"
             except KeyError:
-                return _("Approved the bundle")
+                return "Approved the bundle"

--- a/cms/core/blocks/base.py
+++ b/cms/core/blocks/base.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
 from wagtail.blocks import (
     CharBlock,
     PageChooserBlock,
@@ -63,18 +62,18 @@ class LinkBlock(StructBlock):
 
         # Require exactly one link
         if not page and not external_url:
-            error = ValidationError(_("Either Page or External Link is required."), code="invalid")
+            error = ValidationError("Either Page or External Link is required.", code="invalid")
             errors["page"] = ErrorList([error])
             errors["external_url"] = ErrorList([error])
-            non_block_errors.append(ValidationError(_("Missing required fields")))
+            non_block_errors.append(ValidationError("Missing required fields"))
         elif page and external_url:
-            error = ValidationError(_("Please select either a page or a URL, not both."), code="invalid")
+            error = ValidationError("Please select either a page or a URL, not both.", code="invalid")
             errors["page"] = ErrorList([error])
             errors["external_url"] = ErrorList([error])
 
         # Require title for external links
         if not page and external_url and not value["title"]:
-            errors["title"] = ErrorList([ValidationError(_("Title is required for external links."), code="invalid")])
+            errors["title"] = ErrorList([ValidationError("Title is required for external links.", code="invalid")])
 
         if errors:
             raise StreamBlockValidationError(block_errors=errors, non_block_errors=non_block_errors)

--- a/cms/core/blocks/embeddable.py
+++ b/cms/core/blocks/embeddable.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.template.defaultfilters import filesizeformat
-from django.utils.translation import gettext as _
 from wagtail import blocks
 from wagtail.blocks import StructBlockValidationError
 from wagtail.documents.blocks import DocumentChooserBlock
@@ -88,9 +87,7 @@ class ONSEmbedBlock(blocks.StructBlock):
         errors = {}
 
         if not value["url"].startswith(settings.ONS_EMBED_PREFIX):
-            errors["url"] = ValidationError(
-                _("The URL must start with %(prefix)s") % {"prefix": settings.ONS_EMBED_PREFIX}
-            )
+            errors["url"] = ValidationError(f"The URL must start with {settings.ONS_EMBED_PREFIX}")
 
         if errors:
             raise StructBlockValidationError(block_errors=errors)
@@ -106,16 +103,16 @@ class VideoEmbedBlock(blocks.StructBlock):
     """A video embed block."""
 
     link_url = blocks.URLBlock(
-        help_text=_(
+        help_text=(
             "The URL to the video hosted on YouTube or Vimeo, for example, "
             "https://www.youtube.com/watch?v={ video ID } or https://vimeo.com/video/{ video ID }. "
             "Used to link to the video when cookies are not enabled."
         )
     )
-    image = ImageChooserBlock(help_text=_("The video cover image, used when cookies are not enabled."))
-    title = blocks.CharBlock(help_text=_("The descriptive title for the video used by screen readers."))
+    image = ImageChooserBlock(help_text="The video cover image, used when cookies are not enabled.")
+    title = blocks.CharBlock(help_text="The descriptive title for the video used by screen readers.")
     link_text = blocks.CharBlock(
-        help_text=_("The text to be shown when cookies are not enabled e.g. 'Watch the {title} on Youtube'.")
+        help_text="The text to be shown when cookies are not enabled e.g. 'Watch the {title} on Youtube'."
     )
 
     def get_embed_url(self, link_url: str) -> str:
@@ -177,7 +174,7 @@ class VideoEmbedBlock(blocks.StructBlock):
             return super().clean(value)
 
         if not any(re.match(pattern, value["link_url"]) for pattern in other_patterns):
-            errors["link_url"] = ValidationError(_("The link URL must use a valid Vimeo or YouTube video URL"))
+            errors["link_url"] = ValidationError("The link URL must use a valid Vimeo or YouTube video URL")
 
         if errors:
             raise StructBlockValidationError(block_errors=errors)

--- a/cms/core/blocks/headline_figures.py
+++ b/cms/core/blocks/headline_figures.py
@@ -1,15 +1,14 @@
 from typing import Any
 
-from django.utils.translation import gettext as _
 from wagtail.blocks import CharBlock, ListBlock, StructBlock
 
 
 class HeadlineFiguresItemBlock(StructBlock):
     """Represents a headline figure."""
 
-    title = CharBlock(label=_("Title"), max_length=60, required=True)
-    figure = CharBlock(label=_("Figure"), max_length=10, required=True)
-    supporting_text = CharBlock(label=_("Supporting text"), max_length=100, required=True)
+    title = CharBlock(label="Title", max_length=60, required=True)
+    figure = CharBlock(label="Figure", max_length=10, required=True)
+    supporting_text = CharBlock(label="Supporting text", max_length=100, required=True)
 
 
 class HeadlineFiguresBlock(ListBlock):
@@ -21,5 +20,5 @@ class HeadlineFiguresBlock(ListBlock):
 
     class Meta:
         icon = "data-analysis"
-        label = _("Headline figures")
+        label = "Headline figures"
         template = "templates/components/streamfield/headline_figures_block.html"

--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Union
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.text import slugify
-from django.utils.translation import gettext as _
 from wagtail import blocks
 from wagtail.contrib.table_block.blocks import TableBlock as WagtailTableBlock
 from wagtail_tinytableblock.blocks import TinyTableBlock
@@ -55,7 +54,7 @@ class BasicTableBlock(WagtailTableBlock):
     class Meta:
         icon = "table"
         template = "templates/components/streamfield/basic_table_block.html"
-        label = _("Basic table")
+        label = "Basic table"
 
     def _get_header(self, value: dict) -> list[dict[str, str]]:
         """Prepares the table header for the Design System."""
@@ -80,12 +79,12 @@ class BasicTableBlock(WagtailTableBlock):
     def clean(self, value: dict) -> dict:
         """Validate that a header was chosen, and the cells are not empty."""
         if not value or not value.get("table_header_choice"):
-            raise ValidationError(_("Select an option for Table headers"))
+            raise ValidationError("Select an option for Table headers")
 
         data = value.get("data", [])
         all_cells_empty = all(not cell for row in data for cell in row)
         if all_cells_empty:
-            raise ValidationError(_("The table cannot be empty"))
+            raise ValidationError("The table cannot be empty")
 
         cleaned_value: dict = super().clean(value)
         return cleaned_value
@@ -112,8 +111,8 @@ class BasicTableBlock(WagtailTableBlock):
 class ONSTableBlock(TinyTableBlock):
     """The ONS table block."""
 
-    source = blocks.CharBlock(label=_("Source"), required=False)
-    footnotes = blocks.RichTextBlock(label=_("Footnotes"), features=settings.RICH_TEXT_BASIC, required=False)
+    source = blocks.CharBlock(label="Source", required=False)
+    footnotes = blocks.RichTextBlock(label="Footnotes", features=settings.RICH_TEXT_BASIC, required=False)
 
     def get_context(self, value: dict, parent_context: dict | None = None) -> dict:
         """Insert the DS-ready options in the template context."""

--- a/cms/core/blocks/panels.py
+++ b/cms/core/blocks/panels.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.forms import Media
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.blocks.field_block import FieldBlockAdapter
 from wagtail.blocks.struct_block import StructBlockAdapter
@@ -18,30 +17,30 @@ class BasePanelBlock(blocks.StructBlock):
 
     class Meta:
         abstract = True
-        group = _("Panels")
+        group = "Panels"
 
 
 class WarningPanelBlock(BasePanelBlock):
     class Meta:
         template = "templates/components/streamfield/warning_panel.html"
         icon = "warning"
-        label = _("Warning Panel")
+        label = "Warning Panel"
 
 
 class AnnouncementPanelBlock(BasePanelBlock):
     class Meta:
         template = "templates/components/streamfield/announcement_panel.html"
         icon = "pick"
-        label = _("Announcement Panel")
+        label = "Announcement Panel"
 
 
 class InformationPanelBlock(BasePanelBlock):
-    title = blocks.CharBlock(required=True, label=_("Title"))
+    title = blocks.CharBlock(required=True, label="Title")
 
     class Meta:
         template = "templates/components/streamfield/information_panel.html"
         icon = "info-circle"
-        label = _("Information Panel")
+        label = "Information Panel"
 
 
 class PreviousVersionBlock(blocks.IntegerBlock):

--- a/cms/core/blocks/section_blocks.py
+++ b/cms/core/blocks/section_blocks.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, ClassVar
 
 from django.utils.text import slugify
-from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import RichTextBlock, StreamBlock, StructBlock
 from wagtail.images.blocks import ImageChooserBlock
 from wagtailmath.blocks import MathBlock
@@ -37,7 +36,7 @@ class SectionContentBlock(StreamBlock):
     video_embed = VideoEmbedBlock(group="Media")
     table = ONSTableBlock(group="DataVis", allow_links=True)
     equation = MathBlock(group="DataVis", icon="decimal")
-    ons_embed = ONSEmbedBlock(group="DataVis", label=_("ONS General Embed"))
+    ons_embed = ONSEmbedBlock(group="DataVis", label="ONS General Embed")
     related_links = RelatedLinksBlock(icon="link")
     definitions = GlossaryTermsBlock()
 

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Self, cast
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import ObjectList, TabbedInterface
 from wagtail.models import Page
 from wagtail.query import PageQuerySet
@@ -55,7 +54,7 @@ class BasePage(ListingFieldsMixin, SocialFieldsMixin, Page):  # type: ignore[dja
     content_field_name: str = "content"
 
     # used a page type label in the front-end
-    label = _("Page")
+    label = "Page"
 
     class Meta:
         abstract = True

--- a/cms/core/models/snippets.py
+++ b/cms/core/models/snippets.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.functions import Lower
-from django.utils.translation import gettext_lazy as _
 from wagtail.fields import RichTextField
 from wagtail.models import PreviewableMixin, RevisionMixin, TranslatableMixin
 from wagtail.search import index
@@ -42,13 +41,13 @@ class ContactDetails(index.Indexed, models.Model):
     ]
 
     class Meta:
-        verbose_name_plural = _("contact details")
+        verbose_name_plural = "contact details"
         constraints: ClassVar[list[models.BaseConstraint]] = [
             models.UniqueConstraint(
                 Lower("name"),
                 Lower("email"),
                 name="core_contactdetails_name_unique",
-                violation_error_message=_("Contact details with this name and email combination already exists."),
+                violation_error_message="Contact details with this name and email combination already exists.",
             ),
         ]
 
@@ -93,7 +92,7 @@ class GlossaryTerm(TranslatableMixin, PreviewableMixin, RevisionMixin, index.Ind
             models.UniqueConstraint(
                 Lower("name"),
                 name="core_glossary_term_name_unique",
-                violation_error_message=_("A glossary term with this name already exists."),
+                violation_error_message="A glossary term with this name already exists.",
             ),
             models.UniqueConstraint(
                 fields=("translation_key", "locale"), name="unique_translation_key_locale_core_glossaryterm"

--- a/cms/core/utils.py
+++ b/cms/core/utils.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 from django.db.models import QuerySet
 from django.utils.formats import date_format
+from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -29,13 +30,13 @@ def get_formatted_pages_list(
                 "url": page.get_url(request=request),
             },
             "metadata": {
-                "object": {"text": getattr(page, "label", "Page")},
+                "object": {"text": getattr(page, "label", _("Page"))},
             },
             "description": getattr(page, "listing_summary", "") or getattr(page, "summary", ""),
         }
         if release_date := page.release_date:
             datum["metadata"]["date"] = {
-                "prefix": "Released",
+                "prefix": _("Released"),
                 "showPrefix": True,
                 "iso": date_format(release_date, "c"),
                 "short": date_format(release_date, "DATE_FORMAT"),

--- a/cms/core/utils.py
+++ b/cms/core/utils.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 from django.db.models import QuerySet
 from django.utils.formats import date_format
-from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -30,13 +29,13 @@ def get_formatted_pages_list(
                 "url": page.get_url(request=request),
             },
             "metadata": {
-                "object": {"text": getattr(page, "label", _("Page"))},
+                "object": {"text": getattr(page, "label", "Page")},
             },
             "description": getattr(page, "listing_summary", "") or getattr(page, "summary", ""),
         }
         if release_date := page.release_date:
             datum["metadata"]["date"] = {
-                "prefix": _("Released"),
+                "prefix": "Released",
                 "showPrefix": True,
                 "iso": date_format(release_date, "c"),
                 "short": date_format(release_date, "DATE_FORMAT"),

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -41,7 +41,7 @@ class MethodologyRelatedPage(Orderable):
 class MethodologyPage(GenericTaxonomyMixin, BasePage):  # type: ignore[django-manager-missing]
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     template = "templates/pages/methodology_page.html"
-    label = "Methodology"
+    label = _("Methodology")
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     publication_date = models.DateField()

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -41,7 +41,7 @@ class MethodologyRelatedPage(Orderable):
 class MethodologyPage(GenericTaxonomyMixin, BasePage):  # type: ignore[django-manager-missing]
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     template = "templates/pages/methodology_page.html"
-    label = _("Methodology")
+    label = _("Methodology")  # type: ignore[assignment]
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     publication_date = models.DateField()

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -41,7 +41,7 @@ class MethodologyRelatedPage(Orderable):
 class MethodologyPage(GenericTaxonomyMixin, BasePage):  # type: ignore[django-manager-missing]
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     template = "templates/pages/methodology_page.html"
-    label = _("Methodology")
+    label = "Methodology"
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     publication_date = models.DateField()
@@ -73,7 +73,7 @@ class MethodologyPage(GenericTaxonomyMixin, BasePage):  # type: ignore[django-ma
                 "contact_details",
                 "show_cite_this_page",
             ],
-            heading=_("Metadata"),
+            heading="Metadata",
             icon="cog",
         ),
         FieldPanel("content", icon="list-ul"),
@@ -91,7 +91,7 @@ class MethodologyPage(GenericTaxonomyMixin, BasePage):  # type: ignore[django-ma
         super().clean()
 
         if self.last_revised_date and self.last_revised_date <= self.publication_date:
-            raise ValidationError({"last_revised_date": _("The last revised date must be after the published date.")})
+            raise ValidationError({"last_revised_date": "The last revised date must be after the published date."})
 
     def get_context(self, request: HttpRequest, *args: Any, **kwargs: Any) -> dict:
         """Additional context for the template."""

--- a/cms/navigation/blocks.py
+++ b/cms/navigation/blocks.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import CharBlock, ListBlock, PageChooserBlock, StructBlock
 
 from cms.core.blocks.base import LinkBlock
@@ -8,37 +7,37 @@ class ThemeLinkBlock(LinkBlock):
     page = PageChooserBlock(required=False, page_type="themes.ThemePage")
 
     class Meta:
-        label = _("Theme Link")
+        label = "Theme Link"
 
 
 class TopicLinkBlock(LinkBlock):
     page = PageChooserBlock(required=False, page_type="topics.TopicPage")
 
     class Meta:
-        label = _("Topic Link")
+        label = "Topic Link"
 
 
 class MainMenuHighlightsBlock(LinkBlock):
     description = CharBlock(
-        required=True, max_length=50, help_text=_("For example: 'View our latest and upcoming releases.'")
+        required=True, max_length=50, help_text="For example: 'View our latest and upcoming releases.'"
     )
 
     class Meta:
         icon = "star"
-        label = _("Highlight")
+        label = "Highlight"
 
 
 class MainMenuSectionBlock(StructBlock):
-    section_link = ThemeLinkBlock(help_text=_("Main link for this section (Theme pages or external URLs)."))
+    section_link = ThemeLinkBlock(help_text="Main link for this section (Theme pages or external URLs).")
     links = ListBlock(
         TopicLinkBlock(),
-        help_text=_("Sub-links for this section (Topic pages or external URLs)."),
+        help_text="Sub-links for this section (Topic pages or external URLs).",
         max_num=15,
     )
 
     class Meta:
         icon = "folder"
-        label = _("Section")
+        label = "Section"
 
 
 class MainMenuColumnBlock(StructBlock):
@@ -46,14 +45,14 @@ class MainMenuColumnBlock(StructBlock):
 
     class Meta:
         icon = "list-ul"
-        label = _("Column")
+        label = "Column"
 
 
 class LinksColumn(StructBlock):
-    title = CharBlock(required=True, label=_("Column title"))
+    title = CharBlock(required=True, label="Column title")
     links = ListBlock(
         LinkBlock(),
-        help_text=_("Links for this column (pages or external URLs)."),
+        help_text="Links for this column (pages or external URLs).",
         max_num=10,
     )
 

--- a/cms/navigation/forms.py
+++ b/cms/navigation/forms.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
-from django.utils.translation import gettext as _
 from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.blocks import StreamBlockValidationError, StructBlock, StructBlockValidationError, StructValue
 from wagtail.models import Page
@@ -59,9 +58,9 @@ def validate_links(
     link_url = link_value.get("external_url")
 
     if link_page is not None:
-        errors += check_duplicates(link_page, seen_pages, "page", _("Duplicate page. Please choose a different one."))
+        errors += check_duplicates(link_page, seen_pages, "page", "Duplicate page. Please choose a different one.")
     if link_url is not None:
-        errors += check_duplicates(link_url, seen_urls, "external_url", _("Duplicate URL. Please add a different one."))
+        errors += check_duplicates(link_url, seen_urls, "external_url", "Duplicate URL. Please add a different one.")
     return errors
 
 
@@ -83,9 +82,9 @@ class MainMenuAdminForm(WagtailAdminModelForm):
             external_url = block_value.get("external_url")
 
             errors = []
-            errors += check_duplicates(page, seen_pages, "page", _("Duplicate page. Please choose a different one."))
+            errors += check_duplicates(page, seen_pages, "page", "Duplicate page. Please choose a different one.")
             errors += check_duplicates(
-                external_url, seen_urls, "external_url", _("Duplicate URL. Please add a different one.")
+                external_url, seen_urls, "external_url", "Duplicate URL. Please add a different one."
             )
             return errors
 
@@ -111,10 +110,10 @@ class MainMenuAdminForm(WagtailAdminModelForm):
             section_url = section_link.get("external_url")
 
             sec_errors += check_duplicates(
-                section_page, seen_pages, "section_link", _("Duplicate page. Please choose a different one.")
+                section_page, seen_pages, "section_link", "Duplicate page. Please choose a different one."
             )
             sec_errors += check_duplicates(
-                section_url, seen_urls, "section_link", _("Duplicate URL. Please add a different one.")
+                section_url, seen_urls, "section_link", "Duplicate URL. Please add a different one."
             )
 
             sub_links = section_value.get("links", [])

--- a/cms/navigation/models.py
+++ b/cms/navigation/models.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, ClassVar, Union
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import PublishingPanel
 from wagtail.contrib.settings.models import register_setting
 from wagtail.models import DraftStateMixin, PreviewableMixin, RevisionMixin
@@ -24,13 +23,13 @@ class MainMenu(DraftStateMixin, RevisionMixin, PreviewableMixin, models.Model):
         [("highlight", MainMenuHighlightsBlock())],
         blank=True,
         max_num=3,
-        help_text=_("Up to 3 highlights. Each highlight must have either a page or a URL."),
+        help_text="Up to 3 highlights. Each highlight must have either a page or a URL.",
     )
     columns = StreamField(
         [("column", MainMenuColumnBlock())],
         blank=True,
         max_num=3,
-        help_text=_("Up to 3 columns. Each column contains sections with links."),
+        help_text="Up to 3 columns. Each column contains sections with links.",
     )
 
     _revisions = GenericRelation("wagtailcore.Revision", related_query_name="main_menu")
@@ -59,7 +58,7 @@ class FooterMenu(DraftStateMixin, RevisionMixin, PreviewableMixin, models.Model)
         [("column", LinksColumn())],
         blank=True,
         max_num=3,
-        help_text=_("Up to 3 columns. Each column contains a title with links."),
+        help_text="Up to 3 columns. Each column contains a title with links.",
     )
     _revisions = GenericRelation("wagtailcore.Revision", related_query_name="footer_menu")
 
@@ -87,7 +86,7 @@ class NavigationSettings(BaseSiteSetting):
         null=True,
         blank=True,
         related_name="+",
-        help_text=_("Select the main menu to display on the site."),
+        help_text="Select the main menu to display on the site.",
     )
 
     footer_menu = models.ForeignKey(
@@ -96,7 +95,7 @@ class NavigationSettings(BaseSiteSetting):
         null=True,
         blank=True,
         related_name="+",
-        help_text=_("Select the footer menu to display on the site."),
+        help_text="Select the footer menu to display on the site.",
     )
 
     panels: ClassVar[list] = ["main_menu", "footer_menu"]

--- a/cms/private_media/constants.py
+++ b/cms/private_media/constants.py
@@ -1,7 +1,6 @@
 from django.db.models import TextChoices
-from django.utils.translation import gettext_lazy as _
 
 
 class Privacy(TextChoices):
-    PRIVATE = "private", _("Private")
-    PUBLIC = "public", _("Public")
+    PRIVATE = "private", "Private"
+    PUBLIC = "public", "Public"

--- a/cms/release_calendar/enums.py
+++ b/cms/release_calendar/enums.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 
 
 class ReleaseStatus(models.TextChoices):
@@ -7,10 +6,10 @@ class ReleaseStatus(models.TextChoices):
     Note that both Provisional and Confirmed fall under "Upcoming" on the Release Calendar listing.
     """
 
-    PROVISIONAL = "PROVISIONAL", _("Provisional")
-    CONFIRMED = "CONFIRMED", _("Confirmed")
-    CANCELLED = "CANCELLED", _("Cancelled")
-    PUBLISHED = "PUBLISHED", _("Published")
+    PROVISIONAL = "PROVISIONAL", "Provisional"
+    CONFIRMED = "CONFIRMED", "Confirmed"
+    CANCELLED = "CANCELLED", "Cancelled"
+    PUBLISHED = "PUBLISHED", "Published"
 
 
 NON_PROVISIONAL_STATUSES = [ReleaseStatus.CONFIRMED, ReleaseStatus.PUBLISHED, ReleaseStatus.CANCELLED]

--- a/cms/release_calendar/forms.py
+++ b/cms/release_calendar/forms.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Any
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext as _
 from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.models import Locale
 
@@ -29,12 +28,12 @@ class ReleaseCalendarPageAdminForm(WagtailAdminPageForm):
         status = cleaned_data.get("status")
 
         if status == ReleaseStatus.CANCELLED and not cleaned_data.get("notice"):
-            raise ValidationError({"notice": _("The notice field is required when the release is cancelled")})
+            raise ValidationError({"notice": "The notice field is required when the release is cancelled"})
 
         if status in [ReleaseStatus.CONFIRMED, ReleaseStatus.PUBLISHED]:
             if not cleaned_data.get("release_date"):
                 raise ValidationError(
-                    {"release_date": _("The release date field is required when the release is confirmed")}
+                    {"release_date": "The release date field is required when the release is confirmed"}
                 )
 
             if (
@@ -45,7 +44,7 @@ class ReleaseCalendarPageAdminForm(WagtailAdminPageForm):
                 # A change in the release date requires updating changes_to_release_date
                 raise ValidationError(
                     {
-                        "changes_to_release_date": _(
+                        "changes_to_release_date": (
                             "If a confirmed calendar entry needs to be rescheduled, "
                             "the 'Changes to release date' field must be filled out."
                         )
@@ -57,15 +56,15 @@ class ReleaseCalendarPageAdminForm(WagtailAdminPageForm):
             and cleaned_data.get("next_release_date")
             and cleaned_data["release_date"] >= cleaned_data["next_release_date"]
         ):
-            raise ValidationError({"next_release_date": _("The next release date must be after the release date.")})
+            raise ValidationError({"next_release_date": "The next release date must be after the release date."})
 
         release_date_text = cleaned_data.get("release_date_text")
         if cleaned_data.get("release_date") and release_date_text:
-            error = _("Please enter the release date or the release date text, not both.")
+            error = "Please enter the release date or the release date text, not both."
             raise ValidationError({"release_date": error, "release_date_text": error})
 
         if cleaned_data.get("next_release_date") and cleaned_data.get("next_release_text"):
-            error = _("Please enter the next release date or the next release text, not both.")
+            error = "Please enter the next release date or the next release text, not both."
             raise ValidationError({"next_release_date": error, "next_release_text": error})
 
         # TODO: expand to validate for non-English locales when adding multi-language.
@@ -83,12 +82,12 @@ class ReleaseCalendarPageAdminForm(WagtailAdminPageForm):
             if len(parts) > 1:
                 date_to = datetime.strptime(parts[1], "%B %Y")
                 if date_from >= date_to:
-                    raise ValidationError({"release_date_text": _("The end month must be after the start month.")})
+                    raise ValidationError({"release_date_text": "The end month must be after the start month."})
 
         except ValueError:
             raise ValidationError(
                 {
-                    "release_date_text": _(
+                    "release_date_text": (
                         "The release date text must be in the 'Month YYYY' or 'Month YYYY to Month YYYY' format."
                     )
                 }

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -49,20 +49,20 @@ class ReleaseCalendarPage(BasePage):  # type: ignore[django-manager-missing]
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
 
     release_date = models.DateTimeField(
-        blank=True, null=True, help_text=_("Required once the release has been confirmed.")
+        blank=True, null=True, help_text="Required once the release has been confirmed."
     )
     release_date_text = models.CharField(
-        max_length=50, blank=True, help_text=_("Format: 'Month YYYY', or 'Month YYYY to Month YYYY'.")
+        max_length=50, blank=True, help_text="Format: 'Month YYYY', or 'Month YYYY to Month YYYY'."
     )
     next_release_date = models.DateTimeField(blank=True, null=True)
     next_release_text = models.CharField(
-        max_length=255, blank=True, help_text=_("Formats: 'DD Month YYYY Time' or 'To be confirmed'.")
+        max_length=255, blank=True, help_text="Formats: 'DD Month YYYY Time' or 'To be confirmed'."
     )
 
     notice = RichTextField(
         features=settings.RICH_TEXT_BASIC,
         blank=True,
-        help_text=_(
+        help_text=(
             "Used for data change or cancellation notices. The notice is required when the release is cancelled"
         ),
     )
@@ -79,23 +79,23 @@ class ReleaseCalendarPage(BasePage):  # type: ignore[django-manager-missing]
 
     # Fields: about the data
     is_accredited = models.BooleanField(
-        _("Accredited Official Statistics"),
+        "Accredited Official Statistics",
         default=False,
-        help_text=_(
+        help_text=(
             "If ticked, will display an information block about the data being accredited official statistics "
             "and include the accredited logo."
         ),
     )
     is_census = models.BooleanField(
-        _("Census"),
+        "Census",
         default=False,
-        help_text=_("If ticked, will display an information block about the data being related to the Census."),
+        help_text="If ticked, will display an information block about the data being related to the Census.",
     )
 
     changes_to_release_date = StreamField(
         ReleaseCalendarChangesStoryBlock(),
         blank=True,
-        help_text=_("Required if making changes to confirmed release dates."),
+        help_text="Required if making changes to confirmed release dates.",
     )
     pre_release_access = StreamField(ReleaseCalendarPreReleaseAccessStoryBlock(), blank=True)
     related_links = StreamField(ReleaseCalendarRelatedLinksStoryBlock(), blank=True)
@@ -108,20 +108,20 @@ class ReleaseCalendarPage(BasePage):  # type: ignore[django-manager-missing]
                 FieldRowPanel(
                     [
                         "release_date",
-                        FieldPanel("release_date_text", heading=_("Or, release date text")),
+                        FieldPanel("release_date_text", heading="Or, release date text"),
                     ],
                     heading="",
                 ),
                 FieldRowPanel(
                     [
                         "next_release_date",
-                        FieldPanel("next_release_text", heading=_("Or, next release text")),
+                        FieldPanel("next_release_text", heading="Or, next release text"),
                     ],
                     heading="",
                 ),
                 "notice",
             ],
-            heading=_("Metadata"),
+            heading="Metadata",
             icon="cog",
         ),
         "summary",
@@ -132,7 +132,7 @@ class ReleaseCalendarPage(BasePage):  # type: ignore[django-manager-missing]
                 "is_accredited",
                 "is_census",
             ],
-            heading=_("About the data"),
+            heading="About the data",
             icon="info-circle",
         ),
         FieldPanel("changes_to_release_date", icon="comment"),

--- a/cms/release_calendar/viewsets.py
+++ b/cms/release_calendar/viewsets.py
@@ -1,6 +1,5 @@
 from django.db.models import QuerySet
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.ui.tables import Column, DateColumn
 from wagtail.admin.views.generic.chooser import ChooseResultsView, ChooseView
 from wagtail.admin.viewsets.chooser import ChooserViewSet
@@ -20,10 +19,10 @@ class FutureReleaseCalendarMixin:
         return [
             self.title_column,  # type: ignore[attr-defined]
             Column("release_date"),
-            Column("release_status", label=_("Status"), accessor="get_status_display"),
+            Column("release_status", label="Status", accessor="get_status_display"),
             DateColumn(
                 "updated",
-                label=_("Last Updated"),
+                label="Last Updated",
                 width="12%",
                 accessor="latest_revision_created_at",
             ),
@@ -43,9 +42,9 @@ class FutureReleaseCalendarPageChooserViewSet(ChooserViewSet):
     register_widget = False
 
     icon = "calendar-check"
-    choose_one_text = _("Choose Release Calendar page")
-    choose_another_text = _("Choose another Release Calendar page")
-    edit_item_text = _("Edit Release Calendar page")
+    choose_one_text = "Choose Release Calendar page"
+    choose_another_text = "Choose another Release Calendar page"
+    edit_item_text = "Edit Release Calendar page"
 
 
 release_calendar_chooser_viewset = FutureReleaseCalendarPageChooserViewSet("release_calendar_chooser")

--- a/cms/release_calendar/wagtail_hooks.py
+++ b/cms/release_calendar/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
 from django.shortcuts import redirect
-from django.utils.translation import gettext as _
 from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.utils import get_valid_next_url_from_request
@@ -20,13 +19,11 @@ if TYPE_CHECKING:
 def before_delete_page(request: "HttpRequest", page: "Page") -> Optional["HttpResponseRedirect"]:
     """Block release calendar page deletion and show a message."""
     if page.specific_class == ReleaseCalendarPage:
-        messages.warning(
-            request, _("Release Calendar pages cannot be deleted. You can mark them as cancelled instead.")
-        )
+        messages.warning(request, "Release Calendar pages cannot be deleted. You can mark them as cancelled instead.")
         return redirect("wagtailadmin_pages:edit", page.pk)
 
     if page.specific_class == ReleaseCalendarIndex:
-        messages.warning(request, _("The Release Calendar index cannot be deleted."))
+        messages.warning(request, "The Release Calendar index cannot be deleted.")
 
         # redirect to a valid next url (passed via the 'next' query parameter)
         if next_url := get_valid_next_url_from_request(request):

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-from django.utils.translation import gettext_lazy as _
 from django_jinja.builtins import DEFAULT_EXTENSIONS
 
 env = os.environ.copy()
@@ -316,9 +315,9 @@ WAGTAIL_I18N_ENABLED = False
 
 LANGUAGE_CODE = "en-gb"
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
-    ("en-gb", _("English")),
-    ("cy", _("Welsh")),
-    ("uk", _("Ukrainian")),
+    ("en-gb", "English"),
+    ("cy", "Welsh"),
+    ("uk", "Ukrainian"),
 ]
 
 LOCALE_PATHS = [PROJECT_DIR / "locale"]

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
+from django.utils.translation import gettext_lazy as _
 from django_jinja.builtins import DEFAULT_EXTENSIONS
 
 env = os.environ.copy()
@@ -315,9 +316,9 @@ WAGTAIL_I18N_ENABLED = False
 
 LANGUAGE_CODE = "en-gb"
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
-    ("en-gb", "English"),
-    ("cy", "Welsh"),
-    ("uk", "Ukrainian"),
+    ("en-gb", _("English")),
+    ("cy", _("Welsh")),
+    ("uk", _("Ukrainian")),
 ]
 
 LOCALE_PATHS = [PROJECT_DIR / "locale"]

--- a/cms/standard_pages/models.py
+++ b/cms/standard_pages/models.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import InlinePanel
 from wagtail.fields import RichTextField
 from wagtail.search import index
@@ -53,7 +52,7 @@ class IndexPage(BasePage):  # type: ignore[django-manager-missing]
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     featured_items = StreamField(
         [("featured_item", RelatedContentBlock())],
-        help_text=_("Leave blank to automatically populate with child pages. Only published pages will be displayed."),
+        help_text="Leave blank to automatically populate with child pages. Only published pages will be displayed.",
         blank=True,
     )
 

--- a/cms/taxonomy/mixins.py
+++ b/cms/taxonomy/mixins.py
@@ -3,7 +3,6 @@ from typing import ClassVar
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultipleChooserPanel, Panel
 
 from cms.taxonomy.models import Topic
@@ -28,7 +27,7 @@ class ExclusiveTaxonomyMixin(models.Model):
         super().clean()
 
         if not self.topic_id:
-            raise ValidationError({"topic": _("A topic is required.")})
+            raise ValidationError({"topic": "A topic is required."})
 
         if not settings.ENFORCE_EXCLUSIVE_TAXONOMY:
             return
@@ -45,14 +44,14 @@ class ExclusiveTaxonomyMixin(models.Model):
                 qs = qs.exclude(pk=self.pk)
 
             if qs.exists():
-                raise ValidationError({"topic": _("This topic is already linked to another theme or topic page.")})
+                raise ValidationError({"topic": "This topic is already linked to another theme or topic page."})
 
 
 class GenericTaxonomyMixin(models.Model):
     """Generic Taxonomy mixin allows pages to be tagged with one or more topics non-exclusively."""
 
     taxonomy_panels: ClassVar[list["Panel"]] = [
-        MultipleChooserPanel("topics", label=_("Topics"), chooser_field_name=_("topic")),
+        MultipleChooserPanel("topics", label="Topics", chooser_field_name="topic"),
     ]
 
     class Meta:

--- a/cms/taxonomy/viewsets.py
+++ b/cms/taxonomy/viewsets.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.db.models import QuerySet
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.views.generic.chooser import ChooseResultsView, ChooseView
 from wagtail.admin.viewsets.chooser import ChooserViewSet
@@ -18,7 +17,7 @@ class TopicChooseViewMixin:
     def columns(self) -> list[Column]:
         return [
             *getattr(super(), "columns", []),
-            Column("parent_topics", label=_("Parent Topics"), accessor="display_parent_topics"),
+            Column("parent_topics", label="Parent Topics", accessor="display_parent_topics"),
         ]
 
 
@@ -32,8 +31,8 @@ class TopicChooserViewSet(ChooserViewSet):
     model = Topic
     icon = "tag"
 
-    choose_one_text = _("Choose a topic")
-    choose_another_text = _("Choose a different topic")
+    choose_one_text = "Choose a topic"
+    choose_another_text = "Choose a different topic"
 
     choose_view_class = TopicChooseView
     choose_results_view_class = TopicChooseResultsView

--- a/cms/themes/models.py
+++ b/cms/themes/models.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, ClassVar
 
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 from wagtail.fields import RichTextField
 
 from cms.core.models import BasePage
@@ -17,8 +16,8 @@ class ThemePage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
     template = "templates/pages/theme_page.html"
     parent_page_types: ClassVar[list[str]] = ["home.HomePage", "ThemePage"]
     subpage_types: ClassVar[list[str]] = ["ThemePage", "topics.TopicPage"]
-    page_description = _("A theme page, such as 'Economy'.")
-    label = _("Theme")
+    page_description = "A theme page, such as 'Economy'."
+    label = "Theme"
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
 

--- a/cms/topics/blocks.py
+++ b/cms/topics/blocks.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import CharBlock, PageChooserBlock, StreamBlock, StructBlock, URLBlock
 from wagtail.images.blocks import ImageChooserBlock
 
@@ -10,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class ExploreMoreExternalLinkBlock(StructBlock):
-    url = URLBlock(label=_("External URL"))
+    url = URLBlock(label="External URL")
     title = CharBlock()
     description = CharBlock()
     thumbnail = ImageChooserBlock()
@@ -36,15 +35,15 @@ class ExploreMoreExternalLinkBlock(StructBlock):
 
 class ExploreMoreInternalLinkBlock(StructBlock):
     page = PageChooserBlock()
-    title = CharBlock(required=False, help_text=_("Use to override the chosen page title."))
+    title = CharBlock(required=False, help_text="Use to override the chosen page title.")
     description = CharBlock(
         required=False,
-        help_text=_(
+        help_text=(
             "Use to override the chosen page description. "
             "By default, we will attempt to use the listing summary or the summary field."
         ),
     )
-    thumbnail = ImageChooserBlock(required=False, help_text=_("Use to override the chosen page listing image."))
+    thumbnail = ImageChooserBlock(required=False, help_text="Use to override the chosen page listing image.")
 
     class Meta:
         icon = "doc-empty-inverse"

--- a/cms/topics/models.py
+++ b/cms/topics/models.py
@@ -72,7 +72,7 @@ class TopicPage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
     parent_page_types: ClassVar[list[str]] = ["themes.ThemePage"]
     subpage_types: ClassVar[list[str]] = ["articles.ArticleSeriesPage", "methodology.MethodologyPage"]
     page_description = "A specific topic page. e.g. 'Public sector finance' or 'Inflation and price indices'."
-    label = "Topic"
+    label = _("Topic")
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     featured_series = models.ForeignKey(

--- a/cms/topics/models.py
+++ b/cms/topics/models.py
@@ -71,8 +71,8 @@ class TopicPage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
     template = "templates/pages/topic_page.html"
     parent_page_types: ClassVar[list[str]] = ["themes.ThemePage"]
     subpage_types: ClassVar[list[str]] = ["articles.ArticleSeriesPage", "methodology.MethodologyPage"]
-    page_description = _("A specific topic page. e.g. 'Public sector finance' or 'Inflation and price indices'.")
-    label = _("Topic")
+    page_description = "A specific topic page. e.g. 'Public sector finance' or 'Inflation and price indices'."
+    label = "Topic"
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     featured_series = models.ForeignKey(
@@ -89,13 +89,13 @@ class TopicPage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
         "summary",
         FieldPanel(
             "featured_series",
-            heading=_("Featured"),
+            heading="Featured",
             widget=FeaturedSeriesPageChooserWidget(linked_fields={"topic_page_id": "#id_topic_page_id"}),
         ),
         InlinePanel(
             "related_articles",
-            heading=_("Highlighted articles"),
-            help_text=_(
+            heading="Highlighted articles",
+            help_text=(
                 f"Choose up to {MAX_ITEMS_PER_SECTION} articles to highlight. "
                 "The 'Related articles' section will be topped up automatically."
             ),
@@ -103,14 +103,14 @@ class TopicPage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
         ),
         InlinePanel(
             "related_methodologies",
-            heading=_("Highlighted methods and quality information"),
-            help_text=_(
+            heading="Highlighted methods and quality information",
+            help_text=(
                 f"Choose up to {MAX_ITEMS_PER_SECTION} methodologies to highlight. "
                 "The 'Methods and quality information' section will be topped up automatically."
             ),
             max_num=MAX_ITEMS_PER_SECTION,
         ),
-        FieldPanel("explore_more", heading=_("Explore more")),
+        FieldPanel("explore_more", heading="Explore more"),
     ]
 
     search_fields: ClassVar[list[index.BaseField]] = [*BasePage.search_fields, index.SearchField("summary")]

--- a/cms/topics/models.py
+++ b/cms/topics/models.py
@@ -72,7 +72,7 @@ class TopicPage(ExclusiveTaxonomyMixin, BasePage):  # type: ignore[django-manage
     parent_page_types: ClassVar[list[str]] = ["themes.ThemePage"]
     subpage_types: ClassVar[list[str]] = ["articles.ArticleSeriesPage", "methodology.MethodologyPage"]
     page_description = "A specific topic page. e.g. 'Public sector finance' or 'Inflation and price indices'."
-    label = _("Topic")
+    label = _("Topic")  # type: ignore[assignment]
 
     summary = RichTextField(features=settings.RICH_TEXT_BASIC)
     featured_series = models.ForeignKey(

--- a/cms/topics/tests/test_viewsets.py
+++ b/cms/topics/tests/test_viewsets.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
 from wagtail.test.utils import WagtailTestUtils
 
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
@@ -71,11 +70,9 @@ class FeaturedSeriesPageChooserViewSetTest(WagtailTestUtils, TestCase):
     def test_featured_series_viewset_configuration(self):
         self.assertFalse(featured_series_page_chooser_viewset.register_widget)
         self.assertEqual(featured_series_page_chooser_viewset.model, ArticleSeriesPageFactory._meta.model)
-        self.assertEqual(featured_series_page_chooser_viewset.choose_one_text, _("Choose Article Series page"))
-        self.assertEqual(
-            featured_series_page_chooser_viewset.choose_another_text, _("Choose another Article Series page")
-        )
-        self.assertEqual(featured_series_page_chooser_viewset.edit_item_text, _("Edit Article Series page"))
+        self.assertEqual(featured_series_page_chooser_viewset.choose_one_text, "Choose Article Series page")
+        self.assertEqual(featured_series_page_chooser_viewset.choose_another_text, "Choose another Article Series page")
+        self.assertEqual(featured_series_page_chooser_viewset.edit_item_text, "Edit Article Series page")
 
 
 class HighlightedPageChooserViewSetTest(WagtailTestUtils, TestCase):
@@ -197,17 +194,17 @@ class HighlightedPageChooserViewSetTest(WagtailTestUtils, TestCase):
     def test_highlighted_article_viewset_configuration(self):
         self.assertFalse(highlighted_article_page_chooser_viewset.register_widget)
         self.assertEqual(highlighted_article_page_chooser_viewset.model, StatisticalArticlePageFactory._meta.model)
-        self.assertEqual(highlighted_article_page_chooser_viewset.choose_one_text, _("Choose Article page"))
-        self.assertEqual(highlighted_article_page_chooser_viewset.choose_another_text, _("Choose another Article page"))
-        self.assertEqual(highlighted_article_page_chooser_viewset.edit_item_text, _("Edit Article page"))
+        self.assertEqual(highlighted_article_page_chooser_viewset.choose_one_text, "Choose Article page")
+        self.assertEqual(highlighted_article_page_chooser_viewset.choose_another_text, "Choose another Article page")
+        self.assertEqual(highlighted_article_page_chooser_viewset.edit_item_text, "Edit Article page")
         self.assertIn("topic_page_id", highlighted_article_page_chooser_viewset.preserve_url_parameters)
 
     def test_highlighted_methodology_viewset_configuration(self):
         self.assertFalse(highlighted_methodology_page_chooser_viewset.register_widget)
         self.assertEqual(highlighted_methodology_page_chooser_viewset.model, MethodologyPageFactory._meta.model)
-        self.assertEqual(highlighted_methodology_page_chooser_viewset.choose_one_text, _("Choose Methodology page"))
+        self.assertEqual(highlighted_methodology_page_chooser_viewset.choose_one_text, "Choose Methodology page")
         self.assertEqual(
-            highlighted_methodology_page_chooser_viewset.choose_another_text, _("Choose another Methodology page")
+            highlighted_methodology_page_chooser_viewset.choose_another_text, "Choose another Methodology page"
         )
-        self.assertEqual(highlighted_methodology_page_chooser_viewset.edit_item_text, _("Edit Methodology page"))
+        self.assertEqual(highlighted_methodology_page_chooser_viewset.edit_item_text, "Edit Methodology page")
         self.assertIn("topic_page_id", highlighted_methodology_page_chooser_viewset.preserve_url_parameters)

--- a/cms/topics/viewsets.py
+++ b/cms/topics/viewsets.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, ClassVar
 
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.ui.tables import Column, DateColumn
 from wagtail.admin.ui.tables.pages import PageStatusColumn
 from wagtail.admin.views.generic.chooser import ChooseResultsView, ChooseView
@@ -25,14 +24,14 @@ class FeaturedSeriesPageChooseViewMixin:
     def columns(self) -> list["Column"]:
         return [
             self.title_column,  # type: ignore[attr-defined]
-            Column("parent", label=_("Topic"), accessor="get_parent"),
+            Column("parent", label="Topic", accessor="get_parent"),
             DateColumn(
                 "updated",
-                label=_("Updated"),
+                label="Updated",
                 width="12%",
                 accessor="latest_revision_created_at",
             ),
-            PageStatusColumn("status", label=_("Status"), width="12%"),
+            PageStatusColumn("status", label="Status", width="12%"),
         ]
 
 
@@ -47,9 +46,9 @@ class FeaturedSeriesPageChooserViewSet(ChooserViewSet):
     choose_view_class = FeaturedSeriesPageChooseView
     choose_results_view_class = FeaturedSeriesPageChooseResultsView
     register_widget = False
-    choose_one_text = _("Choose Article Series page")
-    choose_another_text = _("Choose another Article Series page")
-    edit_item_text = _("Edit Article Series page")
+    choose_one_text = "Choose Article Series page"
+    choose_another_text = "Choose another Article Series page"
+    edit_item_text = "Edit Article Series page"
 
 
 class HighlightedChildPageChooseViewMixin:
@@ -82,11 +81,11 @@ class HighlightedChildPageChooseViewMixin:
             title_column,
             Column(
                 "release_date",
-                label=_("Release date"),
+                label="Release date",
                 width="12%",
                 accessor="release_date",
             ),
-            PageStatusColumn("status", label=_("Status"), width="12%"),
+            PageStatusColumn("status", label="Status", width="12%"),
         ]
 
 
@@ -106,16 +105,16 @@ class BaseHighlightedChildrenViewSet(ChooserViewSet):
 
 class HighlightedArticlePageChooserViewSet(BaseHighlightedChildrenViewSet):
     model = StatisticalArticlePage
-    choose_one_text = _("Choose Article page")
-    choose_another_text = _("Choose another Article page")
-    edit_item_text = _("Edit Article page")
+    choose_one_text = "Choose Article page"
+    choose_another_text = "Choose another Article page"
+    edit_item_text = "Edit Article page"
 
 
 class HighlightedMethodologyPageChooserViewSet(BaseHighlightedChildrenViewSet):
     model = MethodologyPage
-    choose_one_text = _("Choose Methodology page")
-    choose_another_text = _("Choose another Methodology page")
-    edit_item_text = _("Edit Methodology page")
+    choose_one_text = "Choose Methodology page"
+    choose_another_text = "Choose another Methodology page"
+    edit_item_text = "Edit Methodology page"
 
 
 featured_series_page_chooser_viewset = FeaturedSeriesPageChooserViewSet("topic_featured_series_page_chooser")


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-387. The goal is to *not* use `gettext` and `gettext_lazy` for text which appears in the admin panel. However, public user facing content *should* be translatable.

### How to review

* Look at changed files and ensure that no unnecessary changes have been made

### Follow-up Actions

N/A
