### PR TITLE
Add audio description field

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -27,6 +27,9 @@ class BaseVisualisationBlock(blocks.StructBlock):
 
     title = blocks.CharBlock()
     subtitle = blocks.CharBlock()
+    audio_description = blocks.TextBlock(
+        required=True, help_text="An overview of what the chart shows for screen readers."
+    )
     caption = blocks.CharBlock(required=False)
 
     table = SimpleTableBlock(label="Data table")
@@ -114,6 +117,7 @@ class BaseVisualisationBlock(blocks.StructBlock):
             "chartType": self.get_highcharts_chart_type(value),
             "theme": value.get("theme"),
             "headingLevel": 3,
+            "description": value.get("audio_description"),
             "title": value.get("title"),
             "subtitle": value.get("subtitle"),
             "caption": value.get("caption"),

--- a/cms/datavis/tests/test_chart_blocks_base.py
+++ b/cms/datavis/tests/test_chart_blocks_base.py
@@ -23,6 +23,7 @@ class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
             "title": "Test Chart",
             "subtitle": "Test Subtitle",
             "caption": "Test Caption",
+            "audio_description": "Test Audio Description",
             "table": TableDataFactory(),
             "theme": "primary",
             "show_legend": True,
@@ -64,6 +65,7 @@ class BaseChartBlockTestCase(SimpleTestCase, WagtailTestUtils):
             # `value` dict key, expected value
             ("title", "Test Chart"),
             ("subtitle", "Test Subtitle"),
+            ("audio_description", "Test Audio Description"),
             ("caption", "Test Caption"),
         ]
         if "theme" in self.block.child_blocks:

--- a/cms/datavis/tests/test_scatter_plot_block.py
+++ b/cms/datavis/tests/test_scatter_plot_block.py
@@ -17,6 +17,7 @@ class ScatterPlotBlockTestCase(BaseChartBlockTestCase):
             "title": "Test Chart",
             "subtitle": "Test Subtitle",
             "caption": "Test Caption",
+            "audio_description": "Test Audio Description",
             "table": TableDataFactory(
                 table_data=[
                     ["X", "Y", "Group"],

--- a/functional_tests/features/statistical_article_page.feature
+++ b/functional_tests/features/statistical_article_page.feature
@@ -134,6 +134,7 @@ Feature: Statistical Article Page components
         And the user switches to the Promote tab
         And the user clicks "Line chart" in the featured chart streamfield block selector
         And the user fills in the line chart title
+        And the user fills in the chart audio description
         And the user enters data into the chart table
         And the user clicks "Publish"
         Then submitting the Wagtail page edit form is successful

--- a/functional_tests/features/statistical_article_page.feature
+++ b/functional_tests/features/statistical_article_page.feature
@@ -155,6 +155,7 @@ Feature: Statistical Article Page components
         And the user switches to the Promote tab
         And the user clicks "Line chart" in the featured chart streamfield block selector
         And the user fills in the line chart title
+        And the user fills in the chart audio description
         And the user enters data into the chart table
         And the user selects the "featured chart" preview mode
         Then the user sees a preview of the containing Topic page

--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -395,7 +395,6 @@ def user_fills_in_chart_title(context: Context):
 @step("the user fills in the chart audio description")
 def user_fills_in_chart_audio_description(context: Context):
     featured_chart_content = context.page.locator("#panel-child-promote-featured_chart-content")
-    context.page.pause()
     featured_chart_content.get_by_label("Audio Description*").fill("This is the audio description")
 
 

--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -392,6 +392,13 @@ def user_fills_in_chart_title(context: Context):
     featured_chart_content.get_by_label("Title*").fill("Test Chart")
 
 
+@step("the user fills in the chart audio description")
+def user_fills_in_chart_audio_description(context: Context):
+    featured_chart_content = context.page.locator("#panel-child-promote-featured_chart-content")
+    context.page.pause()
+    featured_chart_content.get_by_label("Audio Description*").fill("This is the audio description")
+
+
 @step("the user enters data into the chart table")
 def user_enters_data_into_chart_table(context: Context):
     """Fill the table with test data by clicking and typing in each cell."""

--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -462,6 +462,7 @@ def a_statistical_article_page_with_configured_featured_chart_exists(context: Co
             "value": {
                 "title": "Test Chart",
                 "subtitle": "Test Subtitle",
+                "audio_description": "This is the audio description",
                 "table": TableDataFactory(table_data=[["", "Series 1"], ["2005", "100"]]),
                 "theme": "primary",
                 "show_legend": True,


### PR DESCRIPTION
### What is the context of this PR?

See https://jira.ons.gov.uk/browse/CCB-150
Adds a required audio description field for all charts.

### How to review

Check that when you edit a statistical article page, and add a chart, the audio description field is present and required.
Todo: add the field to the featured chart once that work is merged.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
