### PR TITLE
Chore: fix broken Pysheets link in docs

### DIFF
--- a/docs/conventions/type_hinting.md
+++ b/docs/conventions/type_hinting.md
@@ -240,5 +240,5 @@ def increment_value(self, value: T) -> T:
 ## Useful links
 
 - <https://www.python.org/dev/peps/pep-0484/>
-- <https://www.pythonsheets.com/notes/python-typing.html>
+- <https://www.pythonsheets.com/notes/basic/python-typing.html>
 - <https://google.github.io/styleguide/pyguide.html#319-type-annotations>


### PR DESCRIPTION
### What is the context of this PR?

Update broken link that makes Megalinter fail in the CI.
The error: https://github.com/ONSdigital/dis-wagtail/actions/runs/17372565378/job/49311533061
