### PR TITLE
Fix navigation tags for the temporarily removed page from ThemeLinkBlock

### DIFF
--- a/cms/navigation/templatetags/navigation_tags.py
+++ b/cms/navigation/templatetags/navigation_tags.py
@@ -43,9 +43,9 @@ def _extract_item(
         item[text_key] = value["title"]
         item["url"] = value["external_url"]
 
-    elif value["page"] and value["page"].live:
-        item[text_key] = value["title"] or value["page"].title
-        item["url"] = value["page"].get_url(request=request)
+    elif (page := value.get("page")) and page.live:
+        item[text_key] = value["title"] or getattr(page.specific_deferred, "display_title", page.title)
+        item["url"] = page.get_url(request=request)
 
     if include_description and "description" in value:
         item["description"] = value["description"]


### PR DESCRIPTION
### What is the context of this PR?

Fixes a regression in #288

### How to review

Requires a main menu that links to a theme page, created prior to #288 
Note: this is difficult to create a test for given we drop the "page" block in `ThemeLinkBlock.__init__`

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
