### PR TITLE
Fix displayed page title on Statistical Article Pages

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -280,7 +280,11 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
 
     def get_admin_display_title(self) -> str:
         """Changes the admin display title to include the parent title."""
-        return f"{self.get_parent().title}: {self.draft_title or self.title}"
+        return self.get_full_display_title(self.draft_title)
+
+    def get_full_display_title(self, title: str | None = None) -> str:
+        """Returns the full display title for the page, including the parent series title."""
+        return f"{self.get_parent().title}: {title or self.title}"
 
     def get_headline_figure(self, figure_id: str) -> dict[str, str]:
         if not self.headline_figures:
@@ -313,7 +317,7 @@ class StatisticalArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):  # 
     @property
     def display_title(self) -> str:
         """Returns the page display title. If the news headline is set, it takes precedence over the series+title."""
-        return self.news_headline.strip() or self.get_admin_display_title()
+        return self.news_headline.strip() or self.get_full_display_title()
 
     @cached_property
     def table_of_contents(self) -> list[dict[str, str | object]]:

--- a/cms/articles/tests/test_models.py
+++ b/cms/articles/tests/test_models.py
@@ -401,6 +401,28 @@ class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
         self.assertNotContains(response, self.page.get_admin_display_title())
         self.assertContains(response, "Breaking News!")
 
+    def test_full_display_title(self):
+        self.assertEqual(self.basic_page.display_title, "PSF: November 2024")
+
+        self.basic_page.title = "Lorem Ipsum"
+        self.basic_page.save_revision()
+
+        # The page object shows the newer title
+        self.assertEqual(self.basic_page.display_title, "PSF: Lorem Ipsum")
+
+        # However, the live page will show the old title until it is published
+        response = self.client.get(self.basic_page_url)
+
+        self.assertNotContains(response, "PSF: Lorem Ipsum")
+        self.assertContains(response, "PSF: November 2024")
+
+        self.basic_page.save_revision().publish()
+
+        response = self.client.get(self.basic_page_url)
+
+        self.assertContains(response, "PSF: Lorem Ipsum")
+        self.assertNotContains(response, "PSF: November 2024")
+
     def test_next_release_date(self):
         """Checks that when no next release date, the template shows 'To be announced'."""
         response = self.client.get(self.basic_page_url)


### PR DESCRIPTION
### What is the context of this PR?

This PR is related to CMS-409.

It fixes an issue when the admin display title was being used on the live page. This caused a bug where the draft title of the page would be displayed on the live page and superseded pages if there were corrections.

### How to review

1. Create a statistical article page
2. Set a memorable title
3. Publish the page
4. Check the page title is correct
5. Go back to page editing and update the title
6. Save a draft
7. Check that the live page is using the _old_ title, not the one from the draft
8. Publish the draft
9. Check that the page title has been updated
10. Once again change the title and create a correction
11. Publish the correction
12. Ensure that the superseded version uses the old (second) title, not the latest (third) title

### Follow-up Actions

N/A
