### PR TITLE
Reconcile confidence interval charts and reference line annotations

### DIFF
--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -245,7 +245,7 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
         [
             ("point", PointAnnotationCategoricalBlock()),
             ("range", RangeAnnotationBarColumnBlock()),
-            # TODO: add reference line annotation when https://github.com/ONSdigital/dis-wagtail/pull/232 is merged
+            ("reference_line", LineAnnotationBarColumnBlock()),
         ],
         required=False,
     )


### PR DESCRIPTION
Two separate features were added recently which have not been reconciled with each other:

- #232 
- #239 

This simply enables the use of the former with the latter.