### PR TITLE
Allow assigning users to teams is team management is enabled

### DIFF
--- a/cms/teams/admin_forms.py
+++ b/cms/teams/admin_forms.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from django import forms
+from django.conf import settings
+from wagtail.admin.forms import WagtailAdminModelForm
+
+from cms.teams.models import Team
+from cms.users.models import User
+
+
+class TeamAdminForm(WagtailAdminModelForm):
+    users = forms.ModelMultipleChoiceField(
+        queryset=User.objects.all(), widget=forms.CheckboxSelectMultiple(), required=False
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        if self.instance.pk:
+            self.fields["users"].initial = self.instance.users.all()
+
+    def save(self, commit: bool = True) -> Team:
+        instance: Team = super().save(commit=False)
+        if commit:
+            instance.save()
+            instance.users.set(self.cleaned_data["users"])
+        return instance
+
+    class Meta(WagtailAdminModelForm.Meta):
+        model = Team
+        fields = ["name", "identifier", "users"] if settings.ALLOW_TEAM_MANAGEMENT else ["name"]

--- a/cms/teams/viewsets.py
+++ b/cms/teams/viewsets.py
@@ -8,6 +8,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.permission_policies import ModelPermissionPolicy
 
+from .admin_forms import TeamAdminForm
 from .models import Team
 
 if TYPE_CHECKING:
@@ -51,11 +52,8 @@ class TeamsViewSet(ModelViewSet):
         "users",
     ]
 
-    @property
-    def form_fields(self) -> list[str]:
-        # note: when ALLOW_TEAM_MANAGEMENT is removed, convert this to an actual property
-        # form_fields: ClassVar[list[str]] = ["name"]
-        return ["name", "identifier"] if settings.ALLOW_TEAM_MANAGEMENT else ["name"]
+    def get_form_class(self, for_update: bool = False) -> type[TeamAdminForm]:
+        return TeamAdminForm
 
     @property
     def permission_policy(self) -> ViewOnlyModelPermissionPolicy:


### PR DESCRIPTION
### What is the context of this PR?

This will enabled better testing of the end-to-end workflows.
Builds on #120 and #132

<details><summary>Screenshot</summary>

![Screenshot 2025-04-03 at 17 14 08](https://github.com/user-attachments/assets/61e1ab6e-c2b9-4d8c-8c49-ae764fecb377)

</details> 

### How to review

- set `ALLOW_TEAM_MANAGEMENT = True` in `cms/settings/local.py`
- as a superuser go to preview teams, add or edit an existing one

### Follow-up Actions
N/A
