### PR TITLE
Custom reference line, for indexed data

### DIFF
--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -200,6 +200,8 @@ class BaseVisualisationBlock(blocks.StructBlock):
             config["max"] = max_value
         if (end_on_tick := attrs.get("end_on_tick")) is not None:
             config["endOnTick"] = end_on_tick
+        if (custom_reference_line := attrs.get("custom_reference_line")) is not None:
+            config["customReferenceLineValue"] = custom_reference_line
         return config
 
     def get_annotations_config(self, value: "StructValue") -> AnnotationsReturn:

--- a/cms/datavis/tests/test_bar_column_chart_block.py
+++ b/cms/datavis/tests/test_bar_column_chart_block.py
@@ -476,6 +476,85 @@ class BarColumnChartBlockTestCase(BaseChartBlockTestCase):
                 self.assertNotIn("startOnTick", x_axis_config)
                 self.assertNotIn("endOnTick", x_axis_config)
 
+    def test_custom_reference_line_with_one_series(self):
+        self.raw_data["select_chart_type"] = BarColumnChartTypeChoices.COLUMN
+        self.raw_data["y_axis"]["custom_reference_line"] = 100
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Series 1"],
+                ["2005", "100"],
+                ["2006", "120"],
+                ["2007", "140"],
+            ]
+        )
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(100, y_axis_config["customReferenceLineValue"])
+
+    def test_custom_reference_line_not_supported_for_bar_charts(self):
+        self.raw_data["select_chart_type"] = BarColumnChartTypeChoices.BAR
+        self.raw_data["y_axis"]["custom_reference_line"] = 100
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Series 1"],  # only one series
+                ["2005", "100"],
+                ["2006", "120"],
+                ["2007", "140"],
+            ]
+        )
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+        self.assertEqual(
+            BarColumnChartBlock.ERROR_HORIZONTAL_BAR_NO_CUSTOM_REFERENCE_LINE,
+            cm.exception.block_errors["y_axis"].block_errors["custom_reference_line"].code,
+        )
+
+    def test_custom_reference_line_not_supported_for_multiple_series(self):
+        self.raw_data["select_chart_type"] = BarColumnChartTypeChoices.COLUMN
+        self.raw_data["y_axis"]["custom_reference_line"] = 100
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Series 1", "Series 2"],
+                ["2005", "100", "50"],
+                ["2006", "120", "55"],
+                ["2007", "140", "60"],
+            ]
+        )
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+        self.assertEqual(
+            BarColumnChartBlock.ERROR_MULTIPLE_SERIES_NO_REFERENCE_LINE,
+            cm.exception.block_errors["y_axis"].block_errors["custom_reference_line"].code,
+        )
+
+    def test_custom_reference_line_not_supported_for_line_overlay(self):
+        """Line overlay requires a series, so custom reference line is not supported.
+
+        It's questionable whether this should be allowed, but it's not
+        currently. Extra validation would be necessary to permit this.
+
+        This test is to ensure that the tests are updated if this feature is
+        supported in future.
+        """
+        self.raw_data["select_chart_type"] = BarColumnChartTypeChoices.COLUMN
+        self.raw_data["use_stacked_layout"] = True
+        self.raw_data["y_axis"]["custom_reference_line"] = 100
+        self.raw_data["series_customisation"] = [{"type": "series_as_line_overlay", "value": 1}]
+        self.raw_data["table"] = TableDataFactory(
+            table_data=[
+                ["", "Series 1", "Series 2"],
+                ["2005", "100", "50"],
+                ["2006", "120", "55"],
+                ["2007", "140", "60"],
+            ]
+        )
+        with self.assertRaises(blocks.StructBlockValidationError) as cm:
+            self.block.clean(self.get_value())
+        self.assertEqual(
+            BarColumnChartBlock.ERROR_MULTIPLE_SERIES_NO_REFERENCE_LINE,
+            cm.exception.block_errors["y_axis"].block_errors["custom_reference_line"].code,
+        )
+
 
 class ColumnChartWithLineTestCase(BaseChartBlockTestCase):
     block_type = BarColumnChartBlock

--- a/cms/datavis/tests/test_line_chart_block.py
+++ b/cms/datavis/tests/test_line_chart_block.py
@@ -194,3 +194,9 @@ class LineChartBlockTestCase(BaseChartBlockTestCase):
         self.assertNotIn("max", x_axis_config)
         self.assertNotIn("startOnTick", x_axis_config)
         self.assertNotIn("endOnTick", x_axis_config)
+
+    def test_custom_reference_line(self):
+        self.raw_data["y_axis"]["custom_reference_line"] = 100
+        self.block.clean(self.get_value())
+        y_axis_config = self.get_value().block.get_component_config(self.get_value())["yAxis"]
+        self.assertEqual(100, y_axis_config["customReferenceLineValue"])


### PR DESCRIPTION
### What is the context of this PR?

This enables a custom thicker line at a value other than zero, for indexed data.

Ticket: https://jira.ons.gov.uk/browse/CCB-127

### How to review

In a line chart or bar/column chart (the latter set to column orientation), add a "custom reference line" value to the y-axis configuration.

<details><summary>Screenshot</summary>
<p>

![Screenshot from 2025-07-04 16-42-29](https://github.com/user-attachments/assets/ae781c4b-e994-4291-912d-83cc25b63cdc)

</p>
</details> 