### PR TITLE
Refactor tests and business logic to use named objects

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -103,17 +103,17 @@ class BaseVisualisationBlock(blocks.StructBlock):
         required=False,
     )
 
-    desktop_aspect_ratio = "desktop_aspect_ratio"
-    mobile_aspect_ratio = "mobile_aspect_ratio"
+    DESKTOP_ASPECT_RATIO = "desktop_aspect_ratio"
+    MOBILE_ASPECT_RATIO = "mobile_aspect_ratio"
     options_key_map: ClassVar[dict[str, str]] = {
         # A dict to map our block types to the Design System macro options
-        desktop_aspect_ratio: "percentageHeightDesktop",
-        mobile_aspect_ratio: "percentageHeightMobile",
+        DESKTOP_ASPECT_RATIO: "percentageHeightDesktop",
+        MOBILE_ASPECT_RATIO: "percentageHeightMobile",
     }
     options = blocks.StreamBlock(
         [
             (
-                desktop_aspect_ratio,
+                DESKTOP_ASPECT_RATIO,
                 AspectRatioBlock(
                     required=False,
                     help_text='Remove this option, or set "Default", to use the default aspect ratio for desktop.',
@@ -121,7 +121,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
                 ),
             ),
             (
-                mobile_aspect_ratio,
+                MOBILE_ASPECT_RATIO,
                 AspectRatioBlock(
                     required=False,
                     help_text='Remove this option, or set "Default", to use the default aspect ratio for mobile.',
@@ -130,8 +130,8 @@ class BaseVisualisationBlock(blocks.StructBlock):
             ),
         ],
         block_counts={
-            desktop_aspect_ratio: {"max_num": 1},
-            mobile_aspect_ratio: {"max_num": 1},
+            DESKTOP_ASPECT_RATIO: {"max_num": 1},
+            MOBILE_ASPECT_RATIO: {"max_num": 1},
         },
         help_text="Additional settings for the chart",
         required=False,
@@ -303,7 +303,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
 
     def clean(self, value: "StructValue") -> "StructValue":
         result = super().clean(value)
-        aspect_ratio_keys = [self.desktop_aspect_ratio, self.mobile_aspect_ratio]
+        aspect_ratio_keys = [self.DESKTOP_ASPECT_RATIO, self.MOBILE_ASPECT_RATIO]
 
         options_errors = {}
         if self.get_highcharts_chart_type(result) == "bar":

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from contextlib import suppress
 from typing import Any, ClassVar, Optional, cast
 
-from django.core.exceptions import ValidationError
 from django.forms.widgets import Media, RadioSelect
 from django.utils.functional import cached_property
 from wagtail import blocks
@@ -300,22 +299,6 @@ class BaseVisualisationBlock(blocks.StructBlock):
                 },
             ],
         }
-
-    def clean(self, value: "StructValue") -> "StructValue":
-        result = super().clean(value)
-        aspect_ratio_keys = [self.DESKTOP_ASPECT_RATIO, self.MOBILE_ASPECT_RATIO]
-
-        options_errors = {}
-        if self.get_highcharts_chart_type(result) == "bar":
-            for i, option in enumerate(result["options"]):
-                if option.block_type in aspect_ratio_keys:
-                    options_errors[i] = ValidationError("Bar charts do not support aspect ratio options.")
-
-        if options_errors:
-            raise blocks.StructBlockValidationError(
-                block_errors={"options": blocks.StreamBlockValidationError(block_errors=options_errors)}
-            )
-        return result
 
     @cached_property
     def media(self) -> Media:

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -34,6 +34,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
     ERROR_HORIZONTAL_BAR_NO_LINE = "horizontal_bar_no_line_overlay"
     ERROR_SERIES_OUT_OF_RANGE = "series_number_out_of_range"
     ERROR_ALL_SERIES_SELECTED = "all_series_selected"
+    ERROR_BAR_CHART_NO_ASPECT_RATIO = "bar_chart_no_aspect_ratio"
 
     # Remove unsupported features
     show_markers = None
@@ -109,42 +110,66 @@ class BarColumnChartBlock(BaseVisualisationBlock):
 
     def clean(self, value: "StructValue") -> "StructValue":
         value = super().clean(value)
+        value = self.clean_series_customisation(value)
+        value = self.clean_options(value)
+        return value
 
+    def clean_series_customisation(self, value: "StructValue") -> "StructValue":
         _, series = self.get_series_data(value)
-        sub_block_errors = {}
 
+        errors = {}
+        stream_block_errors = {}
         seen_series_numbers = set()
         for i, block in enumerate(value.get("series_customisation", [])):
             if block.block_type == self.SERIES_AS_LINE_OVERLAY_BLOCK:
                 if value.get("select_chart_type") == self.ChartTypeChoices.BAR:
-                    sub_block_errors[i] = ValidationError(
+                    stream_block_errors[i] = ValidationError(
                         "Horizontal bar charts do not support line overlays.", code=self.ERROR_HORIZONTAL_BAR_NO_LINE
                     )
 
                 # Raise an error if the series number is not in the range of the number of series
                 elif block.value < 1 or block.value > len(series):
-                    sub_block_errors[i] = ValidationError(
+                    stream_block_errors[i] = ValidationError(
                         "Series number out of range.", code=self.ERROR_SERIES_OUT_OF_RANGE
                     )
 
                 elif block.value in seen_series_numbers:
-                    sub_block_errors[i] = ValidationError("Duplicate series number.", code=self.ERROR_DUPLICATE_SERIES)
+                    stream_block_errors[i] = ValidationError(
+                        "Duplicate series number.", code=self.ERROR_DUPLICATE_SERIES
+                    )
                 seen_series_numbers.add(block.value)
 
-        # Raise an error if all series are selected for line overlay
         if all(series_number in seen_series_numbers for series_number in range(1, len(series) + 1)):
-            raise blocks.StructBlockValidationError(
-                block_errors={
-                    "series_customisation": ValidationError(
-                        "There must be at least one column remaining. To draw lines only, use a Line Chart.",
-                        code=self.ERROR_ALL_SERIES_SELECTED,
-                    )
-                }
+            # Raise an error if all series are selected for line overlay. Ignore
+            # the individual sub-block errors.
+            errors["series_customisation"] = ValidationError(
+                "There must be at least one column remaining. To draw lines only, use a Line Chart.",
+                code=self.ERROR_ALL_SERIES_SELECTED,
             )
+        elif stream_block_errors:
+            errors["series_customisation"] = blocks.StreamBlockValidationError(block_errors=stream_block_errors)
 
-        if sub_block_errors:
-            raise blocks.StructBlockValidationError(
-                block_errors={"series_customisation": blocks.StreamBlockValidationError(block_errors=sub_block_errors)}
-            )
+        if errors:
+            raise blocks.StructBlockValidationError(block_errors=errors)
+
+        return value
+
+    def clean_options(self, value: "StructValue") -> "StructValue":
+        aspect_ratio_keys = [self.DESKTOP_ASPECT_RATIO, self.MOBILE_ASPECT_RATIO]
+
+        errors = {}
+        options_errors = {}
+        if self.get_highcharts_chart_type(value) == self.ChartTypeChoices.BAR:
+            for i, option in enumerate(value["options"]):
+                if option.block_type in aspect_ratio_keys:
+                    options_errors[i] = ValidationError(
+                        "Bar charts do not support aspect ratio options.", code=self.ERROR_BAR_CHART_NO_ASPECT_RATIO
+                    )
+
+        if options_errors:
+            errors["options"] = blocks.StreamBlockValidationError(block_errors=options_errors)
+
+        if errors:
+            raise blocks.StructBlockValidationError(block_errors=errors)
 
         return value

--- a/cms/datavis/tests/test_chart_blocks.py
+++ b/cms/datavis/tests/test_chart_blocks.py
@@ -332,8 +332,8 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
 
                 err = cm.exception
                 self.assertEqual(
-                    "Bar charts do not support aspect ratio options.",
-                    err.block_errors["options"].block_errors[0].message,
+                    BarColumnChartBlock.ERROR_BAR_CHART_NO_ASPECT_RATIO,
+                    err.block_errors["options"].block_errors[0].code,
                 )
 
     def test_column_chart_aspect_ratio_options_are_allowed(self):


### PR DESCRIPTION
### What is the context of this PR?

There is no ticket for this work. It is refactoring and code cleanup for consistency and to reduce fragility.

- change some comparisons in business logic to use Enum constants (rather than their value strings)
- use named strings as error codes
- use error codes (rather than the message strings) for assertions in unit tests
- use capitalised names for constants (for consistency with changes added in #190)
- move bar-chart-only cleaning from the generic `BaseVisualisationBlock` to the child `BarAndColumnChartBlock`

### How to review

No functional changes. This needs code review and a passing test suite only.