### PR TITLE
Add configurable chart aspect ratios

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -111,9 +111,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
     def get_context(self, value: "StructValue", parent_context: Optional[dict[str, Any]] = None) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context(value, parent_context)
 
-        # Add template and visualisation context to support rendering
-        context["config"] = self.get_component_config(value)
-        context["download"] = self.get_download_config(value)
+        context["chart_config"] = self.get_component_config(value)
         return context
 
     def get_highcharts_chart_type(self, value: "StructValue") -> str:
@@ -126,12 +124,22 @@ class BaseVisualisationBlock(blocks.StructBlock):
         headers: list[str] = value["table"].headers
         rows: list[list[str | int | float]] = value["table"].rows
 
-        return {
+        config = {
+            "chartType": self.get_highcharts_chart_type(value),
+            "theme": value.get("theme"),
+            "title": value.get("title"),
+            "subtitle": value.get("subtitle"),
+            "caption": value.get("caption"),
             "legend": value.get("show_legend", True),
             "xAxis": self.get_x_axis_config(value.get("x_axis"), rows),
             "yAxis": self.get_y_axis_config(value.get("y_axis")),
             "series": self.get_series_data(value, headers, rows),
+            "useStackedLayout": value.get("use_stacked_layout"),
+            "annotations_values": self.get_annotations_config(value),
+            "download": self.get_download_config(value),
         }
+
+        return config
 
     def get_x_axis_config(
         self,

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -110,6 +110,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
     desktop_aspect_ratio = "desktop_aspect_ratio"
     mobile_aspect_ratio = "mobile_aspect_ratio"
     options_key_map: ClassVar[dict[str, str]] = {
+        # A dict to map our block types to the Design System macro options
         desktop_aspect_ratio: "percentageHeightDesktop",
         mobile_aspect_ratio: "percentageHeightMobile",
     }

--- a/cms/datavis/blocks/chart_options.py
+++ b/cms/datavis/blocks/chart_options.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from django.db.models import IntegerChoices
+from django.forms import TypedChoiceField
+from wagtail import blocks
+
+
+class AspectRatioBlock(blocks.ChoiceBlock):
+    class AspectRatioChoices(IntegerChoices):
+        _1_1 = int(100 / 1), "1:1"
+        _4_3 = int(100 / (4 / 3)), "4:3"
+        _16_9 = int(100 / (16 / 9)), "16:9"
+        _21_9 = int(100 / (21 / 9)), "21:9"
+        _10_3 = int(100 / (10 / 3)), "10:3"
+
+        __empty__ = "Default"
+
+    choices = AspectRatioChoices.choices
+
+    def get_field(self, **kwargs: Any) -> TypedChoiceField:
+        """Coerce choices to integers, or None.
+
+        The Design System expects aspect ratios as integer percentages. To
+        revert to the default behaviour, the key must be either omitted or set
+        to `null`.
+        """
+        return TypedChoiceField(coerce=int, empty_value=None, **kwargs)

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -46,7 +46,7 @@ class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
                 "value_suffix": "",
                 "tooltip_suffix": "",
             },
-            "annotations": [{"type": "point", "value": {"label": "Peak", "x_position": "2", "y_position": "140"}}],
+            "annotations": [{"type": "point", "value": {"label": "Peak", "x_position": 2, "y_position": 140}}],
         }
 
     def get_value(self, raw_data: dict[str, Any] | None = None):

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -314,3 +314,36 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 self.assertIn("name", item)
                 self.assertIn("data", item)
                 self.assertNotIn("marker", item)
+
+    def test_bar_chart_aspect_ratio_options_not_allowed(self):
+        self.raw_data["select_chart_type"] = "bar"
+        for option in [
+            "desktop_aspect_ratio",
+            "mobile_aspect_ratio",
+        ]:
+            with self.subTest(option=option):
+                self.raw_data["options"] = [{"type": option, "value": 75}]
+                value = self.get_value()
+
+                with self.assertRaises(ValidationError) as cm:
+                    self.block.clean(value)
+
+                err = cm.exception
+                self.assertEqual(
+                    "Bar charts do not support aspect ratio options.",
+                    err.block_errors["options"].block_errors[0].message,
+                )
+
+    def test_column_chart_aspect_ratio_options_are_allowed(self):
+        self.raw_data["select_chart_type"] = "column"
+        for option in [
+            "desktop_aspect_ratio",
+            "mobile_aspect_ratio",
+        ]:
+            with self.subTest(option=option):
+                self.raw_data["options"] = [{"type": option, "value": 75}]
+                value = self.get_value()
+                try:
+                    self.block.clean(value)
+                except ValidationError:
+                    self.fail("Expected no ValidationError for column chart aspect ratio options")

--- a/cms/datavis/tests/test_chart_options.py
+++ b/cms/datavis/tests/test_chart_options.py
@@ -1,0 +1,72 @@
+from types import NoneType
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+from wagtail.blocks.struct_block import StructValue
+
+from cms.datavis.blocks.chart_options import AspectRatioBlock
+from cms.datavis.blocks.charts import LineChartBlock
+from cms.datavis.tests.test_chart_blocks import BaseChartBlockTestCase
+
+
+class AspectRatioTestCase(SimpleTestCase):
+    def test_aspect_ratio_types(self):
+        """Test that the block returns an int or None.
+
+        This is only made possible by using TypedChoiceField, hence the
+        apparently trivial test.
+        """
+        block = AspectRatioBlock(required=False)
+        for raw_data, expected in [
+            (None, NoneType),
+            (75, int),
+        ]:
+            with self.subTest(raw_data=raw_data):
+                value = block.field.clean(raw_data)
+                self.assertIsInstance(value, expected)
+
+
+class ChartOptionsTestCase(BaseChartBlockTestCase):
+    block_type = LineChartBlock
+
+    def test_no_options_added(self):
+        value = self.get_value()
+        self.assertEqual(0, len(value.get("options")))
+        self.assertEqual({}, value.block.get_additional_options(value))
+
+    def test_one_option_added(self):
+        self.raw_data["options"] = [{"type": "desktop_aspect_ratio", "value": 75}]
+        value = self.get_value()
+        self.assertEqual(1, len(value.get("options", [])))
+        self.assertEqual(75, value.get("options", [])[0].value)
+        self.assertEqual({"percentageHeightDesktop": 75}, value.block.get_additional_options(value))
+
+    def test_default_value_selected(self):
+        self.raw_data["options"] = [{"type": "desktop_aspect_ratio", "value": None}]
+        value = self.get_value()
+        self.assertEqual(1, len(value.get("options", [])))
+        self.assertIsNone(value.get("options", [])[0].value)
+        self.assertEqual({"percentageHeightDesktop": None}, value.block.get_additional_options(value))
+
+    def test_setting_multiple_options(self):
+        self.raw_data["options"] = [
+            {"type": "desktop_aspect_ratio", "value": 75},
+            {"type": "mobile_aspect_ratio", "value": 75},
+        ]
+        value = self.get_value()
+        self.assertEqual(2, len(value.get("options", [])))
+        self.assertEqual(75, value.get("options", [])[0].value)
+        self.assertEqual(
+            {"percentageHeightDesktop": 75, "percentageHeightMobile": 75},
+            value.block.get_additional_options(value),
+        )
+
+    def test_duplicate_options(self):
+        self.raw_data["options"] = [
+            {"type": "mobile_aspect_ratio", "value": 75},
+            {"type": "mobile_aspect_ratio", "value": 75},
+        ]
+        value = self.get_value()
+        self.assertIsInstance(value, StructValue)
+        with self.assertRaises(ValidationError, msg="Expected ValidationError for duplicate options"):
+            self.block.clean(value)

--- a/cms/jinja2/templates/components/streamfield/datavis/base_highcharts_chart_block.html
+++ b/cms/jinja2/templates/components/streamfield/datavis/base_highcharts_chart_block.html
@@ -1,21 +1,4 @@
 {% from "components/chart/_macro.njk" import onsChart %}
 
-{# fmt:off #}
-{{
-    onsChart({
-        "chartType": value.block.get_highcharts_chart_type(value),
-        "theme": value.theme,
-        "title": value.title,
-        "subtitle": value.subtitle,
-        "id": block_id,
-        "caption": value.caption,
-        "legend": config.legend,
-        "yAxis": config.yAxis,
-        "xAxis": config.xAxis,
-        "series": config.series,
-        "useStackedLayout": value.use_stacked_layout,
-        "annotations": value.block.get_annotations_config(value),
-        "download": download,
-    })
-}}
-{# fmt:on #}
+{%- do chart_config.update(id=block_id) -%}
+{{ onsChart(chart_config) }}


### PR DESCRIPTION
### What is the context of this PR?

Add configurable chart aspect ratios.

Ticket: [CCB-76](https://jira.ons.gov.uk/browse/CCB-76)

### How to review

- Check out the branch, and create an Information Page.
- Add various different types of chart block (except horizontal bar chart)
- For each, add **options** > **Desktop aspect ratio**, or **options** > **Mobile aspect ratio**.
- See that the aspect ratio is changed
- Try again for a bar chart, and see an error message

