### PR TITLE
Set KafkaPublisher Retries to 5 To Fix NotLeaderForPartitionError

### DIFF
--- a/cms/search/publishers.py
+++ b/cms/search/publishers.py
@@ -132,6 +132,7 @@ class KafkaPublisher(BasePublisher):
             bootstrap_servers=[settings.KAFKA_SERVER],
             api_version=settings.KAFKA_API_VERSION,
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            retries=5,
         )
 
     @property

--- a/cms/search/tests/test_publishers.py
+++ b/cms/search/tests/test_publishers.py
@@ -367,6 +367,7 @@ class KafkaPublisherTests(TestCase):
             bootstrap_servers=["localhost:9092"],
             api_version=(3, 5, 1),
             value_serializer=ANY,  # or a lambda
+            retries=5,
         )
 
         self.assertEqual(publisher.created_or_updated_channel, "search-content-updated")  # pylint: disable=W0212


### PR DESCRIPTION
### What is the context of this PR?

This is a quick follow-up PR to the https://github.com/ONSdigital/dis-wagtail/pull/115 work. This PR address an issue where when the kafka tries to produce and send events for the first time, the topics `search-content-updated` and `search-content-deleted` doesn't exists in the Kafka  `broker` container.

This PR adds a retry of `5`. If the first attempt hits “NotLeaderForPartition,” it will retry. By attempt #2 or #3, the topic will have been created and will have a leader.

### How to review

- Spin up a fresh Kafka broker container locally by removing the existing broker containers.
- Run the search tests, and everything should be passing on the first go.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
