### PR TITLE
Headline figures UX improvements

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -231,6 +231,10 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         if self.next_release_date and self.next_release_date <= self.release_date:
             raise ValidationError({"next_release_date": "The next release date must be after the release date."})
 
+        if self.headline_figures and len(self.headline_figures[0].value) == 1:  # pylint: disable=unsubscriptable-object
+            # Check if headline_figures has 1 item (we can't use min_num because we allow 0)
+            raise ValidationError({"headline_figures": "If you add headline figures, please add at least 2."})
+
         if self.headline_figures and len(self.headline_figures) > 0:
             figure_ids = [figure["figure_id"] for figure in self.headline_figures[0].value]  # pylint: disable=unsubscriptable-object
         else:

--- a/cms/articles/tests/factories.py
+++ b/cms/articles/tests/factories.py
@@ -48,9 +48,7 @@ class StatisticalArticlePageFactory(wagtail_factories.PageFactory):
     next_release_date = factory.LazyAttribute(lambda o: o.release_date + timedelta(days=1))
     contact_details = factory.SubFactory(ContactDetailsFactory)
 
-    headline_figures = wagtail_factories.StreamFieldFactory(
-        {"headline_figure": factory.SubFactory(HeadlineFigureBlockFactory)}
-    )
+    headline_figures = wagtail_factories.StreamFieldFactory({"figures": factory.SubFactory(HeadlineFigureBlockFactory)})
     content = wagtail_factories.StreamFieldFactory(
         {
             "section": factory.SubFactory(SectionContentBlockFactory),

--- a/cms/core/blocks/headline_figures.py
+++ b/cms/core/blocks/headline_figures.py
@@ -11,9 +11,9 @@ class HeadlineFiguresItemBlock(StructBlock):
     """Represents a headline figure."""
 
     figure_id = CharBlock(required=False)
-    title = CharBlock(label="Title", max_length=60, required=True)
-    figure = CharBlock(label="Figure", max_length=10, required=True)
-    supporting_text = CharBlock(label="Supporting text", max_length=100, required=True)
+    title = CharBlock(label="Title", required=True)
+    figure = CharBlock(label="Figure", required=True)
+    supporting_text = CharBlock(label="Supporting text", required=True)
 
     class Meta:
         # The help_text may be updated via JavaScript
@@ -24,7 +24,7 @@ class HeadlineFiguresBlock(ListBlock):
     """A list of headline figures."""
 
     def __init__(self, search_index: bool = True, **kwargs: Any) -> None:
-        kwargs.setdefault("max_num", 4)
+        kwargs.setdefault("max_num", 6)
         super().__init__(HeadlineFiguresItemBlock, search_index=search_index, **kwargs)
 
     class Meta:


### PR DESCRIPTION
### What is the context of this PR?

This PR is a follow-up to #152 and lifts the headline figure inputs limits (so they are now 255, the CharField limit), and updates the statistical article headline figure limits and validation logic to be (optional, but if entered - min 2, max 6)

### How to review

- check the branch out. `make collectstatic` if you haven't done it recently
- add or edit a statistical article page and attempt to add just one headline figure

### Follow-up Actions

N/A
