### PR TITLE
Add locale column to additional choosers

### DIFF
--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.test import TestCase
 from django.urls import reverse
 from wagtail.admin.panels import get_edit_handler
-from wagtail.models import Page
+from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.form_data import inline_formset, nested_form_data
 
@@ -408,6 +408,9 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         cls.bundle = BundleFactory()
 
         cls.page_draft = StatisticalArticlePageFactory(live=False, title="Article draft")
+        StatisticalArticlePageFactory(
+            live=False, title="Article draft Welsh", locale=Locale.objects.get(language_code="cy")
+        )
         cls.page_draft.save_revision()
         cls.page_live = StatisticalArticlePageFactory(live=True, title="Live page")
         cls.page_live_plus_draft = StatisticalArticlePageFactory(live=True, title="Live page with draft")
@@ -451,6 +454,7 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         # Test that the chooser includes the correct columns
         self.assertContains(response, "Locale")
         self.assertContains(response, "English")
+        self.assertContains(response, "Welsh")
         self.assertContains(response, "Parent")
         self.assertContains(response, self.page_draft.get_parent().get_admin_display_title())
 

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -448,6 +448,12 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         self.assertNotContains(response, self.page_live.get_admin_display_title())
         self.assertNotContains(response, self.page_draft_in_bundle.get_admin_display_title())
 
+        # Test that the chooser includes the correct columns
+        self.assertContains(response, "Locale")
+        self.assertContains(response, "English")
+        self.assertContains(response, "Parent")
+        self.assertContains(response, self.page_draft.get_parent().get_admin_display_title())
+
     def test_choose_view__includes_page_in_inactive_bundle(self):
         self.bundle.status = BundleStatus.PUBLISHED
         self.bundle.save(update_fields=["status"])

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -408,9 +408,6 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         cls.bundle = BundleFactory()
 
         cls.page_draft = StatisticalArticlePageFactory(live=False, title="Article draft")
-        cls.welsh_page_draft = StatisticalArticlePageFactory(
-            live=False, title="Article draft Welsh", locale=Locale.objects.get(language_code="cy")
-        )
         cls.page_draft.save_revision()
         cls.page_live = StatisticalArticlePageFactory(live=True, title="Live page")
         cls.page_live_plus_draft = StatisticalArticlePageFactory(live=True, title="Live page with draft")
@@ -441,13 +438,17 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         )
 
     def test_choose_view(self):
+        welsh_page_draft = StatisticalArticlePageFactory(
+            live=False, title="Article draft Welsh", locale=Locale.objects.get(language_code="cy")
+        )
+        welsh_page_draft.save_revision()
         response = self.client.get(self.chooser_url)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/chooser/chooser.html")
 
         self.assertContains(response, self.page_draft.get_admin_display_title())
-        self.assertContains(response, self.welsh_page_draft.get_admin_display_title())
+        self.assertContains(response, welsh_page_draft.get_admin_display_title())
         self.assertContains(response, self.page_live_plus_draft.get_admin_display_title())
         self.assertNotContains(response, self.page_live.get_admin_display_title())
         self.assertNotContains(response, self.page_draft_in_bundle.get_admin_display_title())

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -408,7 +408,7 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         cls.bundle = BundleFactory()
 
         cls.page_draft = StatisticalArticlePageFactory(live=False, title="Article draft")
-        StatisticalArticlePageFactory(
+        cls.welsh_page_draft = StatisticalArticlePageFactory(
             live=False, title="Article draft Welsh", locale=Locale.objects.get(language_code="cy")
         )
         cls.page_draft.save_revision()
@@ -447,6 +447,7 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/chooser/chooser.html")
 
         self.assertContains(response, self.page_draft.get_admin_display_title())
+        self.assertContains(response, self.welsh_page_draft.get_admin_display_title())
         self.assertContains(response, self.page_live_plus_draft.get_admin_display_title())
         self.assertNotContains(response, self.page_live.get_admin_display_title())
         self.assertNotContains(response, self.page_draft_in_bundle.get_admin_display_title())

--- a/cms/bundles/viewsets/bundle_page_chooser.py
+++ b/cms/bundles/viewsets/bundle_page_chooser.py
@@ -41,6 +41,7 @@ class PagesWithDraftsMixin:
         return [
             title_column,
             Column("parent", label="Parent", accessor="get_parent"),
+            Column("locale", label="Locale"),
             DateColumn(
                 "updated",
                 label="Updated",

--- a/cms/release_calendar/tests/test_viewsets.py
+++ b/cms/release_calendar/tests/test_viewsets.py
@@ -80,3 +80,10 @@ class TestFutureReleaseCalendarChooserViewSet(WagtailTestUtils, TestCase):
         self.assertContains(
             response, "There are no release calendar pages that are pending or not in an active bundle already."
         )
+
+    def test_choose__contains_locale_column(self):
+        """Tests that the chooser view contains the locale column."""
+        response = self.client.get(self.chooser_url)
+
+        self.assertContains(response, "Locale")
+        self.assertContains(response, "English")

--- a/cms/release_calendar/viewsets.py
+++ b/cms/release_calendar/viewsets.py
@@ -25,6 +25,7 @@ class FutureReleaseCalendarMixin:
     def columns(self) -> list[Column]:
         return [
             self.title_column,  # type: ignore[attr-defined]
+            Column("locale"),
             Column("release_date"),
             Column("release_status", label="Status", accessor="get_status_display"),
             DateColumn(

--- a/cms/topics/tests/test_viewsets.py
+++ b/cms/topics/tests/test_viewsets.py
@@ -53,6 +53,7 @@ class FeaturedSeriesPageChooserViewSetTest(WagtailTestUtils, TestCase):
         self.assertContains(response, "Topic")
         self.assertContains(response, "Updated")
         self.assertContains(response, "Status")
+        self.assertContains(response, "Locale")
 
     def test_chooser_search(self):
         """Test the AJAX results view."""
@@ -150,6 +151,21 @@ class HighlightedPageChooserViewSetTest(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/chooser/chooser.html")
         self.assertNotContains(response, "Article 1")
         self.assertNotContains(response, "Article 2")
+
+    def test_article_choose_view_columns(self):
+        response = self.client.get(f"{self.article_chooser_url}?topic_page_id={self.topic_page.id}")
+
+        self.assertEqual(response.status_code, 200)
+
+        # Check column headers
+        self.assertContains(response, "Release date")
+        self.assertContains(response, "Status")
+        self.assertContains(response, "Locale")
+
+        # Check values
+        self.assertContains(response, "1 January 2024")
+        self.assertContains(response, "English")
+        self.assertContains(response, "live")
 
     def test_article_results_view_with_topic_filter(self):
         """Test the article AJAX results view with topic_page_id filter."""

--- a/cms/topics/viewsets.py
+++ b/cms/topics/viewsets.py
@@ -25,6 +25,7 @@ class FeaturedSeriesPageChooseViewMixin:
         return [
             self.title_column,  # type: ignore[attr-defined]
             Column("parent", label="Topic", accessor="get_parent"),
+            Column("locale", label="Locale"),
             DateColumn(
                 "updated",
                 label="Updated",
@@ -79,6 +80,7 @@ class HighlightedChildPageChooseViewMixin:
         title_column.accessor = "get_admin_display_title"
         return [
             title_column,
+            Column("locale", label="Locale"),
             Column(
                 "release_date",
                 label="Release date",

--- a/functional_tests/features/bundle.feature
+++ b/functional_tests/features/bundle.feature
@@ -1,0 +1,15 @@
+Feature: CMS users can manage bundles
+
+
+    Background:
+        Given a CMS user logs into the admin site
+
+    Scenario: A content editor can see the locale column when selecting a release calendar
+        When the user goes to the bundle creation page
+        And the user opens the release calendar page chooser
+        Then the locale column is displayed in the chooser
+
+    Scenario: A content editor can see the locale column when selecting a page
+        When the user goes to the bundle creation page
+        And the user opens the release calendar page chooser
+        Then the locale column is displayed in the chooser

--- a/functional_tests/steps/bundles.py
+++ b/functional_tests/steps/bundles.py
@@ -28,3 +28,28 @@ def a_bundle_has_a_preview_team(context: Context) -> None:
 def the_viewer_is_in_the_preview_team(context: Context) -> None:
     user = context.user_data["user"]
     user.teams.add(context.team)
+
+
+@step("the user goes to the bundle creation page")
+def the_user_goes_to_the_bundle_creation_page(context: Context) -> None:
+    context.page.goto(context.base_url + "/admin/bundle/new/")
+
+
+@step("the user opens the release calendar page chooser")
+def the_user_selects_a_release_calendar(context: Context) -> None:
+    context.page.get_by_role("button", name="Choose Release Calendar page").click()
+    context.page.wait_for_timeout(250)  # Wait for the modal to open
+
+
+@step("the user opens the page chooser")
+def the_user_opens_page_chooser(context: Context) -> None:
+    context.page.get_by_role("button", name="Add page").click()
+    context.page.wait_for_timeout(100)
+    context.page.get_by_role("button", name="Choose a page").click()
+    context.page.wait_for_timeout(250)  # Wait for the modal to open
+
+
+@step("the locale column is displayed in the chooser")
+def the_locale_column_is_displayed(context: Context) -> None:
+    modal = context.page.locator(".modal-body")
+    modal.get_by_role("columnheader", name="Locale").is_visible()


### PR DESCRIPTION
### What is the context of this PR?

This related to ticket CMS-457 and adds columns to other choosers, supplementing work done in #140.

### How to review

1. Pull branch
2. Login to admin panel
3. Ensure that whenever content is being selected via a chooser, either the locale column exists, or a clear labelling of the locale is present

### Follow-up Actions

N/A
