### PR TITLE
Scatter Plot on Statistical Article and Methodology pages only

### DIFF
--- a/cms/core/blocks/section_blocks.py
+++ b/cms/core/blocks/section_blocks.py
@@ -18,7 +18,7 @@ from cms.core.blocks import (
 )
 from cms.core.blocks.glossary_terms import GlossaryTermsBlock
 from cms.core.blocks.markup import ONSTableBlock
-from cms.datavis.blocks import BarColumnChartBlock, LineChartBlock
+from cms.datavis.blocks import BarColumnChartBlock, LineChartBlock, ScatterPlotBlock
 
 if TYPE_CHECKING:
     from wagtail.blocks import StructValue
@@ -43,6 +43,7 @@ class SectionContentBlock(StreamBlock):
 
     line_chart = LineChartBlock(group="DataVis", label="Line Chart")
     bar_column_chart = BarColumnChartBlock(group="DataVis", label="Bar/Column Chart")
+    scatter_plot = ScatterPlotBlock(group="DataVis", label="Scatter Plot")
 
     class Meta:
         template = "templates/components/streamfield/stream_block.html"

--- a/cms/core/blocks/stream_blocks.py
+++ b/cms/core/blocks/stream_blocks.py
@@ -17,7 +17,7 @@ from cms.core.blocks import (
     WarningPanelBlock,
 )
 from cms.core.blocks.section_blocks import SectionBlock
-from cms.datavis.blocks import BarColumnChartBlock, LineChartBlock, ScatterPlotBlock
+from cms.datavis.blocks import BarColumnChartBlock, LineChartBlock
 
 if TYPE_CHECKING:
     from wagtail.blocks import StreamValue
@@ -59,7 +59,6 @@ class CoreStoryBlock(StreamBlock):
 
     line_chart = LineChartBlock(group="DataVis", label="Line Chart")
     bar_column_chart = BarColumnChartBlock(group="DataVis", label="Bar/Column Chart")
-    scatter_plot = ScatterPlotBlock(group="DataVis", label="Scatter Plot")
 
     class Meta:
         block_counts: ClassVar[dict[str, dict]] = {"related_links": {"max_num": 1}}


### PR DESCRIPTION
### What is the context of this PR?

Following the recent merge of #200 and #205, enable Scatter Plot on the future planned page types only.
