### PR TITLE
Slim down packages used for LaTeX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Install dependencies
         run: |
           make install-dev
-          sudo apt-get install -y gettext texlive-latex-extra texlive-fonts-recommended cm-super
+          sudo apt-get install -y gettext texlive-latex-extra
 
       - uses: actions/download-artifact@v4
         with:
@@ -225,7 +225,7 @@ jobs:
       - name: Install dependencies
         run: |
           make install-dev
-          sudo apt-get install -y gettext texlive-latex-extra texlive-fonts-recommended cm-super
+          sudo apt-get install -y gettext texlive-latex-extra
 
       - name: Playwright Install
         run: poetry run python -m playwright install --with-deps ${{ matrix.browser }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,6 @@ RUN apt --quiet --yes update \
         unzip \
         gettext \
         texlive-latex-extra \
-        texlive-fonts-recommended \
-        cm-super \
         postgresql-common \
     # Install the Postgres repo
     && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-515 and an issue originally raised by @kacperpONS.

`texlive-fonts-recommended` is included in `texlive-latex-extra`, and `cm-super` doesn't seem to be needed currently.

Reference: https://tex.stackexchange.com/questions/245982/differences-between-texlive-packages-in-linux/504566#504566

### How to review

Ensure that equation generation still works.

### Follow-up Actions

Reconsider whether `cm-super` is needed: https://ctan.org/pkg/cm-super
