### PR TITLE
Fix incorrect ToC on superseded pages

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -358,13 +358,13 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         # NB: Little validation is done on previous_version, as it's assumed handled on save
         revision = get_object_or_404(self.revisions, pk=correction.value["previous_version"])
 
-        revision_object = revision.as_object()
+        revision_page = revision.as_object()
 
         response: TemplateResponse = self.render(
             request,
             context_overrides={
-                "page": revision_object,
-                "table_of_contents": revision_object.table_of_contents,
+                "page": revision_page,
+                "table_of_contents": revision_page.table_of_contents,
                 "latest_version_url": self.get_url(request),
             },
         )

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -358,8 +358,15 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         # NB: Little validation is done on previous_version, as it's assumed handled on save
         revision = get_object_or_404(self.revisions, pk=correction.value["previous_version"])
 
+        revision_object = revision.as_object()
+
         response: TemplateResponse = self.render(
-            request, context_overrides={"page": revision.as_object(), "latest_version_url": self.get_url(request)}
+            request,
+            context_overrides={
+                "page": revision_object,
+                "table_of_contents": revision_object.table_of_contents,
+                "latest_version_url": self.get_url(request),
+            },
         )
 
         return response

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -275,12 +275,6 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         # At this stage we can override the figure ids to account for deleted ones
         self.update_headline_figures_figure_ids(figure_ids)
 
-    def get_context(self, request: "HttpRequest", *args: Any, **kwargs: Any) -> dict:
-        """Additional context for the template."""
-        context: dict = super().get_context(request, *args, **kwargs)
-        context["table_of_contents"] = self.table_of_contents
-        return context
-
     def get_admin_display_title(self) -> str:
         """Changes the admin display title to include the parent title."""
         return f"{self.get_parent().title}: {self.draft_title or self.title}"
@@ -358,13 +352,10 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
         # NB: Little validation is done on previous_version, as it's assumed handled on save
         revision = get_object_or_404(self.revisions, pk=correction.value["previous_version"])
 
-        revision_page = revision.as_object()
-
         response: TemplateResponse = self.render(
             request,
             context_overrides={
-                "page": revision_page,
-                "table_of_contents": revision_page.table_of_contents,
+                "page": revision.as_object(),
                 "latest_version_url": self.get_url(request),
             },
         )

--- a/cms/jinja2/templates/pages/statistical_article_page.html
+++ b/cms/jinja2/templates/pages/statistical_article_page.html
@@ -240,7 +240,7 @@
                     onsTableOfContents({
                         "title": toc_title,
                         "ariaLabel": toc_aria_label,
-                        "itemsList": table_of_contents,
+                        "itemsList": page.table_of_contents,
                         "relatedLinks": related_links,
                         "button": {
                             "text": _("Save or print this page")


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-481 and fixes an issue which caused the table of contents on superseded pages to use the latest version of the content rather than the one from the superseded page. In other words, instead of showing the original table of contents it would show the new table of contents.

Loom video:

https://www.loom.com/share/82b4d0f4646f421d939979fc51bbe527?sid=2768c670-b3f6-4948-a99a-a26a200b5c96

### How to review

1. Create a statistical article page
2. Add some content with specific section titles
3. Publish the article
4. Return to editing the article
5. Change a section title
6. Add a correction
7. Publish the article again
8. Confirm that the latest article has the correct, new ToC (correct section names)
9. Confirm that the superseded article has the correct, original ToC (correct section names)



### Follow-up Actions

N/A