### PR TITLE
Add test for previous releases breadcrumbs

### DIFF
--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -63,7 +63,7 @@ class ArticleSeriesPageTests(WagtailPageTestCase):
 
     def test_previous_releases_breadcrumbs(self):
         """Test that the previous releases page includes a breadcrumb for the latest article."""
-        _latest_article = StatisticalArticlePageFactory(parent=self.page, title="Latest Article")
+        StatisticalArticlePageFactory(parent=self.page, title="Latest Article")
         response = self.client.get(f"{self.page.url}/editions")
         self.assertEqual(response.status_code, HTTPStatus.OK)
 


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to a bug that appears to have been fixed in other changes since it was raised, as such it doesn't change any functionality, just adds a page test to protect against regression.

The bug was for incorrect breadcrumbs on the previous releases for statistical articles, which were apparently missing a breadcrumb for the latest article. This breadcrumb is now already present, so this PR just adds a page test verifying this. 

### How to review
Check the described bug is indeed fixed, check the new test makes sense.

### Follow-up Actions
None
