### PR TITLE
Bypass broken link checking for jwt.io

### DIFF
--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -2,7 +2,8 @@
   "ignorePatterns": [
     { "pattern": "^http://localhost" },
     { "pattern": "^http://127\\.0\\.0\\.1" },
-    { "pattern": "^http://0\\.0\\.0\\.0" }
+    { "pattern": "^http://0\\.0\\.0\\.0" },
+    { "pattern": "^https?://jwt\\.io" }
   ],
   "retryOn429": true,
   "retryCount": 3,


### PR DESCRIPTION
### What is the context of this PR?

Bypass `jwt.io` from the markdown-link-check linter as `jwt.io` is quite flaky and often returns `500` status, resulting in a flaky build. We can try enabling JWT.io links in future.

### How to review

Ensure CI passes, or try a broken JWT URL and it should pass megalinter.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
