### PR TITLE
Replace preview frame with page in charts functional test

### DIFF
--- a/functional_tests/steps/statistical_article_page.py
+++ b/functional_tests/steps/statistical_article_page.py
@@ -570,6 +570,7 @@ def user_selects_featured_chart_preview_mode(context: Context):
     preview_mode_select.select_option(value="featured_article")
     context.page.wait_for_timeout(250)
 
+    # Open preview in new tab for more reliable testing
     browser_context = context.playwright_context
     with browser_context.expect_page() as preview_page:
         context.page.get_by_role("link", name="Preview in new tab").click()


### PR DESCRIPTION
### What is the context of this PR?

This PR changes the approach of the featured charts tests by using a preview page rather than relying on a preview iframe.

This is done in order to reduce flakiness as seen for example here: https://github.com/ONSdigital/dis-wagtail/actions/runs/16722800944/job/47331061044

Several things have been tested, such as waiting for the `networkidle` event, before moving to this solution.

### How to review

Ensure that functional tests pass during the headless pipeline run.

### Follow-up Actions

N/A
