### PR TITLE
Rendering LaTeX Equations Locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,18 @@ format-html:  ## Format the HTML code
 format-frontend:  ## Format front-end files (CSS, JS, YAML, MD)
 	npm run format
 
+.PHONY: nvm-use
+nvm-use: ## Use the Node Version Manager to set the Node version
+	nvm use
+	
+.PHONY: npm-install
+npm-install: nvm-use ## Install the Node.js dependencies
+	npm install
+
+.PHONY: npm-build
+npm-build: nvm-use ## Build the front-end assets
+	npm run build
+
 .PHONY: lint
 lint: lint-py lint-html lint-frontend lint-migrations ## Run all linters (python, html, front-end, migrations)
 
@@ -166,7 +178,7 @@ runserver: ## Run the Django application locally
 	poetry run python ./manage.py runserver 0:8000
 
 .PHONY: dev-init
-dev-init: load-design-system-templates collectstatic compilemessages makemigrations migrate load-topics createsuperuser  ## Run the pre-run setup scripts
+dev-init: load-design-system-templates collectstatic compilemessages makemigrations migrate load-topics createsuperuser npm-install npm-build ## Run the pre-run setup scripts
 
 .PHONY: functional-tests-up
 functional-tests-up:  ## Start the functional tests docker compose dependencies

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Ensure you have the following installed:
    using the Docker setup.
 5. **[Node](https://nodejs.org/en)** and **[`nvm` (Node Version Manager)](https://github.com/nvm-sh/nvm)** for front-end
    tooling.
-6. **[JQ](https://jqlang.github.io/jq/)** for the step in the build that installs the design system templates
-7. **Operation System**: Ubuntu/MacOS
+6. **[JQ](https://jqlang.github.io/jq/)** for the step in the build that installs the design system templates.
+7. **[MacPorts](https://www.macports.org/install.php)**: We need MacPorts so we can install the required packages to render equations using LaTeX strings via Matplotlib locally (outside of a docker container).
+8. **Operation System**: Ubuntu/ MacOS.
 
 ### Setup
 
@@ -461,6 +462,16 @@ and every `send_mail` call will appear instantly in the UI.
 > ```python
 > EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 > ```
+
+### Installing The Required LaTeX Packages For Local Development
+
+In order to generate the equations in Wagtail using LaTeX strings via Matplotlib (Non-JS Equations), we will need to use `MacPorts` to install the following packages `texlive-latex-extra`.
+
+As a prerequisite you will have to have `MacPorts` installed. See [Pre-requisites](#pre-requisites) step 7 for MacPorts installation.
+
+```bash
+sudo port install texlive-latex-extra
+```
 
 ### Django Migrations
 


### PR DESCRIPTION
### What is the context of this PR?

Currently, when we try to utilise the equation block in Wagtail CMS outside of the container, when running the application locally, it will break due to the equivalent packages for rendering equations are not installed locally for MacOS development. This additionally causes the tests to fail when running them locally.

### How to review

**Before**
- Go to an information page -> add an example equation in -> save draft/ publish -> the page would throw an error, not save. 

**After**

- Follow the updated README instructions to install using `MacPorts`
- Go to an information page -> add an example equation in -> save draft/ publish -> the page should save successfully  -> go to the full preview or live page -> turn off JS -> the equations should be rendering successfully.

**Bonus**
- After dev feedback from a couple of members in the team on time wasted, going in circles due to the required `Node packages` not being installed, and the `npm build` not taking place (as we assume everything should be good to go after running the `make dev-init` command), I have decided to add these as part of the `make dev-init` target.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
