### PR TITLE
Allow resources endpoint in internal env

### DIFF
--- a/cms/search/tests/test_api_views.py
+++ b/cms/search/tests/test_api_views.py
@@ -48,7 +48,7 @@ class SearchResourcesViewTests(TestCase, ResourceDictAssertions, ExternalAPITest
 
     def test_resources_returns_200_and_lists_various_page_types(self):
         """Endpoint should return 200 and include all included_pages in the items."""
-        response = self.call_view_as_external(RESOURCE_ENDPOINT)
+        response = self.client.get(RESOURCE_ENDPOINT)
         self.assertEqual(response.status_code, 200, f"Expected 200 OK from {RESOURCE_ENDPOINT}")
 
         data = self.parse_json(response)
@@ -63,7 +63,7 @@ class SearchResourcesViewTests(TestCase, ResourceDictAssertions, ExternalAPITest
         """Non-indexable pages (ArticleSeries, Home, ReleaseCalendarIndex, Theme, Topic)
         should not appear in items.
         """
-        response = self.call_view_as_external(RESOURCE_ENDPOINT)
+        response = self.client.get(RESOURCE_ENDPOINT)
         self.assertEqual(response.status_code, 200)
 
         data = self.parse_json(response)
@@ -73,10 +73,10 @@ class SearchResourcesViewTests(TestCase, ResourceDictAssertions, ExternalAPITest
                 f"Expected page with URI {build_page_uri(page)} not to be present",
             )
 
-    def test_resources_disabled_when_external_env_false(self):
-        """Endpoint should return 404 when IS_EXTERNAL_ENV=False."""
-        response = self.client.get(RESOURCE_ENDPOINT)
-        self.assertEqual(response.status_code, 404)
+    def test_resources_available_in_external_env(self):
+        """Endpoint should return 200 when IS_EXTERNAL_ENV=True."""
+        response = self.call_view_as_external(RESOURCE_ENDPOINT)
+        self.assertEqual(response.status_code, 200)
 
 
 @override_settings(IS_EXTERNAL_ENV=False)
@@ -92,7 +92,7 @@ class ResourceListViewPaginationTests(TestCase, ExternalAPITestMixin):
 
     def test_default_pagination_returns_first_slice(self):
         """With no limit/ offset specified we should get DEFAULT_LIMIT (or all if fewer)."""
-        response = self.call_view_as_external(RESOURCE_ENDPOINT)
+        response = self.client.get(RESOURCE_ENDPOINT)
         self.assertEqual(response.status_code, 200)
 
         data = self.parse_json(response)
@@ -107,7 +107,7 @@ class ResourceListViewPaginationTests(TestCase, ExternalAPITestMixin):
 
     def test_second_slice_returns_remaining_items(self):
         """Requesting offset=<7> should return whatever is left after the first slice."""
-        response = self.call_view_as_external(f"{RESOURCE_ENDPOINT}?offset=7")
+        response = self.client.get(f"{RESOURCE_ENDPOINT}?offset=7")
         self.assertEqual(response.status_code, 200)
 
         data = self.parse_json(response)
@@ -117,7 +117,7 @@ class ResourceListViewPaginationTests(TestCase, ExternalAPITestMixin):
         self.assertEqual(data["offset"], 7)
 
     def test_custom_limit_returns_requested_number(self):
-        response = self.call_view_as_external(f"{RESOURCE_ENDPOINT}?limit=5")
+        response = self.client.get(f"{RESOURCE_ENDPOINT}?limit=5")
         self.assertEqual(response.status_code, 200)
 
         data = self.parse_json(response)
@@ -130,7 +130,7 @@ class ResourceListViewPaginationTests(TestCase, ExternalAPITestMixin):
         """When limit exceeds max_limit, results should be capped at max_limit.
         We add enough extra pages to go past MAX_LIMIT of 20.
         """
-        response = self.call_view_as_external(f"{RESOURCE_ENDPOINT}?limit=30")
+        response = self.client.get(f"{RESOURCE_ENDPOINT}?limit=30")
         self.assertEqual(response.status_code, 200)
 
         data = self.parse_json(response)

--- a/cms/search/views.py
+++ b/cms/search/views.py
@@ -15,9 +15,7 @@ if TYPE_CHECKING:
 
 
 class ResourceListView(APIView):
-    """Provides the list of indexable Wagtail resources for external use.
-    Only available if IS_EXTERNAL_ENV is True.
-    """
+    """Provides the list of indexable Wagtail resources."""
 
     pagination_class = CustomLimitOffsetPagination
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -93,6 +93,10 @@ if settings.IS_EXTERNAL_ENV:
     urlpatterns += [
         path("", include("cms.search.urls")),
     ]
+else:
+    private_urlpatterns += [
+        path("", include("cms.search.urls")),
+    ]
 
 # Set public URLs to use the "default" cache settings.
 urlpatterns = decorate_urlpatterns(urlpatterns, get_default_cache_control_decorator())

--- a/docs/integrations/search_service.md
+++ b/docs/integrations/search_service.md
@@ -9,7 +9,7 @@ and 'search-content-deleted' (deleted) events, aligning with the `StandardPayloa
 - [Search metadata contract](https://github.com/ONSdigital/dis-search-upstream-stub/blob/main/docs/contract/resource_metadata.yml)
 - [Search upstream service endpoints spec](https://github.com/ONSdigital/dis-search-upstream-stub/blob/main/specification.yml)
 
-The CMS also provides a paginated Resource API endpoint with all published pages at `/v1/resources/` in the public facing instance. This is
+The CMS also provides a paginated Resource API endpoint with all published pages at `/v1/resources/`. This is
 used by the search service for reindexing.
 
 ## Environment variables


### PR DESCRIPTION
### What is the context of this PR?

We need to enable the `/v1/resources` endpoint in the internal instance to ensure that the search re-indexing can function properly. The pipelines and services that require access to `/v1/resources` are located within the internal network. For now, I have kept the endpoint in the external instance to match existing behaviour in the legacy CMS. Further discussions will determine whether we need to expose this endpoint to the public in the future. This will be decided later.

### How to review

Run the app and ensure that the `v1/resources` endpoint is available regardless of whether `IS_EXTERNAL_ENV` is true or false.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
