### PR TITLE
Use h3 element for chart headings (and h4 for subheadings)

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -151,6 +151,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
         config = {
             "chartType": self.get_highcharts_chart_type(value),
             "theme": value.get("theme"),
+            "headingLevel": 3,
             "title": value.get("title"),
             "subtitle": value.get("subtitle"),
             "caption": value.get("caption"),


### PR DESCRIPTION
### What is the context of this PR?

From the ticket https://jira.ons.gov.uk/browse/CCB-134:

> The chart component is generally used in a Section block, where each section begins with heading level 2.
Headings level 3 and 4 can be inserted within a Section block.
> 
> The chart component therefore needs to have heading level 3. We discussed in refinement on 4 June that there is no need for now for editors to have a choice of chart component heading level.

The `headingLevel` parameter is supported by the onsChart macro, see https://github.com/ONSdigital/design-system/blob/main/src/components/chart/_macro-options.md. This PR hard-codes that value.