### PR TITLE
Fix column uncertainty chart data points when there is estimate only

### DIFF
--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -360,7 +360,12 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
                 # [whisker min, box bottom, centre line, box top, whisker max].
                 # We do not render the whiskers, so we set them to the same as the
                 # box extents.
-                "data": [(row[2], row[2], row[1], row[3], row[3]) for row in value["table"].rows],
+                "data": [
+                    (row[2], row[2], row[1], row[3], row[3])
+                    if row[2] and row[3]
+                    else (row[1], row[1], row[1], row[1], row[1])
+                    for row in value["table"].rows
+                ],
             }
         ]
 

--- a/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
@@ -103,6 +103,22 @@ class BarColumnConfidenceIntervalChartBlockTestCase(BaseChartBlockTestCase):
         self.assertEqual("Estimate", config["estimateLineLabel"])
         self.assertEqual("Uncertainty range", config["uncertaintyRangeLabel"])
 
+    def test_column_chart_with_no_uncertainty(self):
+        """When a datum has no uncertainty range, all five box plot values should be the same."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.COLUMN
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["Category", "Value", "Range min", "Range max"],
+                ["2005", "100", "", ""],
+                ["2006", "120", "110", "130"],
+            ]
+        )
+        config = self.get_component_config()
+        self.assertEqual(
+            [(100, 100, 100, 100, 100), (110, 110, 120, 130, 130)],
+            config["series"][0]["data"],
+        )
+
     def test_custom_legend_labels(self):
         """Test that custom legend labels are used when provided."""
         self.raw_data["estimate_line_label"] = "Custom Estimate"


### PR DESCRIPTION
### What is the context of this PR?

This addresses defect ticket https://jira.ons.gov.uk/browse/CCB-145.

When a column chart data row has an estimate only, in column B, and no uncertainty range in columns C and D, then it should be rendered as a line only.

- Design System example: https://github.com/ONSdigital/design-system/blob/main/src/components/chart/example-column-with-confidence-levels.njk
- Rendered: https://ons-design-system-preview.netlify.app/components/chart/example-column-with-confidence-levels

### How to review

Create a column chart with uncertainty range.

Enter data such as:

Category|Value|Range min|Range max
---|---|---|---
January|7.98|-13|19.9
February|8.63|25|28
March|11.29||
April|14.41|-1.1|29.4

Observe that the March data point is represented by a line only, with no shaded bar.