### PR TITLE
Update CMS configuration options for line charts

### DIFF
--- a/cms/datavis/apps.py
+++ b/cms/datavis/apps.py
@@ -5,5 +5,5 @@ class DataVisConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "cms.datavis"
 
-    def ready(self):
+    def ready(self) -> None:
         from . import checks  # noqa pylint: disable=import-outside-toplevel,unused-import

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -20,6 +20,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
     title = blocks.CharBlock()
     subtitle = blocks.CharBlock()
     table = SimpleTableBlock(label="Data table")
+    source = blocks.CharBlock()
 
     highcharts_chart_type: ClassVar[str]
 

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -143,7 +143,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
             "categories": [r[0] for r in rows],
         }
 
-        # Only add axis title if supported and provided
+        # Only add x-axis title if supported and provided, as the Highcharts
+        # x-axis title default value is undefined. See
+        # https://api.highcharts.com/highcharts/xAxis.title.text
         if (title := attrs.get("title")) and getattr(self, "supports_x_axis_title", False):
             config["title"] = {
                 "text": title,
@@ -166,8 +168,11 @@ class BaseVisualisationBlock(blocks.StructBlock):
             # "reversed": self.y_reversed,
         }
 
-        # Only add axis title if supported and provided
-        if (title := attrs.get("title")) and getattr(self, "supports_y_axis_title", False):
+        # Only add y-axis title if supported
+        if getattr(self, "supports_y_axis_title", False):
+            # Highcharts y-axis title default value is "Values". Set to undefined to
+            # disable. See https://api.highcharts.com/highcharts/yAxis.title.text
+            title = attrs["title"] or None
             config["title"] = {
                 "text": title,
             }

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -136,7 +136,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
         attrs: "StructValue",
         rows: Sequence[list[str | int | float]],
     ) -> dict[str, Any]:
-        config = {
+        config: dict[str, Any] = {
             "type": "linear",
             "categories": [r[0] for r in rows],
         }

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -122,7 +122,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
         rows: list[list[str | int | float]] = value["table"].rows
 
         return {
-            "type": self.highcharts_chart_type,  # TODO: remove this once we upgrade to the latest version of the DS
+            "chart": {
+                "type": self.highcharts_chart_type,  # TODO: remove this once we upgrade to the latest version of the DS
+            },
             "legend": {
                 "enabled": value.get("show_legend", True),
             },

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -4,19 +4,31 @@ from cms.datavis.blocks.base import BaseVisualisationBlock
 
 
 class LineChartBlock(BaseVisualisationBlock):
-    highcharts_chart_type: ClassVar[str] = "line"
+    highcharts_chart_type = "line"
+    supports_stacked_layout = False
+    supports_x_axis_title = True
+    supports_y_axis_title = True
+    supports_data_labels = False
     supports_markers = True
-    x_axis_type = "linear"
+    extra_item_attributes: ClassVar = {
+        "connectNulls": True,
+    }
 
-    # Remove the use_stacked_layout field from the block
+    # Remove unsupported features
     use_stacked_layout = None
+    show_data_labels = None
 
     class Meta:
         icon = "chart-line"
 
 
 class BarChartBlock(BaseVisualisationBlock):
-    highcharts_chart_type: ClassVar[str] = "bar"
+    highcharts_chart_type = "bar"
+    supports_stacked_layout = True
+    supports_x_axis_title = False
+    supports_y_axis_title = True
+    supports_data_labels = True
+    supports_markers = False
 
     class Meta:
         icon = "chart-bar"
@@ -24,7 +36,12 @@ class BarChartBlock(BaseVisualisationBlock):
 
 # FIXME eventually combine bar/column charts into one type
 class ColumnChartBlock(BaseVisualisationBlock):
-    highcharts_chart_type: ClassVar[str] = "column"
+    highcharts_chart_type = "column"
+    supports_stacked_layout = True
+    supports_x_axis_title = True
+    supports_y_axis_title = True
+    supports_data_labels = False
+    supports_markers = False
 
     class Meta:
         icon = "chart-column"

--- a/cms/datavis/blocks/table.py
+++ b/cms/datavis/blocks/table.py
@@ -12,15 +12,23 @@ from wagtailtables.blocks import TableAdapter, TableBlock
 
 from cms.datavis.utils import numberfy
 
+RowType = list[str | float | int]
+TableDataType = Sequence[RowType]
+
 
 class SimpleTableStructValue(StructValue):
     @cached_property
-    def _data(self) -> Sequence[Sequence[str | int | float]]:
+    def _data(self) -> TableDataType:
         """Cache the extracted and processed table data."""
         if not self.get("table_data"):
             return []
         # Decoding the json string value
-        data: list[list[str | float | int]] = json.loads(self.get("table_data"))["data"]
+        table_data: dict[str, TableDataType] = json.loads(self.get("table_data"))
+        try:
+            data: TableDataType = table_data["data"]
+        except TypeError:
+            # When the table is empty, the json is not a dict
+            return []
 
         # Convert valid number strings to ints/floats
         if len(data) > 1:
@@ -31,17 +39,17 @@ class SimpleTableStructValue(StructValue):
         return data
 
     @cached_property
-    def headers(self) -> Sequence[str | int | float]:
+    def headers(self) -> RowType:
         if not self._data:
             return []
-        headers: Sequence[str | int | float] = self._data[0]
+        headers: RowType = self._data[0]
         return headers
 
     @cached_property
-    def rows(self) -> Sequence[Sequence[str | int | float]]:
+    def rows(self) -> TableDataType:
         if not self._data:
             return []
-        rows: Sequence[Sequence[str | int | float]] = self._data[1:]
+        rows: TableDataType = self._data[1:]
         return rows
 
 

--- a/cms/datavis/blocks/utils.py
+++ b/cms/datavis/blocks/utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.forms import TextInput
 from wagtail import blocks
 
@@ -8,7 +10,7 @@ class TextInputIntegerBlock(blocks.IntegerBlock):
     See https://design-system.service.gov.uk/components/text-input/#numbers
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.field.widget = TextInput(attrs={"inputmode": "numeric"})
 
@@ -19,7 +21,7 @@ class TextInputFloatBlock(blocks.FloatBlock):
     See https://design-system.service.gov.uk/components/text-input/#asking-for-decimal-numbers
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         # NB inputmode is intentionally not "decimal" as per the guidance linked
         # in the docstring above

--- a/cms/datavis/checks.py
+++ b/cms/datavis/checks.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.apps import apps
 from django.core.checks import CheckMessage, Error, register
+from wagtail import blocks
 from wagtail.models import Page
 
 from cms.core.fields import StreamField
@@ -35,7 +36,7 @@ def check_visualisation_blocks_mixin(*args: Any, **kwargs: Any) -> Iterator[Chec
                 )
 
 
-def _contains_visualisation_block(block):
+def _contains_visualisation_block(block: blocks.Block) -> bool:
     """Recursively check whether a block, or any descendant block, is an instance
     of BaseVisualisationBlock.
     """

--- a/cms/datavis/constants.py
+++ b/cms/datavis/constants.py
@@ -16,5 +16,5 @@ class MarkerStyle(TextChoices):
 
 
 class HighchartsTheme(TextChoices):
-    PRIMARY = "primary", _("Primary")
-    ALTERNATE = "alternate", _("Alternate")
+    PRIMARY = "primary", "Primary"
+    ALTERNATE = "alternate", "Alternate"

--- a/cms/datavis/tests/factories.py
+++ b/cms/datavis/tests/factories.py
@@ -1,0 +1,27 @@
+import json
+
+from factory import Factory
+
+from cms.datavis.blocks.table import TableDataType
+
+
+class TableDataFactory(Factory):
+    """Factory to create table data in the format expected by SimpleTableBlock."""
+
+    class Meta:
+        model = dict
+
+    table_data: TableDataType
+
+    @classmethod
+    def _create(cls, model_class, *args, table_data: TableDataType | None = None, **kwargs) -> dict[str, str]:
+        if table_data is None:
+            table_data = [
+                ["Header 1", "Header 2", "Header 3"],
+                ["Row 1, Column 1", "Row 1, Column 2", "Row 1, Column 3"],
+                ["Row 2, Column 1", "Row 2, Column 2", "Row 2, Column 3"],
+            ]
+
+        return {
+            "table_data": json.dumps({"data": table_data}),
+        }

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -1,0 +1,195 @@
+from typing import Any, ClassVar
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+from wagtail.blocks.struct_block import StructValue
+from wagtail.test.utils import WagtailTestUtils
+
+from cms.datavis.blocks.base import BaseVisualisationBlock
+from cms.datavis.blocks.charts import LineChartBlock
+from cms.datavis.tests.factories import TableDataFactory
+
+
+class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
+    block_type: ClassVar[type[BaseVisualisationBlock]]
+    raw_data: dict[str, Any]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.block = cls.block_type()
+
+    def setUp(self):
+        super().setUp()
+
+        self.raw_data = {
+            "title": "Test Chart",
+            "subtitle": "Test Subtitle",
+            "caption": "Test Caption",
+            "table": TableDataFactory(),
+            "theme": "primary",
+            "show_legend": True,
+            "show_data_labels": False,
+            "use_stacked_layout": False,
+            "show_markers": True,
+            "x_axis": {
+                "label": "",
+                "min": None,
+                "max": None,
+                "tick_interval": None,
+            },
+            "y_axis": {
+                "label": "",
+                "min": None,
+                "max": None,
+                "tick_interval": None,
+                "value_suffix": "",
+                "tooltip_suffix": "",
+            },
+            "annotations": [{"type": "point", "value": {"label": "Peak", "x_position": "2", "y_position": "140"}}],
+        }
+
+    def get_value(self, raw_data: dict[str, Any] | None = None):
+        if raw_data is None:
+            raw_data = self.raw_data
+        return self.block.to_python(raw_data)
+
+    def _test_generic_properties(self):
+        """Test attributes that are common to all chart blocks."""
+        value = self.get_value()
+        pairs = [
+            # `value` dict key, expected value
+            ("title", "Test Chart"),
+            ("subtitle", "Test Subtitle"),
+            ("caption", "Test Caption"),
+            ("theme", self.raw_data["theme"]),
+        ]
+        for key, expected in pairs:
+            with self.subTest(key=key):
+                self.assertEqual(expected, value[key])
+
+        with self.subTest("table"):
+            # Test the table_data in the table object is the same.
+            # We can't test the whole table object as it is a StructValue, and
+            # contains other fields to do with SimpleTable configuration.
+            self.assertEqual(self.raw_data["table"]["table_data"], value["table"]["table_data"])
+
+    def _test_context(self):
+        self.assertEqual(
+            self.block_type.highcharts_chart_type,
+            self.block.get_context(self.get_value())["highcharts_chart_type"],
+        )
+
+    def _test_get_component_config(self):
+        block_value = self.block.to_python(self.raw_data)
+        config = self.block.get_component_config(block_value)
+
+        # Test basic structure
+        self.assertIn("legend", config)
+        self.assertIn("xAxis", config)
+        self.assertIn("yAxis", config)
+        self.assertIn("series", config)
+
+
+class LineChartBlockTestCase(BaseChartBlockTestCase):
+    block_type = LineChartBlock
+
+    def setUp(self):
+        super().setUp()
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Height", "Weight"],
+                ["Jan", "100", "50"],
+                ["Feb", "120", "55"],
+                ["Mar", "140", "60"],
+            ]
+        )
+
+    def test_generic_properties(self):
+        self._test_generic_properties()
+
+    def test_context(self):
+        self._test_context()
+
+    def test_get_component_config(self):
+        self._test_get_component_config()
+
+    def test_highcharts_chart_type(self):
+        context = self.block.get_context(self.get_value())
+        self.assertEqual("line", context["highcharts_chart_type"])
+
+    def test_validating_data(self):
+        """Test that the data we're using for these unit tests is good."""
+        value = self.get_value()
+        self.assertIsInstance(value, StructValue)
+        try:
+            self.block.clean(value)
+        except ValidationError as e:
+            self.fail(f"ValidationError raised: {e}")
+
+    def test_invalid_data(self):
+        """Validate that these tests can detect invalid data."""
+        invalid_data = self.raw_data.copy()
+        invalid_data["title"] = ""  # Required field
+        value = self.get_value(invalid_data)
+        with self.assertRaises(ValidationError, msg="Expected ValidationError for missing title"):
+            self.block.clean(value)
+
+    def test_get_series_data(self):
+        """Test that we identify two separate series in the data."""
+        block_value = self.block.to_python(self.raw_data)
+        series = self.block.get_series_data(block_value, block_value["table"].headers, block_value["table"].rows)
+        self.assertEqual(len(series), 2)
+        self.assertEqual(series[0]["name"], "Height")
+        self.assertEqual(series[0]["data"], [100, 120, 140])
+        self.assertEqual(series[1]["name"], "Weight")
+        self.assertEqual(series[1]["data"], [50, 55, 60])
+
+    def test_editable_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = "Editable X-axis Title"
+        value = self.get_value()
+        self.assertEqual("Editable X-axis Title", value["x_axis"]["title"])
+
+    def test_blank_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = ""
+        value = self.get_value()
+        self.assertEqual("", value["x_axis"]["title"])
+
+    def test_no_show_data_labels_option(self):
+        """Test that this option is not present for line charts."""
+        with self.subTest("base case"):
+            block_value = self.get_value()
+            series = self.block.get_series_data(block_value, block_value["table"].headers, block_value["table"].rows)
+            for item in series:
+                # Check that we're looking at the right object
+                self.assertIn("name", item)
+                self.assertIn("data", item)
+                self.assertNotIn("dataLabels", item)
+
+        with self.subTest("errantly try to force show_data_labels to True"):
+            # Test that even if we try to pass it in the form cleaned data, it is not in the output.
+            self.raw_data["show_data_labels"] = True
+            block_value = self.get_value()
+            series = self.block.get_series_data(block_value, block_value["table"].headers, block_value["table"].rows)
+            for item in series:
+                # Check that we're looking at the right object
+                self.assertIn("name", item)
+                self.assertIn("data", item)
+                self.assertNotIn("dataLabels", item)
+
+    def test_show_markers(self):
+        for show_markers in [False, True]:
+            with self.subTest(show_markers=show_markers):
+                self.raw_data["show_markers"] = show_markers
+                block_value = self.get_value()
+                series = self.block.get_series_data(
+                    block_value, block_value["table"].headers, block_value["table"].rows
+                )
+                for item in series:
+                    self.assertEqual({"enabled": show_markers}, item["marker"])
+
+    def test_connect_nulls(self):
+        block_value = self.get_value()
+        series = self.block.get_series_data(block_value, block_value["table"].headers, block_value["table"].rows)
+        for item in series:
+            self.assertEqual(True, item["connectNulls"])

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -33,13 +33,13 @@ class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
             "use_stacked_layout": False,
             "show_markers": True,
             "x_axis": {
-                "label": "",
+                "title": "",
                 "min": None,
                 "max": None,
                 "tick_interval": None,
             },
             "y_axis": {
-                "label": "",
+                "title": "",
                 "min": None,
                 "max": None,
                 "tick_interval": None,
@@ -155,7 +155,20 @@ class LineChartBlockTestCase(BaseChartBlockTestCase):
     def test_blank_x_axis_title(self):
         self.raw_data["x_axis"]["title"] = ""
         config = self.get_component_config()
-        self.assertEqual("", config["xAxis"]["title"]["text"])
+        # For line charts, editable X-axis title is supported, but the default
+        # value is `undefined`, so we expect it not to be set.
+        self.assertNotIn("title", config["xAxis"])
+
+    def test_editable_y_axis_title(self):
+        self.raw_data["y_axis"]["title"] = "Editable Y-axis Title"
+        config = self.get_component_config()
+        self.assertEqual({"text": "Editable Y-axis Title"}, config["yAxis"]["title"])
+
+    def test_blank_y_axis_title(self):
+        """A blank value should be converted to None."""
+        self.raw_data["y_axis"]["title"] = ""
+        config = self.get_component_config()
+        self.assertEqual({"text": None}, config["yAxis"]["title"])
 
     def test_no_show_data_labels_option(self):
         """Test that this option is not present for line charts."""

--- a/cms/datavis/tests/test_table_block.py
+++ b/cms/datavis/tests/test_table_block.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+
+from cms.datavis.blocks.table import SimpleTableBlock, SimpleTableStructValue, TableDataType
+from cms.datavis.tests.factories import TableDataFactory
+
+
+class SimpleTableBlockTestCase(TestCase):
+    table_data: TableDataType
+
+    def setUp(self):
+        self.block = SimpleTableBlock()
+        self.block_data = TableDataFactory(
+            table_data=[
+                ["Header 1", "Header 2", "Header 3"],
+                ["Row 1, Column 1", "Row 1, Column 2", "Row 1, Column 3"],
+                ["Row 2, Column 1", "Row 2, Column 2", "Row 2, Column 3"],
+            ]
+        )
+
+    def get_value(self):
+        return self.block.to_python(self.block_data)
+
+    def test_the_test_case(self):
+        # This is just to test that the test case is working, and has the
+        # correct data type
+        value = self.get_value()
+        self.assertIsInstance(value, SimpleTableStructValue)
+
+    def test_headers(self):
+        headers = self.get_value().headers
+        self.assertEqual(["Header 1", "Header 2", "Header 3"], headers)
+
+    def test_rows(self):
+        value = self.get_value()
+        rows = value.rows
+        self.assertEqual(
+            [
+                ["Row 1, Column 1", "Row 1, Column 2", "Row 1, Column 3"],
+                ["Row 2, Column 1", "Row 2, Column 2", "Row 2, Column 3"],
+            ],
+            rows,
+        )
+
+    def test_with_empty_table(self):
+        self.block_data = TableDataFactory(table_data=[])
+        value = self.get_value()
+
+        self.assertEqual([], value.headers)
+        self.assertEqual([], value.rows)
+
+    def test_numberfying_numeric_strings(self):
+        self.block_data = TableDataFactory(
+            table_data=[
+                ["Header 1", "Header 2", "Header 3"],
+                ["  1", "2  ", "3"],  # Intentional surrounding whitespace
+                ["4.0", " 05.07", "6.3"],  # Decimal numbers
+            ]
+        )
+        value = self.get_value()
+        self.assertEqual([1, 2, 3], value.rows[0])
+        self.assertEqual([4.0, 5.07, 6.3], value.rows[1])

--- a/cms/jinja2/templates/components/streamfield/datavis/base_highcharts_chart_block.html
+++ b/cms/jinja2/templates/components/streamfield/datavis/base_highcharts_chart_block.html
@@ -3,7 +3,7 @@
 {# fmt:off #}
 {{
     onsChart({
-        "chartType": value.highcharts_chart_type,
+        "chartType": highcharts_chart_type,
         "theme": value.theme,
         "title": value.title,
         "subtitle": value.subtitle,


### PR DESCRIPTION
### What is the context of this PR?

This change makes the editor UI for line charts more closely match the eventual configuration options.
It sets out a pattern for defining features per chart type, with blocks that subclass the base chart block.

Some options, which are related to configurable axes min/max and suffixes, will be dealt with as part of work on the axes, rather than this specific chart type.

### How to review

Check out the branch, and create an Information Page.
Add a Line Chart block, and enter some data.
Test that the fields in the ticket scope can be edited, and are reflected in the rendered chart.

Disregard that the rendered chart itself does not yet correspond to the spec. The updated version of the chart is in the Design System repo.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/dca0615c-d225-4dcc-833c-60da4becb421)


</p>
</details> 
