### PR TITLE
Fix accordion functional test by avoiding overlap

### DIFF
--- a/functional_tests/steps/page_editor.py
+++ b/functional_tests/steps/page_editor.py
@@ -15,6 +15,7 @@ def user_clicks_action_menu_toggle(context: Context):
 @when('the user clicks "Publish"')
 @when("publishes the page")
 def user_clicks_publish(context: Context) -> None:
+    context.page.locator("#tab-label-content").focus()
     context.page.get_by_role("button", name="More actions").click()
     context.page.get_by_role("button", name="Publish").click()
 
@@ -26,6 +27,7 @@ def user_clicks_view_live_on_publish_confirmation_banner(context: Context) -> No
 
 @step('the user clicks the "{button_text}" button')
 def click_the_given_button(context: Context, button_text: str) -> None:
+    context.page.locator("#tab-label-content").focus()
     if button_text in ("Save Draft", "Preview"):
         # add a small delay to allow any client-side JS to initialise.
         context.page.wait_for_timeout(500)

--- a/functional_tests/steps/page_editor.py
+++ b/functional_tests/steps/page_editor.py
@@ -15,7 +15,7 @@ def user_clicks_action_menu_toggle(context: Context):
 @when('the user clicks "Publish"')
 @when("publishes the page")
 def user_clicks_publish(context: Context) -> None:
-    context.page.locator(".content").focus()
+    context.page.locator('[data-w-tooltip-content-value="Status"]').focus()
     context.page.get_by_role("button", name="More actions").click()
     context.page.get_by_role("button", name="Publish").click()
 
@@ -27,7 +27,7 @@ def user_clicks_view_live_on_publish_confirmation_banner(context: Context) -> No
 
 @step('the user clicks the "{button_text}" button')
 def click_the_given_button(context: Context, button_text: str) -> None:
-    context.page.locator(".content").focus()
+    context.page.locator('[data-w-tooltip-content-value="Status"]').focus()
     if button_text in ("Save Draft", "Preview"):
         # add a small delay to allow any client-side JS to initialise.
         context.page.wait_for_timeout(500)

--- a/functional_tests/steps/page_editor.py
+++ b/functional_tests/steps/page_editor.py
@@ -15,6 +15,7 @@ def user_clicks_action_menu_toggle(context: Context):
 @when('the user clicks "Publish"')
 @when("publishes the page")
 def user_clicks_publish(context: Context) -> None:
+    # Focus on the Status button to prevent overlap when trying to click the Publish button
     context.page.locator('[data-w-tooltip-content-value="Status"]').focus()
     context.page.get_by_role("button", name="More actions").click()
     context.page.get_by_role("button", name="Publish").click()
@@ -27,6 +28,7 @@ def user_clicks_view_live_on_publish_confirmation_banner(context: Context) -> No
 
 @step('the user clicks the "{button_text}" button')
 def click_the_given_button(context: Context, button_text: str) -> None:
+    # Focus on the Status button to prevent overlap when trying to click the button
     context.page.locator('[data-w-tooltip-content-value="Status"]').focus()
     if button_text in ("Save Draft", "Preview"):
         # add a small delay to allow any client-side JS to initialise.

--- a/functional_tests/steps/page_editor.py
+++ b/functional_tests/steps/page_editor.py
@@ -15,7 +15,7 @@ def user_clicks_action_menu_toggle(context: Context):
 @when('the user clicks "Publish"')
 @when("publishes the page")
 def user_clicks_publish(context: Context) -> None:
-    context.page.locator("#tab-label-content").focus()
+    context.page.locator(".content").focus()
     context.page.get_by_role("button", name="More actions").click()
     context.page.get_by_role("button", name="Publish").click()
 
@@ -27,7 +27,7 @@ def user_clicks_view_live_on_publish_confirmation_banner(context: Context) -> No
 
 @step('the user clicks the "{button_text}" button')
 def click_the_given_button(context: Context, button_text: str) -> None:
-    context.page.locator("#tab-label-content").focus()
+    context.page.locator(".content").focus()
     if button_text in ("Save Draft", "Preview"):
         # add a small delay to allow any client-side JS to initialise.
         context.page.wait_for_timeout(500)

--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -252,6 +252,9 @@ def user_adds_accordion_section(context: Context):
     page.get_by_label("Title*").fill("Test Accordion Section")
     page.get_by_role("region", name="Content*").get_by_role("textbox").nth(3).fill("Test accordion content")
     context.page.wait_for_timeout(500)  # Wait for JS to process
+    page.locator(
+        "#panel-child-content-bundle-heading"
+    ).scroll_into_view_if_needed()  # Scroll to the top to avoid overlap with the "Save as draft" button
 
 
 @then("the published statistical article page has the added correction")

--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -252,9 +252,6 @@ def user_adds_accordion_section(context: Context):
     page.get_by_label("Title*").fill("Test Accordion Section")
     page.get_by_role("region", name="Content*").get_by_role("textbox").nth(3).fill("Test accordion content")
     context.page.wait_for_timeout(500)  # Wait for JS to process
-    page.locator(
-        "#panel-child-content-bundle-heading"
-    ).scroll_into_view_if_needed()  # Scroll to the top to avoid overlap with the "Save as draft" button
 
 
 @then("the published statistical article page has the added correction")


### PR DESCRIPTION
### What is the context of this PR?

This is a workaround for an issue raised at wagtail core https://github.com/wagtail/wagtail/issues/13299 which causes the functional tests to occasionally fail as the toolbar covers the button.

![page@7d2ec90407dc30c849245e103c3cebf4-1754062025698](https://github.com/user-attachments/assets/7c304d8b-6f38-41ea-b0f9-ce70a3986ca2)

### How to review

Ensure that functional tests pass.

### Follow-up Actions

Update Wagtail once this issue is fixed in core.
