### PR TITLE
Switch to the bitnami legacy kafka image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       broker:
-        image: bitnami/kafka:3.5.1
+        image: bitnamilegacy/kafka:3.5.1
         env:
           # Enable plaintext connections for local testing.
           ALLOW_PLAINTEXT_LISTENER: 'yes'

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -24,7 +24,7 @@ services:
       - 6379:6379
 
   broker:
-    image: bitnami/kafka:3.5.1
+    image: bitnamilegacy/kafka:3.5.1
     container_name: broker
     environment:
       # Enable plaintext connections for local testing.


### PR DESCRIPTION
### What is the context of this PR?

Bitnami are deprecating most of the old versions of images they maintain including the kafka version we are using, the deprecated image is now found in the `bitnamilegacy` repo. This was breaking our local dev and CI as the image was no longer available.

https://hub.docker.com/r/bitnami/kafka#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog

### How to review

Try `make compose-pull`, the kafka image should be successfully pulled.

### Follow-up Actions
N/A
