### PR TITLE
Fix annotations

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -166,7 +166,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
             "yAxis": self.get_y_axis_config(value.get("y_axis")),
             "series": self.get_series_data(value, headers, rows),
             "useStackedLayout": value.get("use_stacked_layout"),
-            "annotations_values": self.get_annotations_config(value),
+            "annotations": self.get_annotations_config(value),
             "download": self.get_download_config(value),
         }
 


### PR DESCRIPTION
### What is the context of this PR?

This resolves a bug introduced in 31c02109e76bc636c4f46e44e88ddff8a0460cd0, #177, specifically in the commit 28ba8d3bafb13db6226c8259b0da3550395e4b19, when we moved the building of the chart macro configuration dict from the template to the StreamBlock get_context method. The key `annotations` was incorrectly substituted with `annotations_values`.

### How to review

Add an annotation to a chart, as per #172, and see that it is once again correctly rendered.

### Follow-up Actions

Deploy to ons-charts-beta.