### PR TITLE
Enable chart axis min/max configuration

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -54,7 +54,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
 
     # Always define axes in subclasses
     x_axis = blocks.StaticBlock()
-    y_axis = blocks.StructBlock()
+    y_axis = blocks.StaticBlock()
 
     DESKTOP_ASPECT_RATIO = "desktop_aspect_ratio"
     MOBILE_ASPECT_RATIO = "mobile_aspect_ratio"

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -8,7 +8,6 @@ from wagtail.blocks.struct_block import StructValue
 
 from cms.datavis.blocks.chart_options import AspectRatioBlock
 from cms.datavis.blocks.table import SimpleTableBlock
-from cms.datavis.blocks.utils import TextInputFloatBlock
 from cms.datavis.constants import AxisType, HighChartsChartType, HighchartsTheme
 
 AnnotationsList = list[dict[str, Any]]
@@ -53,49 +52,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
         "periods missing.",
     )
 
-    # X axis
-    x_axis = blocks.StructBlock(
-        [
-            (
-                "title",
-                blocks.CharBlock(
-                    required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents.",
-                ),
-            ),
-            ("min", TextInputFloatBlock(label="Minimum", required=False)),
-            ("max", TextInputFloatBlock(label="Maximum", required=False)),
-            (
-                "tick_interval_mobile",
-                TextInputFloatBlock(label="Tick interval (mobile)", required=False),
-            ),
-            (
-                "tick_interval_desktop",
-                TextInputFloatBlock(label="Tick interval (desktop)", required=False),
-            ),
-        ]
-    )
-
-    # Y axis
-    y_axis = blocks.StructBlock(
-        [
-            (
-                "title",
-                blocks.CharBlock(
-                    required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents.",
-                ),
-            ),
-            ("min", TextInputFloatBlock(label="Minimum", required=False)),
-            ("max", TextInputFloatBlock(label="Maximum", required=False)),
-            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
-            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
-            ("value_suffix", blocks.CharBlock(required=False)),  # TODO: implement non-stripping charblock for affixes
-            ("tooltip_suffix", blocks.CharBlock(required=False)),  # TODO: implement non-stripping charblock for affixes
-        ]
-    )
+    # Always define axes in subclasses
+    x_axis = blocks.StaticBlock()
+    y_axis = blocks.StructBlock()
 
     DESKTOP_ASPECT_RATIO = "desktop_aspect_ratio"
     MOBILE_ASPECT_RATIO = "mobile_aspect_ratio"
@@ -201,8 +160,12 @@ class BaseVisualisationBlock(blocks.StructBlock):
             config["tickIntervalDesktop"] = tick_interval_desktop
         if (min_value := attrs.get("min")) is not None:
             config["min"] = min_value
+        if (start_on_tick := attrs.get("start_on_tick")) is not None:
+            config["startOnTick"] = start_on_tick
         if (max_value := attrs.get("max")) is not None:
             config["max"] = max_value
+        if (end_on_tick := attrs.get("end_on_tick")) is not None:
+            config["endOnTick"] = end_on_tick
         return config
 
     def get_y_axis_config(
@@ -227,8 +190,12 @@ class BaseVisualisationBlock(blocks.StructBlock):
             }
         if (min_value := attrs.get("min")) is not None:
             config["min"] = min_value
+        if (start_on_tick := attrs.get("start_on_tick")) is not None:
+            config["startOnTick"] = start_on_tick
         if (max_value := attrs.get("max")) is not None:
             config["max"] = max_value
+        if (end_on_tick := attrs.get("end_on_tick")) is not None:
+            config["endOnTick"] = end_on_tick
         return config
 
     def get_annotations_config(self, value: "StructValue") -> AnnotationsReturn:

--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -20,6 +20,7 @@ from cms.datavis.blocks.base import BaseVisualisationBlock
 from cms.datavis.blocks.table import SimpleTableBlock, TableDataType
 from cms.datavis.blocks.utils import TextInputFloatBlock, TextInputIntegerBlock
 from cms.datavis.constants import (
+    AXIS_TITLE_HELP_TEXT,
     AxisType,
     BarColumnChartTypeChoices,
     BarColumnConfidenceIntervalChartTypeChoices,
@@ -51,6 +52,25 @@ class LineChartBlock(BaseVisualisationBlock):
             ("reference_line", LineAnnotationCategoricalBlock()),
         ],
         required=False,
+    )
+
+    x_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+        ]
+    )
+    y_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=True, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=True, required=False)),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+        ]
     )
 
     class Meta:
@@ -107,8 +127,7 @@ class BarColumnChartBlock(BaseVisualisationBlock):
                 "title",
                 blocks.CharBlock(
                     required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents. Column charts only.",
+                    help_text=AXIS_TITLE_HELP_TEXT,
                 ),
             ),
         ],
@@ -121,13 +140,13 @@ class BarColumnChartBlock(BaseVisualisationBlock):
                 "title",
                 blocks.CharBlock(
                     required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents.",
+                    help_text=AXIS_TITLE_HELP_TEXT,
                 ),
             ),
-            # TODO: Add min/max once support is added to the Design System
-            # ("min", TextInputFloatBlock(label="Minimum", required=False)),
-            # ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=True, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=True, required=False)),
             ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
             ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
         ],
@@ -319,31 +338,19 @@ class BarColumnConfidenceIntervalChartBlock(BaseVisualisationBlock):
     )
     # NB X_axis is labelled "Category axis" for bar/column charts
     x_axis = blocks.StructBlock(
-        [
-            (
-                "title",
-                blocks.CharBlock(
-                    required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents. Column charts only.",
-                ),
-            ),
-        ],
+        [("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT))],
         label="Category axis",
     )
     # NB Y_axis is labelled "Value axis" for bar/column charts
     y_axis = blocks.StructBlock(
         [
-            (
-                "title",
-                blocks.CharBlock(
-                    required=False,
-                    help_text="Only use axis titles if it is not clear from the title "
-                    "and subtitle what the axis represents.",
-                ),
-            ),
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
             ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
             ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=True, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=True, required=False)),
         ],
         label="Value axis",
     )
@@ -501,6 +508,29 @@ class ScatterPlotBlock(BaseVisualisationBlock):
     series_customisation = None
     show_markers = None
 
+    x_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=False, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=False, required=False)),
+        ]
+    )
+    y_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=True, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=True, required=False)),
+        ]
+    )
+
     TABLE_DEFAULT_DATA: TableDataType = (
         ["X", "Y", "Group"],
         ["", "", ""],
@@ -567,6 +597,31 @@ class AreaChartBlock(BaseVisualisationBlock):
             ("reference_line", LineAnnotationCategoricalBlock()),
         ],
         required=False,
+    )
+
+    x_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            (
+                "tick_interval_mobile",
+                TextInputFloatBlock(label="Tick interval (mobile)", required=False),
+            ),
+            (
+                "tick_interval_desktop",
+                TextInputFloatBlock(label="Tick interval (desktop)", required=False),
+            ),
+        ]
+    )
+    y_axis = blocks.StructBlock(
+        [
+            ("title", blocks.CharBlock(required=False, help_text=AXIS_TITLE_HELP_TEXT)),
+            ("tick_interval_mobile", TextInputFloatBlock(label="Tick interval (mobile)", required=False)),
+            ("tick_interval_desktop", TextInputFloatBlock(label="Tick interval (desktop)", required=False)),
+            ("min", TextInputFloatBlock(label="Minimum", required=False)),
+            ("start_on_tick", blocks.BooleanBlock(label="Start on tick", default=True, required=False)),
+            ("max", TextInputFloatBlock(label="Maximum", required=False)),
+            ("end_on_tick", blocks.BooleanBlock(label="End on tick", default=True, required=False)),
+        ]
     )
 
     class Meta:

--- a/cms/datavis/constants.py
+++ b/cms/datavis/constants.py
@@ -45,3 +45,6 @@ class BarColumnConfidenceIntervalChartTypeChoices(TextChoices):
 
     BAR = "columnrange", "Bar"
     COLUMN = "boxplot", "Column"
+
+
+AXIS_TITLE_HELP_TEXT = "Only use axis titles if it is not clear from the title and subtitle what the axis represents."

--- a/cms/datavis/tests/test_area_chart_block.py
+++ b/cms/datavis/tests/test_area_chart_block.py
@@ -90,3 +90,37 @@ class AreaChartBlockTestCase(BaseChartBlockTestCase):
         self.raw_data["y_axis"]["title"] = ""
         config = self.get_component_config()
         self.assertEqual(None, config["yAxis"]["title"])
+
+    def test_y_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the y-axis."""
+        self.raw_data["y_axis"]["min"] = 0.0
+        self.raw_data["y_axis"]["max"] = 150.0
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(0.0, y_axis_config["min"])
+        self.assertEqual(150.0, y_axis_config["max"])
+
+    def test_y_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to True for y-axis."""
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(True, y_axis_config["startOnTick"])
+        self.assertEqual(True, y_axis_config["endOnTick"])
+
+    def test_y_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the y-axis."""
+        self.raw_data["y_axis"]["start_on_tick"] = False
+        self.raw_data["y_axis"]["end_on_tick"] = False
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(False, y_axis_config["startOnTick"])
+        self.assertEqual(False, y_axis_config["endOnTick"])
+
+    def test_x_axis_min_max_not_configurable(self):
+        """Test that min/max values are not configurable for x-axis on area charts."""
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("min", x_axis_config)
+        self.assertNotIn("max", x_axis_config)
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)

--- a/cms/datavis/tests/test_bar_column_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_chart_block.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-public-methods
 from typing import NamedTuple, cast
 from unittest import mock
 
@@ -407,6 +408,73 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
         for key in ["tickIntervalMobile", "tickIntervalDesktop"]:
             with self.subTest(key=key):
                 self.assertNotIn(key, x_axis_config)
+
+    def test_value_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the value axis."""
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.raw_data["y_axis"]["min"] = 10.5
+                self.raw_data["y_axis"]["max"] = 100.0
+                self.block.clean(self.get_value())
+                y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+                self.assertEqual(10.5, y_axis_config["min"])
+                self.assertEqual(100.0, y_axis_config["max"])
+
+    def test_value_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to False for value axis."""
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.block.clean(self.get_value())
+                y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+                self.assertEqual(True, y_axis_config["startOnTick"])
+                self.assertEqual(True, y_axis_config["endOnTick"])
+
+    def test_value_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the value axis."""
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.raw_data["y_axis"]["start_on_tick"] = False
+                self.raw_data["y_axis"]["end_on_tick"] = False
+                self.block.clean(self.get_value())
+                y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+                self.assertEqual(False, y_axis_config["startOnTick"])
+                self.assertEqual(False, y_axis_config["endOnTick"])
+
+    def test_category_axis_min_max_configuration(self):
+        """Test that min/max values are not configured for the category axis."""
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.block.clean(self.get_value())
+                x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+                self.assertNotIn("min", x_axis_config)
+                self.assertNotIn("max", x_axis_config)
+                self.assertNotIn("startOnTick", x_axis_config)
+                self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_category_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick are not configured for category axis."""
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.block.clean(self.get_value())
+                x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+                self.assertNotIn("startOnTick", x_axis_config)
+                self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_category_axis_limits_not_configurable(self):
+        for chart_type in BarColumnChartTypeChoices.values:
+            with self.subTest(chart_type=chart_type):
+                self.raw_data["select_chart_type"] = chart_type
+                self.block.clean(self.get_value())
+                x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+                self.assertNotIn("min", x_axis_config)
+                self.assertNotIn("max", x_axis_config)
+                self.assertNotIn("startOnTick", x_axis_config)
+                self.assertNotIn("endOnTick", x_axis_config)
 
 
 class ColumnChartWithLineTestCase(BaseChartBlockTestCase):

--- a/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_confidence_interval_chart_block.py
@@ -314,3 +314,70 @@ class BarColumnConfidenceIntervalChartBlockTestCase(BaseChartBlockTestCase):
                 self.raw_data["y_axis"]["title"] = ""
                 config = self.get_component_config()
                 self.assertEqual(None, config["yAxis"]["title"])
+
+    def test_highcharts_chart_type(self):
+        # The chart type is determined by the select_chart_type field, not a fixed highcharts_chart_type
+        self.assertEqual("columnrange", self.block.get_highcharts_chart_type(self.get_value()))
+
+    def test_value_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the value axis."""
+        self.raw_data["y_axis"]["min"] = 10.0
+        self.raw_data["y_axis"]["max"] = 90.0
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(10.0, y_axis_config["min"])
+        self.assertEqual(90.0, y_axis_config["max"])
+
+    def test_value_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to True for value axis."""
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(True, y_axis_config["startOnTick"])
+        self.assertEqual(True, y_axis_config["endOnTick"])
+
+    def test_value_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the value axis."""
+        self.raw_data["y_axis"]["start_on_tick"] = False
+        self.raw_data["y_axis"]["end_on_tick"] = False
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(False, y_axis_config["startOnTick"])
+        self.assertEqual(False, y_axis_config["endOnTick"])
+
+    def test_category_axis_min_max_configuration_bar_chart(self):
+        """Test that min/max values are not configured for the category axis on bar charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("min", x_axis_config)
+        self.assertNotIn("max", x_axis_config)
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_category_axis_start_end_on_tick_defaults_bar_chart(self):
+        """Test that start_on_tick and end_on_tick are not configured for category axis on bar charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_category_axis_start_end_on_tick_configuration_bar_chart(self):
+        """Test that start_on_tick and end_on_tick are not configured for the category axis on bar charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.BAR
+        self.raw_data["x_axis"]["start_on_tick"] = True
+        self.raw_data["x_axis"]["end_on_tick"] = True
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_category_axis_min_max_not_configured_column_chart(self):
+        """Test that min/max values are not configured for category axis on column charts."""
+        self.raw_data["select_chart_type"] = BarColumnConfidenceIntervalChartTypeChoices.COLUMN
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("min", x_axis_config)
+        self.assertNotIn("max", x_axis_config)
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)

--- a/cms/datavis/tests/test_line_chart_block.py
+++ b/cms/datavis/tests/test_line_chart_block.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-public-methods
 from django.core.exceptions import ValidationError
 from wagtail.blocks.struct_block import StructValue
 
@@ -159,3 +160,37 @@ class LineChartBlockTestCase(BaseChartBlockTestCase):
                 self.assertEqual(expected, config[axis][set_key])
             with self.subTest(axis=axis, key=unset_key, condition="not configured"):
                 self.assertNotIn(unset_key, config[axis])
+
+    def test_y_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the y-axis."""
+        self.raw_data["y_axis"]["min"] = 0.0
+        self.raw_data["y_axis"]["max"] = 200.0
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(0.0, y_axis_config["min"])
+        self.assertEqual(200.0, y_axis_config["max"])
+
+    def test_y_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to True for y-axis."""
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(True, y_axis_config["startOnTick"])
+        self.assertEqual(True, y_axis_config["endOnTick"])
+
+    def test_y_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the y-axis."""
+        self.raw_data["y_axis"]["start_on_tick"] = False
+        self.raw_data["y_axis"]["end_on_tick"] = False
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(False, y_axis_config["startOnTick"])
+        self.assertEqual(False, y_axis_config["endOnTick"])
+
+    def test_x_axis_min_max_not_configurable(self):
+        """Test that min/max values are not configurable for x-axis on line charts."""
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertNotIn("min", x_axis_config)
+        self.assertNotIn("max", x_axis_config)
+        self.assertNotIn("startOnTick", x_axis_config)
+        self.assertNotIn("endOnTick", x_axis_config)

--- a/cms/datavis/tests/test_scatter_plot_block.py
+++ b/cms/datavis/tests/test_scatter_plot_block.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-public-methods
 from django.core.exceptions import ValidationError
 from wagtail.blocks.struct_block import StructValue
 
@@ -52,6 +53,63 @@ class ScatterPlotBlockTestCase(BaseChartBlockTestCase):
 
     def test_get_component_config(self):
         self._test_get_component_config()
+
+    def test_x_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the x-axis."""
+        self.raw_data["x_axis"]["min"] = 0.5
+        self.raw_data["x_axis"]["max"] = 10.0
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertEqual(0.5, x_axis_config["min"])
+        self.assertEqual(10.0, x_axis_config["max"])
+
+    def test_y_axis_min_max_configuration(self):
+        """Test that min/max values are correctly configured for the y-axis."""
+        self.raw_data["y_axis"]["min"] = -5.0
+        self.raw_data["y_axis"]["max"] = 50.0
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(-5.0, y_axis_config["min"])
+        self.assertEqual(50.0, y_axis_config["max"])
+
+    def test_x_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to False for x-axis.
+
+        NB this is the only chart type (at the time of writing) that supports
+        min/max values for a Highcharts xAxis (not counting bar chart, where
+        Highcharts calls its horizontal value axis the yAxis). Highcharts's
+        default start/end-on-tick behaviour for xAxis is False, contrasting
+        with True for yAxis.
+        """
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertEqual(False, x_axis_config["startOnTick"])
+        self.assertEqual(False, x_axis_config["endOnTick"])
+
+    def test_y_axis_start_end_on_tick_defaults(self):
+        """Test that start_on_tick and end_on_tick default to True for y-axis."""
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(True, y_axis_config["startOnTick"])
+        self.assertEqual(True, y_axis_config["endOnTick"])
+
+    def test_x_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the x-axis."""
+        self.raw_data["x_axis"]["start_on_tick"] = False
+        self.raw_data["x_axis"]["end_on_tick"] = False
+        self.block.clean(self.get_value())
+        x_axis_config = self.get_value().block.get_component_config(self.get_value())["xAxis"]
+        self.assertEqual(False, x_axis_config["startOnTick"])
+        self.assertEqual(False, x_axis_config["endOnTick"])
+
+    def test_y_axis_start_end_on_tick_configuration(self):
+        """Test that start_on_tick and end_on_tick can be configured for the y-axis."""
+        self.raw_data["y_axis"]["start_on_tick"] = False
+        self.raw_data["y_axis"]["end_on_tick"] = False
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(False, y_axis_config["startOnTick"])
+        self.assertEqual(False, y_axis_config["endOnTick"])
 
     def test_highcharts_chart_type(self):
         self.assertEqual(HighChartsChartType.SCATTER, self.block.highcharts_chart_type)


### PR DESCRIPTION
### What is the context of this PR?

Enable configuration of axis min/max limits for some chart types, and add "start/end on tick" checkboxes.

Ticket: https://jira.ons.gov.uk/browse/CCB-117

### How to review

See the x-axis and y-axis (or "value" axis) configuration for a chart type.

I have removed the placeholder fields for suffixes, which were a legacy from the proof-of-concept version of this code.

I have also used this opportunity to standardise on all chart types explicitly declaring their axis structblocks, as the rest of the code was heading in this direction anyway.