### PR TITLE
Enable bar/column chart with confidence intervals

### DIFF
--- a/cms/core/blocks/section_blocks.py
+++ b/cms/core/blocks/section_blocks.py
@@ -18,7 +18,13 @@ from cms.core.blocks import (
 from cms.core.blocks.equation import EquationBlock
 from cms.core.blocks.glossary_terms import GlossaryTermsBlock
 from cms.core.blocks.markup import ONSTableBlock
-from cms.datavis.blocks import AreaChartBlock, BarColumnChartBlock, LineChartBlock, ScatterPlotBlock
+from cms.datavis.blocks import (
+    AreaChartBlock,
+    BarColumnChartBlock,
+    BarColumnConfidenceIntervalChartBlock,
+    LineChartBlock,
+    ScatterPlotBlock,
+)
 
 if TYPE_CHECKING:
     from wagtail.blocks import StructValue
@@ -43,6 +49,9 @@ class SectionContentBlock(StreamBlock):
 
     line_chart = LineChartBlock(group="DataVis", label="Line Chart")
     bar_column_chart = BarColumnChartBlock(group="DataVis", label="Bar/Column Chart")
+    bar_column_confidence_interval_chart = BarColumnConfidenceIntervalChartBlock(
+        group="DataVis", label="Bar/Column Chart with Confidence Intervals"
+    )
     scatter_plot = ScatterPlotBlock(group="DataVis", label="Scatter Plot")
     area_chart = AreaChartBlock(group="DataVis", label="Area Chart")
 

--- a/cms/datavis/blocks/__init__.py
+++ b/cms/datavis/blocks/__init__.py
@@ -1,8 +1,15 @@
-from .charts import AreaChartBlock, BarColumnChartBlock, LineChartBlock, ScatterPlotBlock
+from .charts import (
+    AreaChartBlock,
+    BarColumnChartBlock,
+    BarColumnConfidenceIntervalChartBlock,
+    LineChartBlock,
+    ScatterPlotBlock,
+)
 
 __all__ = [
     "AreaChartBlock",
     "BarColumnChartBlock",
+    "BarColumnConfidenceIntervalChartBlock",
     "LineChartBlock",
     "ScatterPlotBlock",
 ]

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -302,23 +302,27 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
 
     def get_component_config(self, value: "StructValue") -> dict[str, Any]:
         config = super().get_component_config(value)
-        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.BAR:
-            config["isChartInverted"] = True
-        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
-            config["estimateLineLabel"] = value.get("estimate_line_label")
-            config["uncertaintyRangeLabel"] = value.get("uncertainty_range_label")
+        match value["select_chart_type"]:
+            case BarColumnConfidenceIntervalChartTypeChoices.BAR:
+                config["isChartInverted"] = True
+            case BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
+                config["estimateLineLabel"] = value.get("estimate_line_label")
+                config["uncertaintyRangeLabel"] = value.get("uncertainty_range_label")
+            case _:
+                raise ValueError(f"Unknown chart type: {value['select_chart_type']}")
         return config
 
     def get_series_data(
         self,
         value: "StructValue",
     ) -> tuple[list[list[str | int | float]], list[dict[str, Any]]]:
-        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.BAR:
-            series = self.get_series_data_bar(value)
-        elif value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
-            series = self.get_series_data_column(value)
-        else:
-            raise ValueError(f"Unknown chart type: {value['select_chart_type']}")
+        match value["select_chart_type"]:
+            case BarColumnConfidenceIntervalChartTypeChoices.BAR:
+                series = self.get_series_data_bar(value)
+            case BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
+                series = self.get_series_data_column(value)
+            case _:
+                raise ValueError(f"Unknown chart type: {value['select_chart_type']}")
         return value["table"].rows, series
 
     def get_series_data_bar(self, value: "StructValue") -> list[dict[str, Any]]:

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.core.exceptions import ValidationError
-from django.db.models import TextChoices
 from django.forms import widgets
 from wagtail import blocks
 
@@ -17,7 +16,12 @@ from cms.datavis.blocks.annotations import (
 from cms.datavis.blocks.base import BaseVisualisationBlock
 from cms.datavis.blocks.table import SimpleTableBlock, TableDataType
 from cms.datavis.blocks.utils import TextInputFloatBlock, TextInputIntegerBlock
-from cms.datavis.constants import AxisType, HighChartsChartType
+from cms.datavis.constants import (
+    AxisType,
+    BarColumnChartTypeChoices,
+    BarColumnConfidenceIntervalChartTypeChoices,
+    HighChartsChartType,
+)
 
 if TYPE_CHECKING:
     from wagtail.blocks.struct_block import StructValue
@@ -70,14 +74,10 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         required=False,
     )
 
-    class ChartTypeChoices(TextChoices):
-        BAR = "bar", "Bar"
-        COLUMN = "column", "Column"
-
     # Block overrides
     select_chart_type = blocks.ChoiceBlock(
-        choices=ChartTypeChoices.choices,
-        default=ChartTypeChoices.BAR,
+        choices=BarColumnChartTypeChoices.choices,
+        default=BarColumnChartTypeChoices.BAR,
         label="Display as",
         widget=widgets.RadioSelect,
     )
@@ -158,7 +158,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         seen_series_numbers = set()
         for i, block in enumerate(value.get("series_customisation", [])):
             if block.block_type == self.SERIES_AS_LINE_OVERLAY_BLOCK:
-                if value.get("select_chart_type") == self.ChartTypeChoices.BAR:
+                if value.get("select_chart_type") == BarColumnChartTypeChoices.BAR:
                     stream_block_errors[i] = ValidationError(
                         "Horizontal bar charts do not support line overlays.", code=self.ERROR_HORIZONTAL_BAR_NO_LINE
                     )
@@ -195,7 +195,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
 
         errors = {}
         options_errors = {}
-        if self.get_highcharts_chart_type(value) == self.ChartTypeChoices.BAR:
+        if self.get_highcharts_chart_type(value) == BarColumnChartTypeChoices.BAR:
             for i, option in enumerate(value["options"]):
                 if option.block_type in aspect_ratio_keys:
                     options_errors[i] = ValidationError(
@@ -204,6 +204,206 @@ class BarColumnChartBlock(BaseVisualisationBlock):
 
         if options_errors:
             errors["options"] = blocks.StreamBlockValidationError(block_errors=options_errors)
+
+        if errors:
+            raise blocks.StructBlockValidationError(block_errors=errors)
+
+        return value
+
+
+class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
+    x_axis_type = AxisType.CATEGORICAL
+
+    # Error codes
+    ERROR_BAR_CHART_NO_ASPECT_RATIO = "bar_chart_no_aspect_ratio"
+    ERROR_UNMATCHED_RANGE = "unmatched_range"
+    ERROR_INSUFFICIENT_COLUMNS = "insufficient_columns"
+    ERROR_NON_NUMERIC_VALUE = "non_numeric_value"
+
+    # Table data settings
+    INITIAL_COLUMN_HEADINGS: tuple[str, ...] = ("Category", "Value", "Range min", "Range max")
+    REQUIRED_COLUMN_COUNT = len(INITIAL_COLUMN_HEADINGS)
+    TABLE_DEFAULT_DATA: TableDataType = (
+        list(INITIAL_COLUMN_HEADINGS),
+        ["", "", "", ""],
+        ["", "", "", ""],
+    )
+
+    # Remove unsupported features
+    show_markers = None
+    use_stacked_layout = None
+    show_legend = None  # Legend is editable differently for confidence interval charts
+    show_data_labels = None
+    theme = None
+
+    annotations = blocks.StreamBlock(
+        [
+            ("point", PointAnnotationCategoricalBlock()),
+            ("range", RangeAnnotationBarColumnBlock()),
+            # TODO: add reference line annotation when https://github.com/ONSdigital/dis-wagtail/pull/232 is merged
+        ],
+        required=False,
+    )
+
+    # Block overrides
+    table = SimpleTableBlock(
+        label="Data",
+        help_text=(
+            "Data is interpreted as four columns: Category, Value, Range min, Range max. "
+            "Column headings in row 1 are ignored. Other columns are ignored."
+        ),
+        default={"table_data": json.dumps({"data": TABLE_DEFAULT_DATA})},
+    )
+    select_chart_type = blocks.ChoiceBlock(
+        choices=BarColumnConfidenceIntervalChartTypeChoices.choices,
+        default=BarColumnConfidenceIntervalChartTypeChoices.BAR,
+        label="Display as",
+        widget=widgets.RadioSelect,
+    )
+    # NB X_axis is labelled "Category axis" for bar/column charts
+    x_axis = blocks.StructBlock(
+        [
+            (
+                "note",
+                blocks.StaticBlock(
+                    admin_text="(Temporary change) No options currently available for the category axis.",
+                ),
+            ),
+        ],
+        label="Category axis",
+    )
+    # NB Y_axis is labelled "Value axis" for bar/column charts
+    y_axis = blocks.StructBlock(
+        [
+            (
+                "title",
+                blocks.CharBlock(
+                    required=False,
+                    help_text="Only use axis titles if it is not clear from the title "
+                    "and subtitle what the axis represents.",
+                ),
+            ),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+        ],
+        label="Value axis",
+    )
+    estimate_line_label = blocks.CharBlock(
+        required=True,
+        help_text="Label for the estimate line in the legend",
+    )
+    uncertainty_range_label = blocks.CharBlock(
+        required=True,
+        help_text="Label for the uncertainty range in the legend",
+    )
+
+    class Meta:
+        icon = "chart-column"
+
+    def get_component_config(self, value: "StructValue") -> dict[str, Any]:
+        config = super().get_component_config(value)
+        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.BAR:
+            config["isChartInverted"] = True
+        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
+            config["estimateLineLabel"] = value.get("estimate_line_label")
+            config["uncertaintyRangeLabel"] = value.get("uncertainty_range_label")
+        return config
+
+    def get_series_data(
+        self,
+        value: "StructValue",
+    ) -> tuple[list[list[str | int | float]], list[dict[str, Any]]]:
+        if value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.BAR:
+            series = self.get_series_data_bar(value)
+        elif value["select_chart_type"] == BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
+            series = self.get_series_data_column(value)
+        else:
+            raise ValueError(f"Unknown chart type: {value['select_chart_type']}")
+        return value["table"].rows, series
+
+    def get_series_data_bar(self, value: "StructValue") -> list[dict[str, Any]]:
+        values: list[str | int | float] = []
+        confidence_intervals: list[tuple[str | int | float, str | int | float]] = []
+
+        for row in value["table"].rows:
+            confidence_intervals.append((row[2], row[3]))
+            values.append(row[1])
+
+        return [
+            {
+                "name": value.get("uncertainty_range_label"),
+                "data": confidence_intervals,
+            },
+            {
+                "name": value.get("estimate_line_label"),
+                "data": values,
+                "marker": True,
+                "type": "scatter",
+            },
+        ]
+
+    def get_series_data_column(self, value: "StructValue") -> list[dict[str, Any]]:
+        return [
+            {
+                # Box plots are in the format
+                # [whisker min, box bottom, centre line, box top, whisker max].
+                # We do not render the whiskers, so we set them to the same as the
+                # box extents.
+                "data": [(row[2], row[2], row[1], row[3], row[3]) for row in value["table"].rows],
+            }
+        ]
+
+    def clean(self, value: "StructValue") -> "StructValue":
+        value = super().clean(value)
+        value = self.clean_options(value)
+        value = self.clean_table(value)
+        return value
+
+    def clean_options(self, value: "StructValue") -> "StructValue":
+        aspect_ratio_keys = [self.DESKTOP_ASPECT_RATIO, self.MOBILE_ASPECT_RATIO]
+
+        errors = {}
+        options_errors = {}
+        if self.get_highcharts_chart_type(value) == BarColumnConfidenceIntervalChartTypeChoices.BAR:  # Bar chart
+            for i, option in enumerate(value["options"]):
+                if option.block_type in aspect_ratio_keys:
+                    options_errors[i] = ValidationError(
+                        "Bar charts do not support aspect ratio options.", code=self.ERROR_BAR_CHART_NO_ASPECT_RATIO
+                    )
+
+        if options_errors:
+            errors["options"] = blocks.StreamBlockValidationError(block_errors=options_errors)
+
+        if errors:
+            raise blocks.StructBlockValidationError(block_errors=errors)
+
+        return value
+
+    def clean_table(self, value: "StructValue") -> "StructValue":
+        errors = {}
+        # Category, Value, Range min, Range max
+        if len(value["table"].headers) < self.REQUIRED_COLUMN_COUNT:
+            errors["table"] = ValidationError(
+                f"Data table must have {self.REQUIRED_COLUMN_COUNT} columns: Category, Value, Range min, Range max",
+                code=self.ERROR_INSUFFICIENT_COLUMNS,
+            )
+
+        else:
+            # We can only validate the range values if we have 4 columns.
+            # Validate that range values are either both present or both absent
+            for row in value["table"].rows:
+                if any((isinstance(cell, str) and cell.strip()) for cell in row[1:4]):
+                    errors["table"] = ValidationError(
+                        f'Non-numeric values in category "{row[0]}"',
+                        code=self.ERROR_NON_NUMERIC_VALUE,
+                    )
+
+                if (row[2] == "") != (row[3] == ""):
+                    errors["table"] = ValidationError(
+                        f'Unmatched range for category "{row[0]}". Enter both '
+                        "lower and upper limits, or leave both blank.",
+                        code=self.ERROR_UNMATCHED_RANGE,
+                    )
 
         if errors:
             raise blocks.StructBlockValidationError(block_errors=errors)

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -306,6 +306,8 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
             case BarColumnConfidenceIntervalChartTypeChoices.BAR:
                 config["isChartInverted"] = True
             case BarColumnConfidenceIntervalChartTypeChoices.COLUMN:
+                # A box plot in Highcharts is a single series; therefore we use
+                # custom component parameters to set the legend labels.
                 config["estimateLineLabel"] = value.get("estimate_line_label")
                 config["uncertaintyRangeLabel"] = value.get("uncertainty_range_label")
             case _:
@@ -392,9 +394,8 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
                 code=self.ERROR_INSUFFICIENT_COLUMNS,
             )
 
-        else:
-            # We can only validate the range values if we have 4 columns.
-            # Validate that range values are either both present or both absent
+        else:  # Only perform row-level validation if we have the expected number of columns.
+            # Validate that range values are either both present or both absent.
             for row in value["table"].rows:
                 if any((isinstance(cell, str) and cell.strip()) for cell in row[1:4]):
                     errors["table"] = ValidationError(

--- a/cms/datavis/constants.py
+++ b/cms/datavis/constants.py
@@ -31,3 +31,17 @@ class BarColumnAxisChoices(TextChoices):
 
     CATEGORY = "x", "Category axis"
     VALUE = "y", "Value axis"
+
+
+class BarColumnChartTypeChoices(TextChoices):
+    """Chart type choices for bar/column charts."""
+
+    BAR = "bar", "Bar"
+    COLUMN = "column", "Column"
+
+
+class BarColumnConfidenceIntervalChartTypeChoices(TextChoices):
+    """Chart type choices for bar/column charts with confidence intervals."""
+
+    BAR = "columnrange", "Bar"
+    COLUMN = "boxplot", "Column"

--- a/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
@@ -1,0 +1,252 @@
+from typing import cast
+
+from django.core.exceptions import ValidationError
+from wagtail import blocks
+from wagtail.blocks.struct_block import StructValue
+
+from cms.datavis.blocks.charts import BarColumnConfidenceIntervalChartBlock
+from cms.datavis.constants import BarColumnConfidenceIntervalChartTypeChoices
+from cms.datavis.tests.factories import TableDataFactory
+from cms.datavis.tests.test_chart_blocks_base import BaseChartBlockTestCase
+
+
+class BarColumnConfidenceIntervalChartBlockTestCase(BaseChartBlockTestCase):
+    block_type = BarColumnConfidenceIntervalChartBlock
+
+    def setUp(self):
+        super().setUp()
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["Category", "Value", "Range min", "Range max"],
+                ["2005", "100", "90", "110"],
+                ["2006", "120", "110", "130"],
+                ["2007", "140", "130", "150"],
+            ]
+        )
+        del self.raw_data["theme"]
+        self.raw_data["estimate_line_label"] = "Estimate"
+        self.raw_data["uncertainty_range_label"] = "Uncertainty range"
+
+    def test_generic_properties(self):
+        self._test_generic_properties()
+
+    def test_get_component_config(self):
+        self._test_get_component_config()
+
+    def test_selectable_chart_type(self):
+        with self.assertRaises(AttributeError):
+            self.block.highcharts_chart_type  # noqa: B018, pylint: disable=pointless-statement
+        for chart_type in BarColumnConfidenceIntervalChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                data = self.raw_data.copy()
+                data["select_chart_type"] = chart_type
+                value = self.get_value(data)
+                self.assertEqual(chart_type, value.block.get_highcharts_chart_type(value))
+                try:
+                    self.block.clean(value)
+                except ValidationError as e:
+                    self.fail(f"ValidationError raised: {e}")
+
+    def test_validating_data(self):
+        """Test that the data we're using for these unit tests is good."""
+        value = self.get_value()
+        self.assertIsInstance(value, StructValue)
+        try:
+            self.block.clean(value)
+        except ValidationError as e:
+            self.fail(f"ValidationError raised: {e}")
+
+    def test_invalid_data(self):
+        """Validate that these tests can detect invalid data."""
+        invalid_data = self.raw_data.copy()
+        invalid_data["title"] = ""  # Required field
+        value = self.get_value(invalid_data)
+        with self.assertRaises(ValidationError, msg="Expected ValidationError for missing title"):
+            self.block.clean(value)
+
+    def test_bar_chart_series_data(self):
+        """Test bar chart data is formatted correctly.
+
+        Bar chart data should be two series: columnrange for the bars, and
+        scatter for the points.
+        """
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+        config = self.get_component_config()
+        self.assertEqual(2, len(config["series"]))
+
+        # Check uncertainty range series
+        self.assertEqual("Uncertainty range", config["series"][0]["name"])
+        self.assertEqual([(90, 110), (110, 130), (130, 150)], config["series"][0]["data"])
+
+        # Check estimate line series
+        self.assertEqual("Estimate", config["series"][1]["name"])
+        self.assertEqual([100, 120, 140], config["series"][1]["data"])
+        self.assertTrue(config["series"][1]["marker"])
+        self.assertEqual("scatter", config["series"][1]["type"])
+
+    def test_column_chart_series_data(self):
+        """Test that column chart data is formatted correctly.
+
+        Column chart data should be one boxplot series for the points, where:
+        - min = lower quartile
+        - max = upper quartile
+        """
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.COLUMN
+        config = self.get_component_config()
+        self.assertEqual(1, len(config["series"]))
+
+        # Check box plot series
+        self.assertEqual(
+            [(90, 90, 100, 110, 110), (110, 110, 120, 130, 130), (130, 130, 140, 150, 150)],
+            config["series"][0]["data"],
+        )
+        self.assertEqual("Estimate", config["estimateLineLabel"])
+        self.assertEqual("Uncertainty range", config["uncertaintyRangeLabel"])
+
+    def test_custom_legend_labels(self):
+        """Test that custom legend labels are used when provided."""
+        self.raw_data["estimate_line_label"] = "Custom Estimate"
+        self.raw_data["uncertainty_range_label"] = "Custom Range"
+
+        with self.subTest(chart_type="bar chart"):
+            self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+            config = self.get_component_config()
+            self.assertEqual("Custom Estimate", config["series"][1]["name"])
+            self.assertEqual("Custom Range", config["series"][0]["name"])
+
+        with self.subTest(chart_type="column chart"):
+            self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.COLUMN
+            config = self.get_component_config()
+            self.assertEqual("Custom Estimate", config["estimateLineLabel"])
+            self.assertEqual("Custom Range", config["uncertaintyRangeLabel"])
+
+    def test_unmatched_range_validation(self):
+        """Test that validation fails when range values are unmatched."""
+        bad_cases = [
+            (
+                "Missing min",
+                TableDataFactory(
+                    table_data=[
+                        ["Category", "Value", "Range min", "Range max"],
+                        ["2005", "100", "", "110"],
+                    ]
+                ),
+            ),
+            (
+                "Missing max",
+                TableDataFactory(
+                    table_data=[
+                        ["Category", "Value", "Range min", "Range max"],
+                        ["2005", "100", "90", ""],
+                    ]
+                ),
+            ),
+        ]
+        for case, bad_table_data in bad_cases:
+            invalid_data = self.raw_data.copy()
+            invalid_data["table"] = bad_table_data
+            value = self.get_value(invalid_data)
+            with self.subTest(bad_case=case):
+                with self.assertRaises(blocks.StructBlockValidationError) as cm:
+                    self.block.clean(value)
+
+                self.assertEqual(
+                    BarColumnConfidenceIntervalChartBlock.ERROR_UNMATCHED_RANGE, cm.exception.block_errors["table"].code
+                )
+
+    def test_non_numeric_values_validation(self):
+        """Test that validation fails when non-numeric values are present."""
+        bad_cases = [
+            (
+                "non-numeric value",
+                TableDataFactory(
+                    table_data=[
+                        ["Category", "Value", "Range min", "Range max"],
+                        ["2005", "eggs", "90", "110"],
+                    ]
+                ),
+            ),
+            (
+                "non-numeric min",
+                TableDataFactory(
+                    table_data=[
+                        ["Category", "Value", "Range min", "Range max"],
+                        ["2005", "100", "fish", "110"],
+                    ]
+                ),
+            ),
+            (
+                "non-numeric max",
+                TableDataFactory(
+                    table_data=[
+                        ["Category", "Value", "Range min", "Range max"],
+                        ["2005", "100", "90", "jam"],
+                    ]
+                ),
+            ),
+        ]
+        for case, bad_table_data in bad_cases:
+            invalid_data = self.raw_data.copy()
+            invalid_data["table"] = bad_table_data
+            value = self.get_value(invalid_data)
+            with self.subTest(bad_case=case):
+                with self.assertRaises(blocks.StructBlockValidationError) as cm:
+                    self.block.clean(value)
+                self.assertEqual(
+                    BarColumnConfidenceIntervalChartBlock.ERROR_NON_NUMERIC_VALUE,
+                    cm.exception.block_errors["table"].code,
+                )
+
+    def test_insufficient_columns_validation(self):
+        """Test that validation fails when there are fewer than 4 columns."""
+        invalid_data = self.raw_data.copy()
+        invalid_data["table"] = TableDataFactory(
+            table_data=[
+                ["Category", "Value", "Range min"],  # Missing Range max
+                ["2005", "100", "90"],
+                ["2006", "120", "110"],
+                ["2007", "140", "130"],
+            ]
+        )
+        value = self.get_value(invalid_data)
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(value)
+
+        self.assertEqual(
+            BarColumnConfidenceIntervalChartBlock.ERROR_INSUFFICIENT_COLUMNS, cm.exception.block_errors["table"].code
+        )
+
+    def test_bar_chart_aspect_ratio_options_not_allowed(self):
+        """Test that aspect ratio options are not allowed for bar charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+        for option in [
+            "desktop_aspect_ratio",
+            "mobile_aspect_ratio",
+        ]:
+            with self.subTest(option=option):
+                self.raw_data["options"] = [{"type": option, "value": 75}]
+                value = self.get_value()
+
+                with self.assertRaises(ValidationError) as cm:
+                    self.block.clean(value)
+
+                err = cast(blocks.StructBlockValidationError, cm.exception)
+                self.assertEqual(
+                    BarColumnConfidenceIntervalChartBlock.ERROR_BAR_CHART_NO_ASPECT_RATIO,
+                    err.block_errors["options"].block_errors[0].code,
+                )
+
+    def test_column_chart_aspect_ratio_options_are_allowed(self):
+        """Test that aspect ratio options are allowed for column charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.COLUMN
+        for option in [
+            "desktop_aspect_ratio",
+            "mobile_aspect_ratio",
+        ]:
+            with self.subTest(option=option):
+                self.raw_data["options"] = [{"type": option, "value": 75}]
+                value = self.get_value()
+                try:
+                    self.block.clean(value)
+                except ValidationError:
+                    self.fail("Expected no ValidationError for column chart aspect ratio options")

--- a/cms/datavis/tests/test_chart_blocks_base.py
+++ b/cms/datavis/tests/test_chart_blocks_base.py
@@ -65,8 +65,9 @@ class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
             ("title", "Test Chart"),
             ("subtitle", "Test Subtitle"),
             ("caption", "Test Caption"),
-            ("theme", self.raw_data["theme"]),
         ]
+        if "theme" in self.block.child_blocks:
+            pairs.append(("theme", self.raw_data["theme"]))
         for key, expected in pairs:
             with self.subTest(key=key):
                 self.assertEqual(expected, value[key])


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/CCB-98

### How to review

On a statistical article page, insert a "Bar/Column Chart with Confidence Intervals" block.

<details><summary>Screenshots</summary>
<p>

![image](https://github.com/user-attachments/assets/b40e575f-93f0-4bac-af99-98efd4483c29)


![image](https://github.com/user-attachments/assets/0c45051d-636c-4494-80b1-110b9ce36b09)


![image](https://github.com/user-attachments/assets/eeed9b33-bc3b-4c59-9ee5-2b9446a2f18f)


</p>
</details> 

### Follow-up Actions

There is some reconciliation needed with an annotation type in #232 which has been added to other chart block types, but not yet this one.