### PR TITLE
Add and use `make test-no-parallel` on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Compile translations
         run: make compilemessages
       - name: Test
-        run: make test
+        run: make test-no-parallel
       - name: Add coverage data to GitHub Action summary
         run: |
           poetry run coverage html --skip-covered --skip-empty

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ test:  ## Run the tests and check coverage.
 	poetry run coverage combine
 	poetry run coverage report --fail-under=90
 
+.PHONY: test-no-parallel
+test-no-parallel:  ## Run the tests without parallel execution.
+	poetry run coverage erase
+	COVERAGE_CORE=sysmon  poetry run coverage run ./manage.py test --settings=cms.settings.test --shuffle
+	poetry run coverage combine
+	poetry run coverage report --fail-under=90
+
 .PHONY: mypy
 mypy:  ## Run mypy.
 	poetry run mypy cms/ .github/*.py


### PR DESCRIPTION
### What is the context of this PR?

This PR adds a a new `make` command called `test-no-parallel` which is exactly the same as `test` but executes the test without the `--parallel` flag. This is then used for the CI workflow on GitHub.

The reason behind this is to reduce test flakiness as there are signs of test isolation issues. The old `make test` command will still work as usual.

### How to review

Observe that tests pass.

### Follow-up Actions

Evaluate impact of change.
