### PR TITLE
fix(docker): add missing UID/GID args to dev stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -284,8 +284,8 @@ USER $USERNAME
 
 # Copy in the node_modules directory from the frontend-deps stage to initialise
 # the volume that gets mounted here
-ARG UID
-ARG GID
+ARG UID=1000
+ARG GID=1000
 COPY --chown=$UID:$GID --from=frontend-deps --link /build/node_modules ./node_modules
 
 # Install the dev dependencies (they're omitted in the base stage)


### PR DESCRIPTION
### What is the context of this PR?

In the dev stage of the Dockerfile, no default UID/GID values were set. This causes builds to fail when `DOCKER_BUILDKIT` is disabled.
This PR adds default values (matching the earlier stages) so the image can be built reliably both with and without BuildKit.

### How to review

Ensure that the image can be built and that the app works as expected when building the image with and without BuildKit. You can toggle buildkit via CLI using `export DOCKER_BUILDKIT=0` and `export DOCKER_BUILDKIT=1`

### Follow-up Actions

- Revisit the Dockerfile and update post Heroku teardown to support ONS infra setup.

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
