### PR TITLE
feat: enable Mailpit for email testing in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Wagtail CMS for managing and publishing content for the Office for National 
         - [Front-end](#front-end)
         - [pre-commit](#pre-commit)
         - [Megalinter](#megalinter-lintformat-non-python-files)
+    - [Mailpit (Email Testing)](#mailpit-email-testing)
     - [Django Migrations](#django-migrations)
 - [Contributing](#contributing)
 - [License](#license)
@@ -436,6 +437,30 @@ To start the linter and automatically rectify fixable issues, run:
 ```bash
 make megalint
 ```
+
+### Mailpit (Email Testing)
+
+Mailpit is a lightweight, local SMTP server and web interface that captures all outgoing email from our application without actually delivering it.
+Rather than sending mail to real recipients, messages are stored in Mailpit’s inbox for easy inspection.
+
+- **SMTP endpoint:** `localhost:1025`
+- **Web UI:** [http://localhost:8025](http://localhost:8025)
+
+Use Mailpit to:
+
+- Preview email content, headers and attachments
+- Verify templates and formatting before going to production
+- Test email-related workflows
+
+No additional configuration is needed here – our development settings already point at Mailpit’s SMTP port,
+and every `send_mail` call will appear instantly in the UI.
+
+> [!TIP]
+> If you want to disable Mailpit and simply log emails to your console, switch to Django’s console backend:
+>
+> ```python
+> EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+> ```
 
 ### Django Migrations
 

--- a/cms/bundles/templates/bundles/notification_emails/html_variant/base_email.html
+++ b/cms/bundles/templates/bundles/notification_emails/html_variant/base_email.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="description" content="You have received a new notification about your bundle.">
+        <title>{% block title %}{% endblock %}</title>
+    </head>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/cms/bundles/templates/bundles/notification_emails/html_variant/bundle_in_review_email.html
+++ b/cms/bundles/templates/bundles/notification_emails/html_variant/bundle_in_review_email.html
@@ -1,16 +1,47 @@
-Hello,
+{% extends "bundles/notification_emails/html_variant/base_email.html" %}
 
-The preview of your release {{bundle_name}} is available for review.
-Please follow this link: {{bundle_inspect_url}} to review.
-Login using your existing Florence user name and password.
-Guidance on how to use Wagtail is available here [link to SharePoint TBC].
+{% block title %}Bundle "{{bundle.name}}" is ready for review{% endblock %}
 
-Changes to your release should be requested via your Tracker change log.
+{% block content %}
+    <!-- djlint:off H021-->     
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+            <td style="padding:0 24px; font-family:Arial, sans-serif;">
 
-If you have any questions please contact your named Publishing Officer (list available <a href="https://statics.teams.cdn.office.net.mcas.ms/evergreen-assets/safelinks/1/atp-safelinks.html">here</a>).
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Hello,
+                </p>
 
-Do not reply directly to this message as this inbox is not monitored.
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    The preview of your release {{bundle_name}} is available for review.<br>
+                    Please follow this link: <a href="{{bundle_inspect_url}}">{{bundle_inspect_url}}</a> to review.<br>
+                    Login using your existing Florence user name and password.<br>
+                    Guidance on how to use Wagtail is available here [link to SharePoint TBC].
+                </p>
 
-Kind regards,
-Publishing team
-Publishing@ons.gov.uk
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Changes to your release should be requested via your Tracker change log.
+                </p>
+
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    If you have any questions please contact your named Publishing Officer (list available <a href="https://statics.teams.cdn.office.net.mcas.ms/evergreen-assets/safelinks/1/atp-safelinks.html">here</a>).
+                </p>
+
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Do not reply directly to this message as this inbox is not monitored.
+                </p>
+
+                <p style="margin:0 0 8px 0; line-height:1.4;">
+                    Kind regards,
+                </p>
+
+                <p style="margin:0; line-height:1.4;">
+                    Publishing team<br>
+                    <a href="mailto:Publishing@ons.gov.uk" style="color:#0066cc;">Publishing@ons.gov.uk</a>
+                </p>
+
+            </td>
+        </tr>
+    </table>
+    <!-- djlint:on -->
+{% endblock %}

--- a/cms/bundles/templates/bundles/notification_emails/html_variant/bundle_published_email.html
+++ b/cms/bundles/templates/bundles/notification_emails/html_variant/bundle_published_email.html
@@ -1,11 +1,40 @@
-Hello,
+{% extends "bundles/notification_emails/html_variant/base_email.html" %}
 
-Your release {{bundle_name}} has now been published to the ONS website.
+{% block title %}Bundle "{{bundle_name}}" has been published{% endblock %}
 
-Please review your release on the ONS website and contact the Publishing team if you require any further support.
+{% block content %}
+    <!-- djlint:off H021-->
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+            <td style="padding:0 24px; font-family:Arial, sans-serif;">
 
-Do not reply to this message as this mailbox isn't monitored.
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Hello,
+                </p>
 
-Kind regards,
-Publishing team
-Publishing@ons.gov.uk
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Your release {{bundle_name}} has now been published on the ONS website.
+                </p>
+
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Please review the release on the ONS website and contact the Publishing team if you need any further support.
+                </p>
+
+                <p style="margin:0 0 16px 0; line-height:1.4;">
+                    Do not reply to this message, as this mailbox is not monitored.
+                </p>
+
+                <p style="margin:0 0 8px 0; line-height:1.4;">
+                    Kind regards,
+                </p>
+
+                <p style="margin:0; line-height:1.4;">
+                    Publishing team<br>
+                    <a href="mailto:Publishing@ons.gov.uk" style="color:#0066cc;">Publishing@ons.gov.uk</a>
+                </p>
+
+            </td>
+        </tr>
+    </table>
+    <!-- djlint:on -->
+{% endblock %}

--- a/cms/settings/dev.py
+++ b/cms/settings/dev.py
@@ -19,8 +19,11 @@ INTERNAL_IPS = ("127.0.0.1", "10.0.2.2")
 # This is only to test Wagtail emails.
 WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
-# Display sent emails in the console while developing locally.
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Display sent emails in via mailpit @ http://localhost:8025
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = env.get("EMAIL_HOST", "localhost")
+EMAIL_PORT = 1025
+EMAIL_USE_TLS = False
 
 # Sender address for email notifications
 DEFAULT_FROM_EMAIL = "cms@example.com"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -54,5 +54,11 @@ services:
     ports:
       - '9094:9094'
 
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - '1025:1025' # SMTP port
+      - '8025:8025' # HTTP UI at http://localhost:8025
+
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       STATIC_URL: /static/
       KAFKA_SERVERS: broker:9092
       WAGTAIL_CORE_ADMIN_LOGIN_ENABLED: true
+      EMAIL_HOST: mailpit
     ports:
       - 3000:3000 # webpack
       - 8000:8000 # runserver
@@ -56,6 +57,11 @@ services:
     extends:
       file: docker-compose-dev.yml
       service: broker
+
+  mailpit:
+    extends:
+      file: docker-compose-dev.yml
+      service: mailpit
 
 volumes:
   node_modules:


### PR DESCRIPTION
### What is the context of this PR?

Introduces Mailpit as a local email testing tool for development. It captures outgoing messages so you can verify template formatting, headers and attachments without deploying the app or relying on real mail servers. [Mailpit](https://github.com/axllent/mailpit) is actively maintained, hence we are using it over MailHog, regardless of it being a dev dependency.

 - Adds a Mailpit service to docker-compose.yml
- Updates `cms/settings/dev.py` to point Django’s SMTP backend at Mailpit
- Adds a Mailpit (Email Testing) section to the README explaining purpose and how to disable it.

### How to review

Ensure the changes are appropriate and that emails are received by the Mailpit client.

Trigger a test email (follow the instructions in https://github.com/ONSdigital/dis-wagtail/pull/298) and confirm the emails appear in Mailpit UI at http://localhost:8025/.

Test the changes work both inside the full dockerised vs partial docker set up (Wagtail locally)

<img width="1792" height="222" alt="Screenshot 2025-07-11 at 13 07 57" src="https://github.com/user-attachments/assets/f6a94756-5900-4806-bc93-fbef7446dfbb" />
<img width="1790" height="671" alt="Screenshot 2025-07-11 at 13 08 05" src="https://github.com/user-attachments/assets/4ac9b680-06ff-4dc3-bc44-db02d3311fbf" />



### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
