### PR TITLE
Disable only the global submitted notifications

### DIFF
--- a/cms/users/signal_handlers.py
+++ b/cms/users/signal_handlers.py
@@ -63,14 +63,8 @@ def audit_user_login_failed(sender: Any, credentials: dict, request: HttpRequest
 def disable_profile_notifications(sender: Any, instance: UserProfile, created: bool, **kwargs: Any) -> None:  # pylint: disable=unused-argument
     if created:
         instance.submitted_notifications = False
-        instance.approved_notifications = False
-        instance.rejected_notifications = False
-        instance.updated_comments_notifications = False
         instance.save(
             update_fields=[
                 "submitted_notifications",
-                "approved_notifications",
-                "rejected_notifications",
-                "updated_comments_notifications",
             ]
         )

--- a/cms/users/signal_handlers.py
+++ b/cms/users/signal_handlers.py
@@ -62,6 +62,8 @@ def audit_user_login_failed(sender: Any, credentials: dict, request: HttpRequest
 @receiver(post_save, sender=UserProfile)
 def disable_profile_notifications(sender: Any, instance: UserProfile, created: bool, **kwargs: Any) -> None:  # pylint: disable=unused-argument
     if created:
+        # We want to disable the "submitted notifications" by default as they are sent regardless
+        # of the user's interaction with pages / workflow-enabled snippets and add a lot of noise.
         instance.submitted_notifications = False
         instance.save(
             update_fields=[

--- a/cms/users/tests/test_signal_handlers.py
+++ b/cms/users/tests/test_signal_handlers.py
@@ -130,7 +130,9 @@ class UserProfileSignalTestCase(WagtailTestUtils, TestCase):
         cls.user = cls.create_superuser(username="admin", password="password")
         cls.profile = UserProfile.get_for_user(cls.user)
 
-    def test_user_profile_notifications_disabled_on_creation(self):
+    def test_user_profile_submitted_notifications_disabled_on_creation(self):
+        # only "submitted notifications" are disabled as they are global
+        # the rest are left as they are as they require interaction with the page/workflow-enabled snippet
         self.assertFalse(self.profile.submitted_notifications)
         self.assertTrue(self.profile.approved_notifications)
         self.assertTrue(self.profile.rejected_notifications)

--- a/cms/users/tests/test_signal_handlers.py
+++ b/cms/users/tests/test_signal_handlers.py
@@ -132,20 +132,14 @@ class UserProfileSignalTestCase(WagtailTestUtils, TestCase):
 
     def test_user_profile_notifications_disabled_on_creation(self):
         self.assertFalse(self.profile.submitted_notifications)
-        self.assertFalse(self.profile.approved_notifications)
-        self.assertFalse(self.profile.rejected_notifications)
-        self.assertFalse(self.profile.updated_comments_notifications)
+        self.assertTrue(self.profile.approved_notifications)
+        self.assertTrue(self.profile.rejected_notifications)
+        self.assertTrue(self.profile.updated_comments_notifications)
 
     def test_user_profile_notifications_not_changed_on_update(self):
         self.profile.submitted_notifications = True
-        self.profile.approved_notifications = True
-        self.profile.rejected_notifications = True
-        self.profile.updated_comments_notifications = True
         self.profile.save()
 
         self.profile.refresh_from_db()
 
         self.assertTrue(self.profile.submitted_notifications)
-        self.assertTrue(self.profile.approved_notifications)
-        self.assertTrue(self.profile.rejected_notifications)
-        self.assertTrue(self.profile.updated_comments_notifications)


### PR DESCRIPTION
### What is the context of this PR?

Follow up to #307. Upon further testing, it is only "submitted notifications" that is global. The other ones are dependent on the user editing/interacting with the page, so they are relevant.

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

### Follow-up Actions
N/A


<details>
<summary>command to run</summary>

```python
from wagtail.users.models import UserProfile

for up in UserProfile.objects.all():
   up.submitted_notifications = False
   up.approved_notifications = True
   up.rejected_notifications = True
   up.updated_comments_notifications = True
   up.save(update_fields=["submitted_notifications", "approved_notifications", "rejected_notifications", "updated_comments_notifications"])
```
</details>