### PR TITLE
Ensure editable titles matches feature mapping

### DIFF
--- a/cms/datavis/tests/test_area_chart_block.py
+++ b/cms/datavis/tests/test_area_chart_block.py
@@ -66,3 +66,27 @@ class AreaChartBlockTestCase(BaseChartBlockTestCase):
             self.block.clean(self.get_value(empty_cell_data))
 
         self.assertEqual(AreaChartBlock.ERROR_EMPTY_CELLS, cm.exception.block_errors["table"].code)
+
+    def test_editable_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = "Editable X-axis Title"
+        config = self.get_component_config()
+        self.assertEqual("Editable X-axis Title", config["xAxis"]["title"])
+
+    def test_blank_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = ""
+        config = self.get_component_config()
+        # For area charts, editable X-axis title is supported, but the default
+        # value is `undefined`, so we expect it not to be set.
+        # Ref: https://api.highcharts.com/highcharts/xAxis.title
+        self.assertNotIn("title", config["xAxis"])
+
+    def test_editable_y_axis_title(self):
+        self.raw_data["y_axis"]["title"] = "Editable Y-axis Title"
+        config = self.get_component_config()
+        self.assertEqual("Editable Y-axis Title", config["yAxis"]["title"])
+
+    def test_blank_y_axis_title(self):
+        """A blank value should be converted to None."""
+        self.raw_data["y_axis"]["title"] = ""
+        config = self.get_component_config()
+        self.assertEqual(None, config["yAxis"]["title"])

--- a/cms/datavis/tests/test_line_chart_block.py
+++ b/cms/datavis/tests/test_line_chart_block.py
@@ -68,6 +68,7 @@ class LineChartBlockTestCase(BaseChartBlockTestCase):
         config = self.get_component_config()
         # For line charts, editable X-axis title is supported, but the default
         # value is `undefined`, so we expect it not to be set.
+        # Ref: https://api.highcharts.com/highcharts/xAxis.title
         self.assertNotIn("title", config["xAxis"])
 
     def test_editable_y_axis_title(self):

--- a/cms/datavis/tests/test_scatter_plot_block.py
+++ b/cms/datavis/tests/test_scatter_plot_block.py
@@ -153,3 +153,27 @@ class ScatterPlotBlockTestCase(BaseChartBlockTestCase):
         config = self.get_component_config()
         for item in config["series"]:
             self.assertEqual(True, item["marker"])
+
+    def test_editable_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = "Editable X-axis Title"
+        config = self.get_component_config()
+        self.assertEqual("Editable X-axis Title", config["xAxis"]["title"])
+
+    def test_blank_x_axis_title(self):
+        self.raw_data["x_axis"]["title"] = ""
+        config = self.get_component_config()
+        # For scatter plots, editable X-axis title is supported, but the default
+        # value is `undefined`, so we expect it not to be set.
+        # Ref: https://api.highcharts.com/highcharts/xAxis.title
+        self.assertNotIn("title", config["xAxis"])
+
+    def test_editable_y_axis_title(self):
+        self.raw_data["y_axis"]["title"] = "Editable Y-axis Title"
+        config = self.get_component_config()
+        self.assertEqual("Editable Y-axis Title", config["yAxis"]["title"])
+
+    def test_blank_y_axis_title(self):
+        """A blank value should be converted to None."""
+        self.raw_data["y_axis"]["title"] = ""
+        config = self.get_component_config()
+        self.assertEqual(None, config["yAxis"]["title"])


### PR DESCRIPTION
### What is the context of this PR?

This re-enables editable x-axis titles on column charts, and adds more granular validation to display an error if the chart is in bar orientation.

It also extends tests of editable, and nullable, titles to scatter charts and area charts, where these tests were missing.

Finally this change includes a refactor of chart blocks, to rename the `clean_FOO(self, value): -> dict` methods to `validate_FOO(self, value): -> None`, as the returned `value` dict was never manipulated.

Ticket: https://jira.ons.gov.uk/browse/CCB-97

### How to review

Try adding an x-axis title to a Bar/Column Chart block. Save in bar orientation, and see that it fails validation. See that preview rendering and saving works fine in column orientation.

Repeat for Bar/Column Chart with Confidence Intervals.
