### PR TITLE
Chore: charts code cleanup

### DIFF
--- a/cms/core/tests/test_tags.py
+++ b/cms/core/tests/test_tags.py
@@ -3,7 +3,13 @@ from django.test import TestCase
 from cms.core.templatetags.util_tags import extend
 
 
-class AppendTagTest(TestCase):
+class ExtendFunctionTest(TestCase):
+    """Tests of the `extend()` function.
+
+    This isn't registered as a template tag, but made globally available to be used in
+    Python code within Jinja2.
+    """
+
     def test_append(self):
         """Test the original list is modified in place."""
         series = [{"name": "Series 1"}, {"name": "Series 2"}]

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -15,11 +15,6 @@ from cms.datavis.constants import HighchartsTheme
 class BaseVisualisationBlock(blocks.StructBlock):
     # Extra attributes for subclasses
     highcharts_chart_type: ClassVar[str]
-    supports_stacked_layout: ClassVar[bool]
-    supports_x_axis_title: ClassVar[bool] = False
-    supports_y_axis_title: ClassVar[bool] = False
-    supports_data_labels: ClassVar[bool]
-    supports_markers: ClassVar[bool]
     extra_series_attributes: ClassVar[dict[str, Any]]
 
     # Editable fields
@@ -146,7 +141,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
         # Only add x-axis title if supported and provided, as the Highcharts
         # x-axis title default value is undefined. See
         # https://api.highcharts.com/highcharts/xAxis.title.text
-        if (title := attrs.get("title")) and getattr(self, "supports_x_axis_title", False):
+        if title := attrs.get("title"):
             config["title"] = title
 
         if (tick_interval := attrs.get("tick_interval")) is not None:
@@ -162,17 +157,13 @@ class BaseVisualisationBlock(blocks.StructBlock):
         self,
         attrs: "StructValue",
     ) -> dict[str, Any]:
-        config = {
-            # TODO: hard code y_reversed for horizontal bar charts
-            # "reversed": self.y_reversed,
-        }
+        config = {}
 
         # Only add y-axis title if supported
-        if self.supports_y_axis_title:
+        if (title := attrs.get("title")) is not None:
             # Highcharts y-axis title default value is "Values". Set to undefined to
             # disable. See https://api.highcharts.com/highcharts/yAxis.title.text
-            title = attrs["title"] or None
-            config["title"] = title
+            config["title"] = title or None
 
         if (tick_interval := attrs.get("tick_interval")) is not None:
             config["tickIntervalMobile"] = tick_interval
@@ -210,12 +201,11 @@ class BaseVisualisationBlock(blocks.StructBlock):
                 "data": data_points,
                 "animation": False,
             }
-            if self.supports_data_labels:
+            if value.get("show_data_labels") is not None:
                 item["dataLabels"] = value.get("show_data_labels")
 
-            if getattr(self, "supports_markers", False):
+            if value.get("show_markers") is not None:
                 item["marker"] = value.get("show_markers")
-
             # Allow subclasses to specify additional parameters for each series
             for key, val in getattr(self, "extra_series_attributes", {}).items():
                 item[key] = val

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -9,11 +9,6 @@ from cms.datavis.blocks.utils import TextInputFloatBlock, TextInputIntegerBlock
 
 class LineChartBlock(BaseVisualisationBlock):
     highcharts_chart_type = "line"
-    supports_stacked_layout = False
-    supports_x_axis_title = True
-    supports_y_axis_title = True
-    supports_data_labels = False
-    supports_markers = True
     extra_series_attributes: ClassVar = {
         "connectNulls": True,
     }
@@ -28,12 +23,6 @@ class LineChartBlock(BaseVisualisationBlock):
 
 
 class BarColumnChartBlock(BaseVisualisationBlock):
-    supports_stacked_layout = True
-    supports_x_axis_title = False  # NB displayed as vertical axis for bar chart
-    supports_y_axis_title = True
-    supports_data_labels = True
-    supports_markers = False
-
     # Remove unsupported features
     show_markers = None
 


### PR DESCRIPTION
### What is the context of this PR?

This makes two non-functional changes to the datavis app code:

1. Change a test case name: ~AppendTagTestCase~ → ExtendFunctionTestCase, since it tests the `extend` function, which isn't a tag.
2. Remove use of the `Chart.supports_FOO` pattern for chart subclasses. The methods instead just detect the presence or absence of a value in the data, and the subclasses instead add or remove fields to enable setting those values or not.

I expect a future refactor of the charts will move to making better use of `StructValue` classes.

### How to review

> [!NOTE]
> This contains the code from #169, so is best reviewed after that is merged. Failing that, view individual commits to review.

No functional testing is needed, and there is no ticket for this work. So long as existing tests pass, this should be just a refactor.