### PR TITLE
Automatically disable global notifications for new Wagtail userprofiles

### DIFF
--- a/cms/users/signal_handlers.py
+++ b/cms/users/signal_handlers.py
@@ -2,8 +2,10 @@ import logging
 from typing import Any
 
 from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import HttpRequest
+from wagtail.users.models import UserProfile
 
 from cms.core.utils import get_client_ip
 
@@ -55,3 +57,20 @@ def audit_user_login_failed(sender: Any, credentials: dict, request: HttpRequest
             "user_agent": request.headers.get("User-Agent") if request else None,
         },
     )
+
+
+@receiver(post_save, sender=UserProfile)
+def disable_profile_notifications(sender: Any, instance: UserProfile, created: bool, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    if created:
+        instance.submitted_notifications = False
+        instance.approved_notifications = False
+        instance.rejected_notifications = False
+        instance.updated_comments_notifications = False
+        instance.save(
+            update_fields=[
+                "submitted_notifications",
+                "approved_notifications",
+                "rejected_notifications",
+                "updated_comments_notifications",
+            ]
+        )

--- a/cms/users/tests/test_signal_handlers.py
+++ b/cms/users/tests/test_signal_handlers.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.users.models import UserProfile
 
 
 class AuditLogTestCase(WagtailTestUtils, TestCase):
@@ -121,3 +122,30 @@ class AuditLogTestCase(WagtailTestUtils, TestCase):
         self.assertEqual(record.event, "user_login_failed")
         self.assertEqual(record.ip_address, "127.0.0.1")
         self.assertEqual(record.user_agent, "my browser")
+
+
+class UserProfileSignalTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = cls.create_superuser(username="admin", password="password")
+        cls.profile = UserProfile.get_for_user(cls.user)
+
+    def test_user_profile_notifications_disabled_on_creation(self):
+        self.assertFalse(self.profile.submitted_notifications)
+        self.assertFalse(self.profile.approved_notifications)
+        self.assertFalse(self.profile.rejected_notifications)
+        self.assertFalse(self.profile.updated_comments_notifications)
+
+    def test_user_profile_notifications_not_changed_on_update(self):
+        self.profile.submitted_notifications = True
+        self.profile.approved_notifications = True
+        self.profile.rejected_notifications = True
+        self.profile.updated_comments_notifications = True
+        self.profile.save()
+
+        self.profile.refresh_from_db()
+
+        self.assertTrue(self.profile.submitted_notifications)
+        self.assertTrue(self.profile.approved_notifications)
+        self.assertTrue(self.profile.rejected_notifications)
+        self.assertTrue(self.profile.updated_comments_notifications)


### PR DESCRIPTION
### What is the context of this PR?

A small PR to disable Wagtail's default opt-in for notifications.
https://github.com/wagtail/wagtail/blob/main/wagtail/users/models.py#L29-L53

### How to review

0. Check out the branch.
1. As an admin, create a new user (Wagtail admin > Settings > Users > Add user)
2. Log in with the newly created user
3. Click on the user icon in the bottom left corner > Account.
4. Switch to the Notifications tab, the options should be unticked/off

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
