### PR TITLE
Add endpoint for running management commands

### DIFF
--- a/cms/core/whitenoise.py
+++ b/cms/core/whitenoise.py
@@ -28,7 +28,6 @@ class CMSWhiteNoiseMiddleware(WhiteNoiseMiddleware):
     # NB: If the app isn't in `INSTALLED_APPS`, it doesn't need to be added here.
     ignore_patterns: tuple[str, ...] = (
         "wagtailadmin/*",
-        "django_extensions/*",
         "wagtaildocs/*",
         "wagtailembeds/*",
         "wagtailimages/*",

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -94,7 +94,6 @@ INSTALLED_APPS = [
     "wagtail",
     "modelcluster",
     "taggit",
-    "django_extensions",
     "django.contrib.auth",  # Wagtail requires the auth app be installed, even if it's not used.
     "django.contrib.contenttypes",
     "whitenoise.runserver_nostatic",  # Must be before `django.contrib.staticfiles`
@@ -949,6 +948,8 @@ BUILD_TIME = datetime.datetime.fromtimestamp(int(env["BUILD_TIME"])) if env.get(
 GIT_COMMIT = env.get("GIT_COMMIT") or None
 TAG = env.get("TAG") or None
 START_TIME = datetime.datetime.now(tz=datetime.UTC)
+
+MANAGEMENT_COMMANDS_URL_SECRET = env.get("MANAGEMENT_COMMANDS_URL_SECRET", "")
 
 SLACK_NOTIFICATIONS_WEBHOOK_URL = env.get("SLACK_NOTIFICATIONS_WEBHOOK_URL")
 

--- a/cms/settings/dev.py
+++ b/cms/settings/dev.py
@@ -32,6 +32,7 @@ ONS_API_BASE_URL = env.get("ONS_API_BASE_URL", "https://api.beta.ons.gov.uk/v1")
 # http://docs.wagtail.io/en/stable/contributing/styleguide.html
 INSTALLED_APPS += ["wagtail.contrib.styleguide"]  # noqa: F405
 INSTALLED_APPS += ["django_migration_linter"]
+INSTALLED_APPS += ["django_extensions"]
 
 # Disable forcing HTTPS locally since development server supports HTTP only.
 SECURE_SSL_REDIRECT = False

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -42,6 +42,10 @@ if not settings.IS_EXTERNAL_ENV:
 
     private_urlpatterns.append(path("admin/", include(wagtailadmin_urls)))
 
+    internal_urlpatterns.append(
+        path("management-command/<slug:command_name>/", core_views.management_command, name="management-command")
+    )
+
 if apps.is_installed("django.contrib.admin"):
     from django.contrib import admin  # pylint: disable=ungrouped-imports
 

--- a/docs/custom-features/scheduled-jobs.md
+++ b/docs/custom-features/scheduled-jobs.md
@@ -3,17 +3,23 @@
 Wagtail publishes pages using a management command. When run, this command publishes any pages which are due to be published.
 It is expected to be run using an external scheduler (e.g. cron).
 
-On the ONS infrastructure, we use the Kubernetes CronJob.
+## Deployment
+
+On the ONS infrastructure, we use the Kubernetes CronJob resource. The Kubernetes jobs run a small container which sends a request back to Wagtail to trigger the corresponding management command. Using a small container avoids the resource demands of a Pod dedicated to the management command and improves responsiveness.
+
+This endpoint requires authentication, and is only available on the internal cluster. For security reasons, commands are run without arguments and do not take input from the requests.
+
+## Local
 
 In other environments, such as the local one, we use [`APScheduler`](https://pypi.org/project/APScheduler/) to run a [continuous scheduler task](https://github.com/ONSdigital/dis-wagtail/blob/main/cms/core/management/commands/scheduler.py)
 that triggers the [`publish_bundles`](https://github.com/ONSdigital/dis-wagtail/blob/main/cms/bundles/management/commands/publish_bundles.py) management command
 every minute, and [`publish_scheduled_without_bundles`](https://github.com/ONSdigital/dis-wagtail/blob/main/cms/bundles/management/commands/publish_scheduled_without_bundles.py) every 5.
 
-## `publish_bundles`
+### `publish_bundles`
 
 Is a management command that publishes [bundles](bundles.md) that are scheduled and ready to publish.
 
-## `publish_scheduled_without_bundles`
+### `publish_scheduled_without_bundles`
 
 Is a modified version of the Wagtail core [`publish_scheduled`](https://github.com/wagtail/wagtail/blob/main/wagtail/management/commands/publish_scheduled.py)
 management command that excludes any pages that are in an active bundle.

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -16,7 +16,7 @@ max_requests_jitter = int(os.environ.get("GUNICORN_MAX_REQUESTS_JITTER", "50"))
 # Log to stdout
 accesslog = "-"
 
-# Time out after 25 seconds (notably shorter than Heroku's)
+# Time out after 25 seconds by default (notably shorter than Heroku's)
 timeout = int(os.environ.get("GUNICORN_TIMEOUT", "25"))
 
 # Load app pre-fork to save memory and worker startup time

--- a/poetry.lock
+++ b/poetry.lock
@@ -3302,4 +3302,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "a57962b1e16c36b500893e29876d166a7d3092ca79fbef5b9507ce92b68aa073"
+content-hash = "8e9e3fa001b245a44f864bea4d0de43b4f2cef69833a179d8fe71189298409c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dj-database-url = "~3.0.0"
 django-basic-auth-ip-whitelist = "~0.8"
 django-csp = "~4.0"
 django-defender = "~0.9.8"
-django-extensions = "~4.1"
 django-jinja = "^2.11.0"
 django-redis = "~5.4"
 django-storages = { version = "~1.14", extras = ["s3"] }
@@ -72,6 +71,7 @@ moto = {extras = ["iam","s3"], version = "^5.0.22"}
 django-migration-linter = "^5.2.0"
 fakeredis = "^2.29.0"
 time-machine = "^2.16.0"
+django-extensions = "^4.1"
 
 [tool.ruff]
 target-version = "py313"


### PR DESCRIPTION
### What is the context of this PR?

https://jira.ons.gov.uk/browse/DIS-3186

As an alternative approach to cron job scheduling, we want to try triggering tasks using a tiny `curl` container in the cluster, which in turn calls out to Wagtail, rather than running a dedicated Wagtail container. This should avoid any potential resource contention issues which would delay the container starting up, but also avoids the container startup time (~3s) since it's already running (with warm caches).

The endpoint is only enabled in the internal environment (it'll 404 on external), and requires basic auth. Similarly, the commands do not take any arguments, reducing the risk of any kind of network privilege escalation.

This PR should be additive - using an external scheduler should continue to work. This just enables an additional method.

### How to review

##### Why is `django-extensions` moved to a dev dependency? 

`django-extensions` has a lot of management commands, many of which can be dangereous to run. Dropping it down to a dev dependency removes them from the main container and makes it smaller. We're not using the features for the main app itself, so it's a dependency we can easily demote.

### Follow-up Actions

If this idea is successful, there is likely value in extracting this out into a separate package. However, that can come in future.

Configuring the cluster to use these endpoints is intentionally out of scope.

Should this experiment fail, and we drop the approach, the PR will be reverted.
