### PR TITLE
Update docs-functional-tests with Sharing code between steps and step helpers

### DIFF
--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -248,6 +248,12 @@ reusable across any steps.
 Note that it is also perfectly valid to annotate the same step function with multiple different step wordings, for example to have multiple different wordings
 of the step to make better grammatical sense in different scenarios.
 
+### Sharing Code between Steps and Step Helpers
+
+Step helpers should not import code from step files. Instead, factor shared logic into standalone helper functions. These helpers should take only the minimal inputs they need (e.g. context.page) rather than depending on context or other steps.
+
+This avoids creating hidden dependencies between steps and will make the test suite easier to maintain.
+
 ### Step wording
 
 Steps should be written in full and concise sentences, avoiding unnecessary abbreviations and shorthand. They should be


### PR DESCRIPTION
What is the context of this PR?

Relates to : #299 [comment](https://github.com/ONSdigital/dis-wagtail/pull/299#discussion_r2313768384)

This PR updates the functional test code guide to clarify best practices around step functions. 
This adds a guideline to avoid calling step functions in helper functions because mixing steps and helpers causes interdependencies and harder refactoring.


### How to review

Read that it makes sense and is understandable for future reference.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
