### PR TITLE
Reference line annotation

### DIFF
--- a/cms/core/wagtail_hooks.py
+++ b/cms/core/wagtail_hooks.py
@@ -33,6 +33,8 @@ def register_icons(icons: list[str]) -> list[str]:
         "wagtailfontawesomesvg/solid/chart-line.svg",
         "wagtailfontawesomesvg/solid/chart-area.svg",
         "wagtailfontawesomesvg/solid/table-cells.svg",
+        "wagtailfontawesomesvg/solid/location-crosshairs.svg",
+        "wagtailfontawesomesvg/solid/square.svg",
     ]
 
 

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -11,6 +11,9 @@ from cms.datavis.blocks.table import SimpleTableBlock
 from cms.datavis.blocks.utils import TextInputFloatBlock
 from cms.datavis.constants import AxisType, HighChartsChartType, HighchartsTheme
 
+AnnotationsList = list[dict[str, Any]]
+AnnotationsReturn = tuple[AnnotationsList, AnnotationsList, AnnotationsList]
+
 
 class BaseVisualisationBlock(blocks.StructBlock):
     # Extra attributes for subclasses
@@ -162,11 +165,13 @@ class BaseVisualisationBlock(blocks.StructBlock):
             "download": self.get_download_config(value),
         }
 
-        point_annotations, range_annotations = self.get_annotations_config(value)
+        point_annotations, range_annotations, line_annotations = self.get_annotations_config(value)
         if point_annotations:
             config["annotations"] = point_annotations
         if range_annotations:
             config["rangeAnnotations"] = range_annotations
+        if line_annotations:
+            config["referenceLineAnnotations"] = line_annotations
 
         config.update(self.get_additional_options(value))
         return config
@@ -225,9 +230,10 @@ class BaseVisualisationBlock(blocks.StructBlock):
             config["max"] = max_value
         return config
 
-    def get_annotations_config(self, value: "StructValue") -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        annotations_values: list[dict[str, Any]] = []
-        range_annotations_values: list[dict[str, Any]] = []
+    def get_annotations_config(self, value: "StructValue") -> AnnotationsReturn:
+        annotations_values: AnnotationsList = []
+        range_annotations_values: AnnotationsList = []
+        line_annotations_values: AnnotationsList = []
 
         for item in value.get("annotations", []):
             config = item.value.get_config()
@@ -236,10 +242,12 @@ class BaseVisualisationBlock(blocks.StructBlock):
                     annotations_values.append(config)
                 case "range":
                     range_annotations_values.append(config)
+                case "reference_line":
+                    line_annotations_values.append(config)
                 case _:
                     raise ValueError(f"Unknown annotation type: {item.block_type}")
 
-        return annotations_values, range_annotations_values
+        return annotations_values, range_annotations_values, line_annotations_values
 
     def get_series_data(
         self,

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -8,6 +8,9 @@ from django.forms import widgets
 from wagtail import blocks
 
 from cms.datavis.blocks.annotations import (
+    LineAnnotationBarColumnBlock,
+    LineAnnotationCategoricalBlock,
+    LineAnnotationLinearBlock,
     PointAnnotationCategoricalBlock,
     PointAnnotationLinearBlock,
     RangeAnnotationBarColumnBlock,
@@ -41,6 +44,7 @@ class LineChartBlock(BaseVisualisationBlock):
         [
             ("point", PointAnnotationCategoricalBlock()),
             ("range", RangeAnnotationCategoricalBlock()),
+            ("reference_line", LineAnnotationCategoricalBlock()),
         ],
         required=False,
     )
@@ -66,6 +70,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         [
             ("point", PointAnnotationCategoricalBlock()),
             ("range", RangeAnnotationBarColumnBlock()),
+            ("reference_line", LineAnnotationBarColumnBlock()),
         ],
         required=False,
     )
@@ -241,6 +246,7 @@ class ScatterPlotBlock(BaseVisualisationBlock):
         [
             ("point", PointAnnotationLinearBlock()),
             ("range", RangeAnnotationLinearBlock()),
+            ("reference_line", LineAnnotationLinearBlock()),
         ],
         required=False,
     )
@@ -284,6 +290,7 @@ class AreaChartBlock(BaseVisualisationBlock):
         [
             ("point", PointAnnotationCategoricalBlock()),
             ("range", RangeAnnotationCategoricalBlock()),
+            ("reference_line", LineAnnotationCategoricalBlock()),
         ],
         required=False,
     )

--- a/cms/datavis/tests/test_annotations_line.py
+++ b/cms/datavis/tests/test_annotations_line.py
@@ -1,0 +1,133 @@
+from wagtail import blocks
+
+from cms.datavis.blocks.annotations import (
+    LineAnnotationCategoricalBlock,
+    LineAnnotationLinearBlock,
+)
+from cms.datavis.constants import AxisChoices
+from cms.datavis.tests.test_annotations_base import BaseAnnotationTestCase
+
+
+class GenericLineAnnotationTestCase(BaseAnnotationTestCase):
+    block_type = LineAnnotationLinearBlock
+
+    def test_basic(self):
+        raw_data = {
+            "label": "Nottingham Marjorie",
+            "axis": "x",
+            "value": 2,
+            "label_width": 150,
+            "label_offset_x": None,
+            "label_offset_y": None,
+        }
+        try:
+            self.block.clean(self.get_value(raw_data))
+        except blocks.StructBlockValidationError as e:
+            self.fail(f"ValidationError raised: {e.block_errors}")
+
+        config = self.get_config(raw_data)
+        self.assertEqual("Nottingham Marjorie", config["text"])
+        self.assertEqual(AxisChoices.X, config["axis"])
+        self.assertEqual(2, config["value"])
+        self.assertEqual(150, config["labelWidth"])
+        self.assertNotIn("labelOffsetX", config)
+        self.assertNotIn("labelOffsetY", config)
+
+    def test_with_custom_label_positioning(self):
+        raw_data = {
+            "label": "Strathcarnage",
+            "axis": "y",
+            "value": 3,
+            "label_width": 150,
+            "label_offset_x": 100,
+            "label_offset_y": 90,
+        }
+
+        try:
+            self.block.clean(self.get_value(raw_data))
+        except blocks.StructBlockValidationError as e:
+            self.fail(f"ValidationError raised: {e.block_errors}")
+
+        config = self.get_config(raw_data)
+        self.assertEqual("Strathcarnage", config["text"])
+        self.assertEqual(AxisChoices.Y, config["axis"])
+        self.assertEqual(3, config["value"])
+        self.assertEqual(150, config["labelWidth"])
+        self.assertEqual(100, config["labelOffsetX"])
+        self.assertEqual(-90, config["labelOffsetY"])  # Y-axis is inverted
+
+
+class LineAnnotationCategoricalTestCase(BaseAnnotationTestCase):
+    block_type = LineAnnotationCategoricalBlock
+
+    def test_x_axis_values_must_be_integers(self):
+        raw_data = {
+            "label": "Taste of Dunfermline",
+            "axis": "x",
+            "value": 3.5,
+            "label_width": 150,
+            "label_offset_x": None,
+            "label_offset_y": None,
+        }
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value(raw_data))
+        self.assertEqual(1, len(cm.exception.block_errors))
+        self.assertIn("value", cm.exception.block_errors)
+        self.assertEqual(self.block.ERROR_X_AXIS_MUST_BE_INTEGER, cm.exception.block_errors["value"].code)
+
+    def test_x_axis_is_one_indexed(self):
+        raw_data = {
+            "label": "Taste of Dunfermline",
+            "axis": "x",
+            "value": 2,
+            "label_width": 150,
+            "label_offset_x": None,
+            "label_offset_y": None,
+        }
+        try:
+            self.block.clean(self.get_value(raw_data))
+        except blocks.StructBlockValidationError as e:
+            self.fail(f"ValidationError raised: {e.block_errors}")
+
+        config = self.get_config(raw_data)
+        self.assertEqual(1, config["value"])  # 1-based UI, 0-based component
+
+    def test_y_axis_value_can_be_float(self):
+        raw_data = {
+            "label": "Sheffield Bonanza",
+            "axis": "y",
+            "value": 3.5,
+            "label_width": 150,
+            "label_offset_x": None,
+            "label_offset_y": None,
+        }
+        try:
+            self.block.clean(self.get_value(raw_data))
+        except blocks.StructBlockValidationError as e:
+            self.fail(f"ValidationError raised: {e.block_errors}")
+
+        config = self.get_config(raw_data)
+        self.assertEqual(3.5, config["value"])
+
+
+class LineAnnotationLinearTestCase(BaseAnnotationTestCase):
+    block_type = LineAnnotationLinearBlock
+
+    def test_linear_values(self):
+        base_raw_data = {
+            "label": "Jam",
+            "value": 3.5,
+            "label_width": 150,
+            "label_offset_x": None,
+            "label_offset_y": None,
+        }
+
+        for axis in AxisChoices:
+            with self.subTest(axis=axis):
+                try:
+                    self.block.clean(self.get_value({**base_raw_data, "axis": axis.value}))
+                except blocks.StructBlockValidationError as e:
+                    self.fail(f"ValidationError raised: {e.block_errors}")
+
+                config = self.get_config({**base_raw_data, "axis": axis.value})
+                self.assertEqual(3.5, config["value"])


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/CCB-55

### How to review

On a chart block, under "annotations" select "reference line".

<details><summary>Screenshots</summary>
<p>

![image](https://github.com/user-attachments/assets/7a4d89fa-907c-4e94-a83f-600c871d8285)

![image](https://github.com/user-attachments/assets/f79261d5-d926-46c7-ab81-3f37edb549b3)


</p>
</details>  

> [!NOTE]
> There is a bug in the DS at the moment: x-axis (or "category axis" for bar/column charts) reference lines are only displayed if there is a y-axis (or "value axis") reference line. This is fixed in https://github.com/ONSdigital/design-system/pull/3619. For now, a workaround is to create a y-axis reference line but at a value that is not shown on the chart.

### Follow-up Actions

Update the DS version to fix the above bug, once an update is released.