### PR TITLE
Add `aliveStatusCodes` to markdown-link-check pipeline settings

### DIFF
--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -8,5 +8,5 @@
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 301, 302, 303, 307, 308, 0]
+  "aliveStatusCodes": [200, 206, 0]
 }

--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -7,5 +7,6 @@
   ],
   "retryOn429": true,
   "retryCount": 3,
-  "fallbackRetryDelay": "30s"
+  "fallbackRetryDelay": "30s",
+  "aliveCodes": [200, 301, 302, 303, 307, 308, 0]
 }

--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -8,5 +8,5 @@
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
-  "aliveCodes": [200, 301, 302, 303, 307, 308, 0]
+  "aliveStatusCodes": [200, 301, 302, 303, 307, 308, 0]
 }


### PR DESCRIPTION
### What is the context of this PR?

This PR adds `0` to `aliveStatusCodes` in `markdown-link-check` pipeline settings, alongside the standard `200` and `206` codes.

### How to review

Ensure the pipeline passes

### Follow-up Actions

Consider removing in the future
