### PR TITLE
Add locale label to admin page tree view

### DIFF
--- a/cms/core/templates/wagtailadmin/pages/page_listing_header.html
+++ b/cms/core/templates/wagtailadmin/pages/page_listing_header.html
@@ -1,0 +1,11 @@
+{% extends 'wagtailadmin/pages/page_listing_header.html' %}
+{% load wagtailadmin_tags %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% if parent_page.url %}
+        <div class="w-mr-4">
+            {% status parent_page.locale classname="w-status--label w-m-0" %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/cms/core/tests/test_views.py
+++ b/cms/core/tests/test_views.py
@@ -4,6 +4,9 @@ from http import HTTPMethod
 from django.conf import settings
 from django.test import Client, SimpleTestCase, TestCase
 from django.urls import reverse
+from wagtail.test.utils import WagtailTestUtils
+
+from cms.home.models import HomePage
 
 
 class CSRFTestCase(TestCase):
@@ -54,3 +57,18 @@ class ReadinessProbeTestCase(SimpleTestCase):
                 self.assertEqual(response.status_code, 204)
                 self.assertEqual(response.content, b"")
                 self.assertEqual(response.templates, [])
+
+
+class AdminPageTreeTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = cls.create_superuser(username="admin")
+
+    def test_locale_label(self):
+        """Check that the admin page tree is present on the page."""
+        self.client.force_login(self.superuser)
+        homepage = HomePage.objects.first()
+        response = self.client.get(f"/admin/pages/{homepage.id}/")
+        content = response.content.decode("utf-8")
+
+        self.assertInHTML('<span class="w-status w-status--label w-m-0">English</span>', content)


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses CMS-455. It adds a locale label to the breadcrumbs of the admin page tree view (a page list).

@AdamHawtin expressed concerns regarding editors being confused about which locale they are viewing. This should hopefully make it more obvious when viewing a list of pages.

### How to review

1. Check out branch
2. Log in to admin panel
3. Go to a page list
4. Confirm that a locale label is present next to the main breadcrumbs

### Follow-up Actions

N/A