### PR TITLE
DAC Report - Update heading levels (Level A)

### DIFF
--- a/cms/core/blocks/glossary_terms.py
+++ b/cms/core/blocks/glossary_terms.py
@@ -23,6 +23,7 @@ class GlossaryTermsBlock(ListBlock):
         context: dict = super().get_context(value, parent_context)
         context["formatted_glossary_terms"] = [
             {
+                "headingLevel": 3,
                 "title": glossary_term.name,
                 "content": richtext(glossary_term.definition),
             }

--- a/cms/core/tests/test_blocks.py
+++ b/cms/core/tests/test_blocks.py
@@ -385,6 +385,7 @@ class GlossaryTermBlockTestCase(TestCase):
             context["formatted_glossary_terms"],
             [
                 {
+                    "headingLevel": 3,
                     "title": term.name,
                     "content": f'<div class="rich-text">{term.definition}</div>',
                 }

--- a/cms/jinja2/templates/components/glossary/glossary_term_preview.html
+++ b/cms/jinja2/templates/components/glossary/glossary_term_preview.html
@@ -10,12 +10,13 @@
             "id": "glossary-terms-accordion",
             "itemsList": [
                 {
+                    "headingLevel": 3,
                     "title": object.name,
                     "content": object.definition|richtext
                 }
             ]
         })
     }}
-    {# fmt:on#}
+    {# fmt:on #}
 
 {% endblock %}

--- a/cms/jinja2/templates/components/streamfield/document_block.html
+++ b/cms/jinja2/templates/components/streamfield/document_block.html
@@ -1,3 +1,9 @@
 {% from "components/document-list/_macro.njk" import onsDocumentList %}
 
-{{ onsDocumentList({"documents": [value.as_macro_data()]}) }}
+{# fmt:off #}
+    {{ onsDocumentList({
+            "headingLevel": 3,
+            "documents": [value.as_macro_data()]
+        })
+    }}
+{# fmt:on #}

--- a/cms/jinja2/templates/components/streamfield/documents_block.html
+++ b/cms/jinja2/templates/components/streamfield/documents_block.html
@@ -1,3 +1,9 @@
 {% from "components/document-list/_macro.njk" import onsDocumentList %}
 
-{{ onsDocumentList({"documents": macro_data}) }}
+{# fmt:off #}
+    {{ onsDocumentList({
+            "headingLevel": 3,
+            "documents": macro_data
+        }) 
+    }}
+{# fmt:on #}

--- a/cms/jinja2/templates/components/streamfield/headline_figures_item_block.html
+++ b/cms/jinja2/templates/components/streamfield/headline_figures_item_block.html
@@ -6,6 +6,7 @@
             "variant": 'feature',
             "title": {
                 "id": value.figure_id + "-card",
+                "headingLevel": 3,
                 "text": value.title,
             },
             "body":{

--- a/cms/jinja2/templates/components/streamfield/related_links_block.html
+++ b/cms/jinja2/templates/components/streamfield/related_links_block.html
@@ -3,5 +3,11 @@
 <section id="{{ slug }}">
     <h2>{{ heading }}</h2>
 
-    {{ onsDocumentList({ "documents": related_links }) }}
+    {# fmt:off #}
+        {{ onsDocumentList({
+                "headingLevel": 3,
+                "documents": related_links
+            }) 
+        }}
+    {# fmt:on #}
 </section>

--- a/cms/jinja2/templates/components/streamfield/topic_headline_figure_block.html
+++ b/cms/jinja2/templates/components/streamfield/topic_headline_figure_block.html
@@ -6,6 +6,7 @@
             "variant": 'feature',
             "title": {
                 "id": figure.figure_id + "-card",
+                "headingLevel": 3,
                 "text": figure.title,
                 "url": figure.url,
             },

--- a/cms/jinja2/templates/pages/topic_page.html
+++ b/cms/jinja2/templates/pages/topic_page.html
@@ -70,21 +70,39 @@
             {% if formatted_articles %}
                 <section id="related-articles" class="spacing">
                     <h2>{{ _("Related articles") }}</h2>
-                    {{ onsDocumentList({"documents": formatted_articles}) }}
+                    {# fmt:off #}
+                        {{ onsDocumentList({
+                                "headingLevel": 3,
+                                "documents": formatted_articles
+                            })
+                        }}
+                    {# fmt:on #}
                 </section>
             {% endif %}
 
             {% if formatted_methodologies %}
                 <section id="related-methods" class="spacing">
                     <h2>{{ _("Methods and quality information") }}</h2>
-                    {{ onsDocumentList({"documents": formatted_methodologies}) }}
+                    {# fmt:off #}
+                        {{ onsDocumentList({
+                                "headingLevel": 3,
+                                "documents": formatted_methodologies
+                            })
+                        }}
+                    {# fmt:on #}
                 </section>
             {% endif %}
 
             {% if page.dataset_document_list %}
                 <section id="data" class="spacing">
                     <h2>{{ _("Data") }}</h2>
-                    {{ onsDocumentList({"documents": page.dataset_document_list}) }}
+                    {# fmt:off #}
+                        {{ onsDocumentList({
+                                "headingLevel": 3,
+                                "documents": page.dataset_document_list
+                            })
+                        }}
+                    {# fmt:on #}
                 </section>
             {% endif %}
 

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-03 13:53+0100\n"
+"POT-Creation-Date: 2025-06-19 15:02+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,16 +19,16 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: cms/articles/models.py:114
+#: cms/articles/models.py:115
 #: cms/jinja2/templates/components/featured/featured-article.html:11
 msgid "Article"
 msgstr ""
 
-#: cms/articles/models.py:323
+#: cms/articles/models.py:326
 msgid "Cite this article"
 msgstr ""
 
-#: cms/articles/models.py:325
+#: cms/articles/models.py:328
 #: cms/jinja2/templates/components/contact_details/contact_details.html:5
 #: cms/methodology/models.py:156 cms/release_calendar/models.py:213
 msgid "Contact details"
@@ -76,15 +76,15 @@ msgstr "Mae'r holl gynnwys ar gael o dan delerau'r"
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
-#: cms/jinja2/templates/base_page.html:46
+#: cms/jinja2/templates/base_page.html:50
 msgid "in English"
 msgstr ""
 
-#: cms/jinja2/templates/base_page.html:47
+#: cms/jinja2/templates/base_page.html:51
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:54
+#: cms/jinja2/templates/base_page.html:58
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "
@@ -102,7 +102,7 @@ msgid "This release includes data from Census 2021"
 msgstr ""
 
 #: cms/jinja2/templates/components/navigation/breadcrumbs.html:9
-#: cms/navigation/templatetags/navigation_tags.py:144
+#: cms/navigation/templatetags/navigation_tags.py:142
 msgid "Home"
 msgstr "Hafan"
 
@@ -111,12 +111,12 @@ msgid "Correction"
 msgstr ""
 
 #: cms/jinja2/templates/components/streamfield/correction_block.html:9
-#: megalinter-reports/updated_sources/cms/jinja2/templates/components/streamfield/correction_block.html:7
 msgid "View superseded version"
 msgstr ""
 
 #: cms/jinja2/templates/components/streamfield/datasets_block.html:2
-#: cms/release_calendar/models.py:207
+#: cms/jinja2/templates/pages/topic_page.html:98
+#: cms/release_calendar/models.py:207 cms/topics/models.py:247
 msgid "Data"
 msgstr ""
 
@@ -418,24 +418,24 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:7 cms/topics/models.py:77
+#: cms/jinja2/templates/pages/topic_page.html:7 cms/topics/models.py:78
 msgid "Topic"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:62 cms/topics/models.py:230
+#: cms/jinja2/templates/pages/topic_page.html:62 cms/topics/models.py:239
 msgid "Featured"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:72 cms/topics/models.py:232
+#: cms/jinja2/templates/pages/topic_page.html:72 cms/topics/models.py:241
 msgid "Related articles"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:79 cms/topics/models.py:234
+#: cms/jinja2/templates/pages/topic_page.html:85 cms/topics/models.py:243
 msgid "Methods and quality information"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:86 cms/topics/models.py:236
-#: cms/topics/tests/test_models.py:128
+#: cms/jinja2/templates/pages/topic_page.html:111 cms/topics/models.py:245
+#: cms/topics/tests/test_models.py:140
 msgid "Explore more"
 msgstr ""
 
@@ -451,17 +451,17 @@ msgstr "Methodoleg"
 msgid "Related publications"
 msgstr ""
 
-#: cms/settings/base.py:351
+#: cms/settings/base.py:357
 msgid "English"
 msgstr ""
 
-#: cms/settings/base.py:352
+#: cms/settings/base.py:358
 msgid "Welsh"
 msgstr "Cymraeg"
 
-#: cms/settings/base.py:353
+#: cms/settings/base.py:359
 msgid "Ukrainian"
 msgstr ""
 
-msgid "To be confirmed"
-msgstr "I'w gadarnhau"
+#~ msgid "To be confirmed"
+#~ msgstr "I'w gadarnhau"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-19 15:02+0100\n"
+"POT-Creation-Date: 2025-06-03 13:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,16 +19,16 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: cms/articles/models.py:115
+#: cms/articles/models.py:114
 #: cms/jinja2/templates/components/featured/featured-article.html:11
 msgid "Article"
 msgstr ""
 
-#: cms/articles/models.py:326
+#: cms/articles/models.py:323
 msgid "Cite this article"
 msgstr ""
 
-#: cms/articles/models.py:328
+#: cms/articles/models.py:325
 #: cms/jinja2/templates/components/contact_details/contact_details.html:5
 #: cms/methodology/models.py:156 cms/release_calendar/models.py:213
 msgid "Contact details"
@@ -76,15 +76,15 @@ msgstr "Mae'r holl gynnwys ar gael o dan delerau'r"
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
-#: cms/jinja2/templates/base_page.html:50
+#: cms/jinja2/templates/base_page.html:46
 msgid "in English"
 msgstr ""
 
-#: cms/jinja2/templates/base_page.html:51
+#: cms/jinja2/templates/base_page.html:47
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:58
+#: cms/jinja2/templates/base_page.html:54
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "
@@ -102,7 +102,7 @@ msgid "This release includes data from Census 2021"
 msgstr ""
 
 #: cms/jinja2/templates/components/navigation/breadcrumbs.html:9
-#: cms/navigation/templatetags/navigation_tags.py:142
+#: cms/navigation/templatetags/navigation_tags.py:144
 msgid "Home"
 msgstr "Hafan"
 
@@ -111,12 +111,12 @@ msgid "Correction"
 msgstr ""
 
 #: cms/jinja2/templates/components/streamfield/correction_block.html:9
+#: megalinter-reports/updated_sources/cms/jinja2/templates/components/streamfield/correction_block.html:7
 msgid "View superseded version"
 msgstr ""
 
 #: cms/jinja2/templates/components/streamfield/datasets_block.html:2
-#: cms/jinja2/templates/pages/topic_page.html:98
-#: cms/release_calendar/models.py:207 cms/topics/models.py:247
+#: cms/release_calendar/models.py:207
 msgid "Data"
 msgstr ""
 
@@ -418,24 +418,24 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:7 cms/topics/models.py:78
+#: cms/jinja2/templates/pages/topic_page.html:7 cms/topics/models.py:77
 msgid "Topic"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:62 cms/topics/models.py:239
+#: cms/jinja2/templates/pages/topic_page.html:62 cms/topics/models.py:230
 msgid "Featured"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:72 cms/topics/models.py:241
+#: cms/jinja2/templates/pages/topic_page.html:72 cms/topics/models.py:232
 msgid "Related articles"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:85 cms/topics/models.py:243
+#: cms/jinja2/templates/pages/topic_page.html:79 cms/topics/models.py:234
 msgid "Methods and quality information"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:111 cms/topics/models.py:245
-#: cms/topics/tests/test_models.py:140
+#: cms/jinja2/templates/pages/topic_page.html:86 cms/topics/models.py:236
+#: cms/topics/tests/test_models.py:128
 msgid "Explore more"
 msgstr ""
 
@@ -451,17 +451,17 @@ msgstr "Methodoleg"
 msgid "Related publications"
 msgstr ""
 
-#: cms/settings/base.py:357
+#: cms/settings/base.py:351
 msgid "English"
 msgstr ""
 
-#: cms/settings/base.py:358
+#: cms/settings/base.py:352
 msgid "Welsh"
 msgstr "Cymraeg"
 
-#: cms/settings/base.py:359
+#: cms/settings/base.py:353
 msgid "Ukrainian"
 msgstr ""
 
-#~ msgid "To be confirmed"
-#~ msgstr "I'w gadarnhau"
+msgid "To be confirmed"
+msgstr "I'w gadarnhau"


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/CMS-538

Resolves issue reported in DAC audit that several headings did not have appropriate heading hierarchy in code. This updates h2 headings to h3 where necessary to match their visual hierarchy.

### How to review

- Review statistical article page and check headline figures component, see that the card titles are displayed as h3 headings
- Review topic page and check headline figures, see that card titles are displayed as h3 headings
- Review any page with a glossary component and check that the individual dropdown headings are using h3 headings
- Add related links & documents streamfield blocks to any page and check the individual link and document titles are now using h3 headings

### Follow-up Actions

n/a
