### PR TITLE
Fix cache key for kafka token

### DIFF
--- a/cms/search/publishers.py
+++ b/cms/search/publishers.py
@@ -63,7 +63,8 @@ class IAMKafkaTokenProvider(AbstractTokenProvider):
 
     # Generating the token does a request, so cache it for slightly less than the expiration.
     @memory_cache(
-        MSKAuthTokenProvider.DEFAULT_TOKEN_EXPIRY_SECONDS - 5, key_generator_callable=lambda self: self.__qualname__
+        MSKAuthTokenProvider.DEFAULT_TOKEN_EXPIRY_SECONDS - 5,
+        key_generator_callable=lambda self: f"{__name__}.{type(self).__qualname__}",
     )
     def token(self) -> str:
         token, _ = MSKAuthTokenProvider.generate_auth_token(settings.AWS_REGION)


### PR DESCRIPTION
### What is the context of this PR?

The Kafka client ignores all exceptions when generating a token.

The root of the issue is that `__qualname__` doesn't exist on class instances, only on the class itself.

### How to review

Confirm the `token` method is still cached, and has a reasonable cache key.

### Follow-up Actions


