### PR TITLE
Ensure that data labels are not allowed if there are more than 20 data points in a series

### DIFF
--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -60,6 +60,7 @@ class LineChartBlock(BaseVisualisationBlock):
 class BarColumnChartBlock(BaseVisualisationBlock):
     x_axis_type = AxisType.CATEGORICAL
     MAX_SERIES_COUNT_WITH_DATA_LABELS = 2
+    MAX_DATA_POINTS_WITH_DATA_LABELS = 20
 
     # Error codes
     ERROR_DUPLICATE_SERIES = "duplicate_series_number"
@@ -92,7 +93,11 @@ class BarColumnChartBlock(BaseVisualisationBlock):
     show_data_labels = blocks.BooleanBlock(
         default=False,
         required=False,
-        help_text="Non-stacked bar charts with one or two series only. Data labels will be hidden for all other cases.",
+        help_text="""
+        Data labels are only allowed on non-stacked bar charts with one or two series,
+        and where the number of data points does not exceed 20 in any series.
+        Data labels will be hidden for all other cases.
+        """,
     )
     use_stacked_layout = blocks.BooleanBlock(default=False, required=False)
     # NB X_axis is labelled "Category axis" for bar/column charts
@@ -247,13 +252,15 @@ class BarColumnChartBlock(BaseVisualisationBlock):
         item = super().get_series_item(value, series_number, series_name, rows)
 
         # Add data labels configuration.
-        # This is only supported for non-stacked horizontal bar charts with 1 or 2 series
+        # This is only supported for non-stacked horizontal bar charts with 1 or 2 series,
+        # and where the number of data points does not exceed 20.
         if (
             value.get("show_data_labels")
             and value.get("select_chart_type") == BarColumnChartTypeChoices.BAR
             and not value.get("use_stacked_layout")
             # +1 to allow for the categories in the first column
             and len(value["table"].headers) <= self.MAX_SERIES_COUNT_WITH_DATA_LABELS + 1
+            and len(value["table"].rows) <= self.MAX_DATA_POINTS_WITH_DATA_LABELS
         ):
             item["dataLabels"] = True
 

--- a/cms/datavis/tests/test_bar_column_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_chart_block.py
@@ -141,19 +141,27 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
             msg="Max number of series with data labels is hardcoded. Update this test if the value changes.",
         )
 
+        self.assertEqual(
+            20,
+            BarColumnChartBlock.MAX_DATA_POINTS_WITH_DATA_LABELS,
+            msg="Max number of points with data labels is hardcoded. Update this test if the value changes.",
+        )
+
         class Case(NamedTuple):
             chart_type: BarColumnChartTypeChoices
             show_data_labels: bool
             series_count: int
+            data_points_count: int
             stacked: bool
             expected_data_labels: bool
 
         cases = (
-            # Data labels are supported on non-stacked bar charts with 1 or 2 series
+            # Data labels are supported on non-stacked bar charts with 1 or 2 series, and a maximum of 20 data points.
             Case(
                 BarColumnChartTypeChoices.BAR,
                 True,
                 1,
+                10,
                 False,
                 True,
             ),
@@ -161,6 +169,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 True,
                 2,
+                10,
                 False,
                 True,
             ),
@@ -169,6 +178,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 True,
                 1,
+                10,
                 True,
                 False,
             ),
@@ -176,6 +186,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 True,
                 2,
+                10,
                 True,
                 False,
             ),
@@ -184,15 +195,26 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 True,
                 3,
+                10,
+                False,
+                False,
+            ),
+            # Don't show data labels if there are more than 20 data points
+            Case(
+                BarColumnChartTypeChoices.BAR,
+                True,
+                1,
+                21,
                 False,
                 False,
             ),
             # Don't show data labels if the option is not checked.
-            # The five cases below otherwise repeat the previous five.
+            # The six cases below otherwise repeat the previous six.
             Case(
                 BarColumnChartTypeChoices.BAR,
                 False,
                 1,
+                10,
                 False,
                 False,
             ),
@@ -200,6 +222,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 False,
                 2,
+                10,
                 False,
                 False,
             ),
@@ -207,6 +230,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 False,
                 1,
+                10,
                 True,
                 False,
             ),
@@ -214,6 +238,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 False,
                 2,
+                10,
                 True,
                 False,
             ),
@@ -221,15 +246,25 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.BAR,
                 False,
                 3,
+                10,
+                False,
+                False,
+            ),
+            Case(
+                BarColumnChartTypeChoices.BAR,
+                False,
+                1,
+                21,
                 False,
                 False,
             ),
             # Don't show data labels on column charts.
-            # The five cases below repeat the previous five, but for column charts.
+            # The six cases below repeat the previous six, but for column charts.
             Case(
                 BarColumnChartTypeChoices.COLUMN,
                 True,
                 1,
+                10,
                 False,
                 False,
             ),
@@ -237,6 +272,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.COLUMN,
                 True,
                 2,
+                10,
                 False,
                 False,
             ),
@@ -244,6 +280,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.COLUMN,
                 True,
                 1,
+                10,
                 True,
                 False,
             ),
@@ -251,6 +288,7 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.COLUMN,
                 True,
                 2,
+                10,
                 True,
                 False,
             ),
@@ -258,6 +296,15 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 BarColumnChartTypeChoices.COLUMN,
                 True,
                 3,
+                10,
+                False,
+                False,
+            ),
+            Case(
+                BarColumnChartTypeChoices.COLUMN,
+                True,
+                1,
+                21,
                 False,
                 False,
             ),
@@ -273,9 +320,10 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 self.raw_data["table"] = TableDataFactory(
                     table_data=[
                         ["", *[f"Series {i}" for i in range(1, testcase.series_count + 1)]],
-                        ["2005", *["100"] * testcase.series_count],
-                        ["2006", *["120"] * testcase.series_count],
-                        ["2007", *["140"] * testcase.series_count],
+                        *[
+                            [str(2005 + i), *[str(100 + (i * 20))] * testcase.series_count]
+                            for i in range(testcase.data_points_count)
+                        ],
                     ]
                 )
 


### PR DESCRIPTION
### What is the context of this PR?

See https://jira.ons.gov.uk/browse/CCB-148

The Design System code is quite process intensive for calculating the positions of data labels. The DS has been updated to disallow data labels on bar charts with more than 20 data points - this is the equivalent change for the chart builder.

### How to review

In your local build, try adding a bar chart with more than 20 rows in the table. When you select to show data labels, they should not display. The help text should explain this.

The rule that data labels are only allowed on bar charts with 1 or 2 series should still apply.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
