### PR TITLE
Column chart with line

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -152,8 +152,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
         return self.highcharts_chart_type
 
     def get_component_config(self, value: "StructValue") -> dict[str, Any]:
-        headers: list[str] = value["table"].headers
-        rows: list[list[str | int | float]] = value["table"].rows
+        rows, series = self.get_series_data(value)
 
         config = {
             "chartType": self.get_highcharts_chart_type(value),
@@ -164,7 +163,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
             "legend": value.get("show_legend", True),
             "xAxis": self.get_x_axis_config(value.get("x_axis"), rows),
             "yAxis": self.get_y_axis_config(value.get("y_axis")),
-            "series": self.get_series_data(value, headers, rows),
+            "series": series,
             "useStackedLayout": value.get("use_stacked_layout"),
             "annotations": self.get_annotations_config(value),
             "download": self.get_download_config(value),
@@ -232,9 +231,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
     def get_series_data(
         self,
         value: "StructValue",
-        headers: Sequence[str],
-        rows: Sequence[list[str | int | float]],
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[list[str | int | float]], list[dict[str, Any]]]:
+        headers: list[str] = value["table"].headers
+        rows: list[list[str | int | float]] = value["table"].rows
         series = []
 
         for i, column in enumerate(headers[1:], start=1):
@@ -260,7 +259,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
                     "valueSuffix": tooltip_suffix,
                 }
             series.append(item)
-        return series
+        return rows, series
 
     def get_additional_options(self, value: "StructValue") -> dict[str, Any]:
         options = {}

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -116,20 +116,20 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         seen_series_numbers = set()
         for i, block in enumerate(value.get("series_customisation", [])):
             if block.block_type == self.SERIES_AS_LINE_OVERLAY_BLOCK:
-                if block.value in seen_series_numbers:
-                    sub_block_errors[i] = ValidationError("Duplicate series number.", code=self.ERROR_DUPLICATE_SERIES)
-                seen_series_numbers.add(block.value)
-
                 if value.get("select_chart_type") == self.ChartTypeChoices.BAR:
                     sub_block_errors[i] = ValidationError(
                         "Horizontal bar charts do not support line overlays.", code=self.ERROR_HORIZONTAL_BAR_NO_LINE
                     )
 
                 # Raise an error if the series number is not in the range of the number of series
-                if block.value < 1 or block.value > len(series):
+                elif block.value < 1 or block.value > len(series):
                     sub_block_errors[i] = ValidationError(
                         "Series number out of range.", code=self.ERROR_SERIES_OUT_OF_RANGE
                     )
+
+                elif block.value in seen_series_numbers:
+                    sub_block_errors[i] = ValidationError("Duplicate series number.", code=self.ERROR_DUPLICATE_SERIES)
+                seen_series_numbers.add(block.value)
 
         # Raise an error if all series are selected for line overlay
         if all(series_number in seen_series_numbers for series_number in range(1, len(series) + 1)):

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -1,10 +1,15 @@
-from typing import ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from django.core.exceptions import ValidationError
+from django.db.models import TextChoices
 from django.forms import widgets
 from wagtail import blocks
 
 from cms.datavis.blocks.base import BaseVisualisationBlock
 from cms.datavis.blocks.utils import TextInputFloatBlock, TextInputIntegerBlock
+
+if TYPE_CHECKING:
+    from wagtail.blocks.struct_block import StructValue
 
 
 class LineChartBlock(BaseVisualisationBlock):
@@ -17,6 +22,7 @@ class LineChartBlock(BaseVisualisationBlock):
     select_chart_type = None
     use_stacked_layout = None
     show_data_labels = None
+    series_customisation = None
 
     class Meta:
         icon = "chart-line"
@@ -26,13 +32,14 @@ class BarColumnChartBlock(BaseVisualisationBlock):
     # Remove unsupported features
     show_markers = None
 
+    class ChartTypeChoices(TextChoices):
+        BAR = "bar", "Bar"
+        COLUMN = "column", "Column"
+
     # Block overrides
     select_chart_type = blocks.ChoiceBlock(
-        choices=[
-            ("bar", "Bar"),
-            ("column", "Column"),
-        ],
-        default="bar",
+        choices=ChartTypeChoices.choices,
+        default=ChartTypeChoices.BAR,
         label="Display as",
         widget=widgets.RadioSelect,
     )
@@ -74,6 +81,59 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         required=False,
         help_text="Legend displays only when there is more than one data series.",
     )
+    SERIES_AS_LINE_OVERLAY_BLOCK = "series_as_line_overlay"
+    series_customisation = blocks.StreamBlock(
+        [
+            (
+                SERIES_AS_LINE_OVERLAY_BLOCK,
+                TextInputIntegerBlock(help_text="The number of the series to display as a line overlay."),
+            ),
+        ],
+        required=False,
+    )
 
     class Meta:
         icon = "chart-bar"
+
+    def get_series_customisation(self, value: "StructValue", series_number: int) -> dict[str, Any]:
+        for block in value.get("series_customisation", []):
+            if block.block_type == self.SERIES_AS_LINE_OVERLAY_BLOCK and block.value == series_number:
+                return {"type": "line"}
+        return {}
+
+    def clean(self, value: "StructValue") -> "StructValue":
+        value = super().clean(value)
+
+        _, series = self.get_series_data(value)
+        sub_block_errors = {}
+
+        seen_series_numbers = set()
+        for i, block in enumerate(value.get("series_customisation", [])):
+            if block.block_type == self.SERIES_AS_LINE_OVERLAY_BLOCK:
+                if block.value in seen_series_numbers:
+                    sub_block_errors[i] = ValidationError("Duplicate series number.")
+                seen_series_numbers.add(block.value)
+
+                if value.get("select_chart_type") == self.ChartTypeChoices.BAR:
+                    sub_block_errors[i] = ValidationError("Horizontal bar charts do not support line overlays.")
+
+                # Raise an error if the series number is not in the range of the number of series
+                if block.value < 1 or block.value > len(series):
+                    sub_block_errors[i] = ValidationError("Series number out of range.")
+
+        # Raise an error if there is only one data series
+        if len(series) == len(seen_series_numbers):
+            raise blocks.StructBlockValidationError(
+                block_errors={
+                    "series_customisation": ValidationError(
+                        "There must be at least one column remaining. To draw lines only, use a Line Chart."
+                    )
+                }
+            )
+
+        if sub_block_errors:
+            raise blocks.StructBlockValidationError(
+                block_errors={"series_customisation": blocks.StreamBlockValidationError(block_errors=sub_block_errors)}
+            )
+
+        return value

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -131,8 +131,8 @@ class BarColumnChartBlock(BaseVisualisationBlock):
                         "Series number out of range.", code=self.ERROR_SERIES_OUT_OF_RANGE
                     )
 
-        # Raise an error if there is only one data series
-        if len(series) == len(seen_series_numbers):
+        # Raise an error if all series are selected for line overlay
+        if all(series_number in seen_series_numbers for series_number in range(1, len(series) + 1)):
             raise blocks.StructBlockValidationError(
                 block_errors={
                     "series_customisation": ValidationError(

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -383,8 +383,10 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
             {"type": "series_as_line_overlay", "value": 1}  # NB 1-indexed
         ]
         self.block.clean(self.get_value())
-        # The first series is the line overlay
         _, series = self.get_value().block.get_series_data(self.get_value())
+        # There are two series
+        self.assertEqual(2, len(series))
+        # The first series is the line overlay
         self.assertEqual("line", series[0]["type"])
         # The second series remains a column
         with self.assertRaises(KeyError):
@@ -399,9 +401,11 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
             self.block.clean(self.get_value())
 
         self.assertEqual(
-            "Horizontal bar charts do not support line overlays.",
-            cm.exception.block_errors["series_customisation"].block_errors[0].message,
+            BarColumnChartBlock.ERROR_HORIZONTAL_BAR_NO_LINE,
+            cm.exception.block_errors["series_customisation"].block_errors[0].code,
         )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))
 
     def test_error_is_raised_if_series_number_is_out_of_range(self):
         self.raw_data["select_chart_type"] = "column"
@@ -413,9 +417,11 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
                 with self.assertRaises(blocks.StructBlockValidationError) as cm:
                     self.block.clean(self.get_value())
                 self.assertEqual(
-                    "Series number out of range.",
-                    cm.exception.block_errors["series_customisation"].block_errors[0].message,
+                    BarColumnChartBlock.ERROR_SERIES_OUT_OF_RANGE,
+                    cm.exception.block_errors["series_customisation"].block_errors[0].code,
                 )
+                # This is the only error
+                self.assertEqual(1, len(cm.exception.block_errors))
 
     def test_error_is_raised_if_series_number_is_duplicated(self):
         self.raw_data["select_chart_type"] = "column"
@@ -427,8 +433,11 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
             self.block.clean(self.get_value())
 
         self.assertEqual(
-            "Duplicate series number.", cm.exception.block_errors["series_customisation"].block_errors[1].message
+            BarColumnChartBlock.ERROR_DUPLICATE_SERIES,
+            cm.exception.block_errors["series_customisation"].block_errors[1].code,
         )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))
 
     def test_error_is_raised_if_all_series_are_selected_for_line_overlay(self):
         self.raw_data["select_chart_type"] = "column"
@@ -441,10 +450,15 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
             ]
         )
         self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 1}]
+        _, series = self.get_value().block.get_series_data(self.get_value())
+        # There is one series
+        self.assertEqual(1, len(series))
         with self.assertRaises(blocks.StructBlockValidationError) as cm:
             self.block.clean(self.get_value())
 
         self.assertEqual(
-            "There must be at least one column remaining. To draw lines only, use a Line Chart.",
-            cm.exception.block_errors["series_customisation"].message,
+            BarColumnChartBlock.ERROR_ALL_SERIES_SELECTED,
+            cm.exception.block_errors["series_customisation"].code,
         )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -407,6 +407,21 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
         # This is the only error
         self.assertEqual(1, len(cm.exception.block_errors))
 
+    def test_horizontal_bar_no_line_error_not_clobbered(self):
+        # We don't want particular details about the series number input to hide
+        # the fact that this should not be allowed on a bar chart at all.
+        self.raw_data["select_chart_type"] = "bar"
+        self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 10}]  # Out of range
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertEqual(
+            BarColumnChartBlock.ERROR_HORIZONTAL_BAR_NO_LINE,
+            cm.exception.block_errors["series_customisation"].block_errors[0].code,
+        )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))
+
     def test_error_is_raised_if_series_number_is_out_of_range(self):
         self.raw_data["select_chart_type"] = "column"
         for series_number in [0, 3]:

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -462,3 +462,22 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
         )
         # This is the only error
         self.assertEqual(1, len(cm.exception.block_errors))
+
+    def test_all_series_selected_not_raised_for_number_out_of_range(self):
+        self.raw_data["select_chart_type"] = "column"
+        self.raw_data["series_customisation"] = [
+            {"type": "series_as_line_overlay", "value": 1},
+            {"type": "series_as_line_overlay", "value": 3},
+        ]
+        _, series = self.get_value().block.get_series_data(self.get_value())
+        # There are two series
+        self.assertEqual(2, len(series))
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertNotEqual(
+            BarColumnChartBlock.ERROR_ALL_SERIES_SELECTED,
+            cm.exception.block_errors["series_customisation"].code,
+        )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -1,7 +1,9 @@
 from typing import Any, ClassVar
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
+from wagtail import blocks
 from wagtail.blocks.struct_block import StructValue
 from wagtail.test.utils import WagtailTestUtils
 
@@ -130,7 +132,7 @@ class LineChartBlockTestCase(BaseChartBlockTestCase):
         with self.assertRaises(ValidationError, msg="Expected ValidationError for missing title"):
             self.block.clean(value)
 
-    def test_get_series_data(self):
+    def test_series_data(self):
         """Test that we identify two separate series in the data."""
         config = self.get_component_config()
         self.assertEqual(len(config["series"]), 2)
@@ -347,3 +349,102 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                     self.block.clean(value)
                 except ValidationError:
                     self.fail("Expected no ValidationError for column chart aspect ratio options")
+
+
+class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
+    block_type = BarColumnChartBlock
+
+    def setUp(self):
+        super().setUp()
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Series 1", "Series 2"],
+                ["2005", "100", "50"],
+                ["2006", "120", "55"],
+                ["2007", "140", "60"],
+            ]
+        )
+
+    def test_get_series_customisation_is_one_indexed(self):
+        with mock.patch.object(self.block, "get_series_customisation") as mock_get_series_customisation:
+            mock_get_series_customisation.return_value = {}
+
+            self.block.clean(self.get_value())
+            mock_get_series_customisation.assert_has_calls(
+                [
+                    mock.call(mock.ANY, 1),
+                    mock.call(mock.ANY, 2),
+                ]
+            )
+
+    def test_column_chart_with_one_line_overlay(self):
+        self.raw_data["select_chart_type"] = "column"
+        self.raw_data["series_customisation"] = [
+            {"type": "series_as_line_overlay", "value": 1}  # NB 1-indexed
+        ]
+        self.block.clean(self.get_value())
+        # The first series is the line overlay
+        _, series = self.get_value().block.get_series_data(self.get_value())
+        self.assertEqual("line", series[0]["type"])
+        # The second series remains a column
+        with self.assertRaises(KeyError):
+            # The only supported value for type is "line", when it is omitted we
+            # know this is a column.
+            series[1]["type"]  # pylint: disable=pointless-statement
+
+    def test_bar_chart_with_line_overlay_is_not_allowed(self):
+        self.raw_data["select_chart_type"] = "bar"
+        self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 1}]
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertEqual(
+            "Horizontal bar charts do not support line overlays.",
+            cm.exception.block_errors["series_customisation"].block_errors[0].message,
+        )
+
+    def test_error_is_raised_if_series_number_is_out_of_range(self):
+        self.raw_data["select_chart_type"] = "column"
+        for series_number in [0, 3]:
+            with self.subTest(series_number=series_number):
+                self.raw_data["series_customisation"] = [
+                    {"type": "series_as_line_overlay", "value": series_number},
+                ]
+                with self.assertRaises(blocks.StructBlockValidationError) as cm:
+                    self.block.clean(self.get_value())
+                self.assertEqual(
+                    "Series number out of range.",
+                    cm.exception.block_errors["series_customisation"].block_errors[0].message,
+                )
+
+    def test_error_is_raised_if_series_number_is_duplicated(self):
+        self.raw_data["select_chart_type"] = "column"
+        self.raw_data["series_customisation"] = [
+            {"type": "series_as_line_overlay", "value": 1},
+            {"type": "series_as_line_overlay", "value": 1},
+        ]
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertEqual(
+            "Duplicate series number.", cm.exception.block_errors["series_customisation"].block_errors[1].message
+        )
+
+    def test_error_is_raised_if_all_series_are_selected_for_line_overlay(self):
+        self.raw_data["select_chart_type"] = "column"
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Only one series"],
+                ["2005", "100"],
+                ["2006", "120"],
+                ["2007", "140"],
+            ]
+        )
+        self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 1}]
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertEqual(
+            "There must be at least one column remaining. To draw lines only, use a Line Chart.",
+            cm.exception.block_errors["series_customisation"].message,
+        )


### PR DESCRIPTION
### What is the context of this PR?

Implement "column chart with line".

Ticket: [CCB-64](https://jira.ons.gov.uk/browse/CCB-64)

This permits an editor to select a series for customisation. There is only one possible customisation at the moment: "series as line overlay". Multiple series can be selected, but not all.

### How to review

- Create an Information Page.
- Add a Bar/Column chart.
- Set the orientation to Column
- Add more than one data series.
- Add a "Series customisation", and enter the number of one of your series.
- Try this with a stacked column chart.
- Try some of the various error states (you may need to save the page to see the messages):
    - Enter 0, or a value higher than the number of series
    - Enter the same series number twice
    - Configure every data series as a line overlay
    - Try this with a bar chart

<details><summary>Screenshots</summary>
<p>Successful state</p>

![image](https://github.com/user-attachments/assets/c7a120d7-b9e3-4bb5-a0b5-6dbd98755db6)


<p>One of various possible error messages.</p>

![image](https://github.com/user-attachments/assets/2ee848a5-0b37-44d1-8e19-869dda8f2c26)


</details>