### PR TITLE
Disallow line overlays for non-stacked column charts

### DIFF
--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -68,6 +68,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
     ERROR_ALL_SERIES_SELECTED = "all_series_selected"
     ERROR_BAR_CHART_NO_ASPECT_RATIO = "bar_chart_no_aspect_ratio"
     ERROR_HORIZONTAL_BAR_NO_CATEGORY_TITLE = "horizontal_bar_no_category_title"
+    ERROR_NON_STACKED_COLUMN_NO_LINE = "non_stacked_column_no_line_overlay"
 
     # Remove unsupported features
     show_markers = None
@@ -170,6 +171,14 @@ class BarColumnChartBlock(BaseVisualisationBlock):
                 if value.get("select_chart_type") == BarColumnChartTypeChoices.BAR:
                     stream_block_errors[i] = ValidationError(
                         "Horizontal bar charts do not support line overlays.", code=self.ERROR_HORIZONTAL_BAR_NO_LINE
+                    )
+
+                elif value.get("select_chart_type") == BarColumnChartTypeChoices.COLUMN and not value.get(
+                    "use_stacked_layout"
+                ):
+                    stream_block_errors[i] = ValidationError(
+                        "Non-stacked column charts do not support line overlays.",
+                        code=self.ERROR_NON_STACKED_COLUMN_NO_LINE,
                     )
 
                 # Raise an error if the series number is not in the range of the number of series

--- a/cms/datavis/tests/test_bar_column_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_chart_block.py
@@ -389,6 +389,7 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
 
     def test_column_chart_with_one_line_overlay(self):
         self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = True
         self.raw_data["series_customisation"] = [
             {"type": "series_as_line_overlay", "value": 1}  # NB 1-indexed
         ]
@@ -432,8 +433,23 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
         # This is the only error
         self.assertEqual(1, len(cm.exception.block_errors))
 
+    def test_stacked_column_chart_with_line_overlay_is_not_allowed(self):
+        self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = False
+        self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 1}]
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+
+        self.assertEqual(
+            BarColumnChartBlock.ERROR_NON_STACKED_COLUMN_NO_LINE,
+            cm.exception.block_errors["series_customisation"].block_errors[0].code,
+        )
+        # This is the only error
+        self.assertEqual(1, len(cm.exception.block_errors))
+
     def test_error_is_raised_if_series_number_is_out_of_range(self):
         self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = True
         for series_number in [0, 3]:
             with self.subTest(series_number=series_number):
                 self.raw_data["series_customisation"] = [
@@ -450,6 +466,7 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
 
     def test_error_is_raised_if_series_number_is_duplicated(self):
         self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = True
         self.raw_data["series_customisation"] = [
             {"type": "series_as_line_overlay", "value": 1},
             {"type": "series_as_line_overlay", "value": 1},
@@ -466,6 +483,7 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
 
     def test_error_is_raised_if_all_series_are_selected_for_line_overlay(self):
         self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = True
         self.raw_data["table"] = TableDataFactory(
             table_data=[
                 ["", "Only one series"],
@@ -490,6 +508,7 @@ class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
 
     def test_all_series_selected_not_raised_for_number_out_of_range(self):
         self.raw_data["select_chart_type"] = "column"
+        self.raw_data["use_stacked_layout"] = True
         self.raw_data["series_customisation"] = [
             {"type": "series_as_line_overlay", "value": 1},
             {"type": "series_as_line_overlay", "value": 3},


### PR DESCRIPTION
### What is the context of this PR?

See https://jira.ons.gov.uk/browse/CCB-113

This change brings the chart builder in line with the DS code, to ensure that line overlays cannot be added to clustered column charts - only to stacked column charts.

### How to review

Try adding a column chart with multiple series, and select one series to be a line overlay.
If the column chart is not stacked, it should give an error message.
Other validation relating to selecting a series as an overlay should all still function correctly - see the ACs on the ticket for details.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
