### PR TITLE
Prevent copying of topic and theme pages

### DIFF
--- a/cms/themes/tests/test_pages.py
+++ b/cms/themes/tests/test_pages.py
@@ -1,0 +1,56 @@
+from http import HTTPStatus
+
+from django.urls import reverse
+from wagtail.test.utils import WagtailPageTestCase
+
+from cms.topics.tests.factories import ThemePageFactory
+
+
+class TopicPageTests(WagtailPageTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.page = ThemePageFactory()
+        cls.superuser = cls.create_superuser(username="admin")
+
+    def test_default_route(self):
+        self.assertPageIsRoutable(self.page)
+
+    def test_default_route_is_renderable(self):
+        self.assertPageIsRenderable(self.page)
+
+    def test_default_route_rendering(self):
+        response = self.client.get(self.page.url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(response, self.page.title)
+        self.assertContains(response, self.page.summary)
+
+    def test_copy_is_not_allowed(self):
+        """Test that copying a ThemePage raises a warning."""
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse("wagtailadmin_pages:copy", args=[self.page.id]),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        response = self.client.get(
+            reverse("wagtailadmin_pages:copy", args=[self.page.id]),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(
+            response,
+            "Topic and theme pages cannot be duplicated as selected taxonomy needs to be unique for each page.",
+        )
+
+        response = self.client.post(
+            reverse("wagtailadmin_pages:copy", args=[self.page.id]),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        response = self.client.post(
+            reverse("wagtailadmin_pages:copy", args=[self.page.id]),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(
+            response,
+            "Topic and theme pages cannot be duplicated as selected taxonomy needs to be unique for each page.",
+        )

--- a/cms/themes/tests/test_pages.py
+++ b/cms/themes/tests/test_pages.py
@@ -6,7 +6,7 @@ from wagtail.test.utils import WagtailPageTestCase
 from cms.topics.tests.factories import ThemePageFactory
 
 
-class TopicPageTests(WagtailPageTestCase):
+class ThemePageTests(WagtailPageTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.page = ThemePageFactory()

--- a/cms/topics/wagtail_hooks.py
+++ b/cms/topics/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.shortcuts import redirect
 from wagtail import hooks
 from wagtail.admin import messages
@@ -48,6 +49,8 @@ def register_series_with_headline_figures_chooser_viewset() -> "SeriesWithHeadli
 
 @hooks.register("before_copy_page")
 def before_create_page(request: "HttpRequest", page: "Page") -> "HttpResponseRedirect | None":
+    if not settings.ENFORCE_EXCLUSIVE_TAXONOMY:
+        return None
     if isinstance(page.specific, TopicPage | ThemePage):
         messages.warning(
             request,

--- a/cms/topics/wagtail_hooks.py
+++ b/cms/topics/wagtail_hooks.py
@@ -49,9 +49,7 @@ def register_series_with_headline_figures_chooser_viewset() -> "SeriesWithHeadli
 
 @hooks.register("before_copy_page")
 def before_create_page(request: "HttpRequest", page: "Page") -> "HttpResponseRedirect | None":
-    if not settings.ENFORCE_EXCLUSIVE_TAXONOMY:
-        return None
-    if isinstance(page.specific, TopicPage | ThemePage):
+    if settings.ENFORCE_EXCLUSIVE_TAXONOMY and isinstance(page.specific, TopicPage | ThemePage):
         messages.warning(
             request,
             "Topic and theme pages cannot be duplicated as selected taxonomy needs to be unique for each page.",


### PR DESCRIPTION
### What is the context of this PR?

This PR related to CMS-430 and resolves an issue where unique taxonomy requirements would raise an exception when being copied due to the fact that there cannot be two pages with the same topic assigned.

This change displays a message explaining this when an admin user attempts to copy/duplicate a theme or topic page.

Loom video: https://www.loom.com/share/565abe76084e40f097a7a74f8145d96a?sid=1c717ce4-77b5-418e-bcc2-b9456b0b642d

### How to review

1. Checkout branch
2. Create a theme page and a topic page
3. Try to copy a theme page and a topic page
4. Confirm that in each scenario you are prevented from doing so, and a message is displayed

### Follow-up Actions

Confirm that the message used is satisfactory.
