### PR TITLE
Remove charts from CoreStoryBlock

### DIFF
--- a/cms/core/blocks/stream_blocks.py
+++ b/cms/core/blocks/stream_blocks.py
@@ -17,7 +17,6 @@ from cms.core.blocks import (
 )
 from cms.core.blocks.equation import EquationBlock
 from cms.core.blocks.section_blocks import SectionBlock
-from cms.datavis.blocks import BarColumnChartBlock, LineChartBlock
 
 if TYPE_CHECKING:
     from wagtail.blocks import StreamValue
@@ -56,9 +55,6 @@ class CoreStoryBlock(StreamBlock):
     table = ONSTableBlock(group="DataVis", allow_links=True)
     equation = EquationBlock(group="DataVis", icon="decimal")
     ons_embed = ONSEmbedBlock(group="DataVis", label="ONS General Embed")
-
-    line_chart = LineChartBlock(group="DataVis", label="Line Chart")
-    bar_column_chart = BarColumnChartBlock(group="DataVis", label="Bar/Column Chart")
 
     class Meta:
         block_counts: ClassVar[dict[str, dict]] = {"related_links": {"max_num": 1}}


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/CCB-124

This removes charts from InformationPage, and any other page type using CoreStoryBlock. In #200, charts were added to StatisticalArticlePage, and were only left in place on InformationPage as a concession to anyone testing current tickets. Any new chart types have been added to StatisticalArticlePage only.

Now that a couple of weeks have passed, it's fine to complete the move. The chart project team is aware of this change.