### PR TITLE
Remove duplicate breadcrumb logic in jinja template

### DIFF
--- a/cms/jinja2/templates/components/navigation/breadcrumbs.html
+++ b/cms/jinja2/templates/components/navigation/breadcrumbs.html
@@ -1,22 +1,10 @@
 {% if page and page.get_ancestors()|length > 1 %}
     {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
-
-    {% set breadcrumbs=[] %}
-
-    {% for ancestor_page in page.get_ancestors().specific().defer_streamfields() %}
-        {% if not ancestor_page.is_root() %}
-            {% if ancestor_page.depth <= 2 %}
-                {% do breadcrumbs.append({"url": "/", "text": _("Home")}) %}
-            {% elif not ancestor_page.exclude_from_breadcrumbs %}
-                {% do breadcrumbs.append({"url": pageurl(ancestor_page), "text": ancestor_page.title}) %}
-            {% endif %}
-        {% endif %}
-    {% endfor %}
     {# fmt:off #}
     {{
         onsBreadcrumbs({
             "ariaLabel": 'Breadcrumbs',
-            "itemsList": breadcrumbs
+            "itemsList": page.get_breadcrumbs(request=request),
         })
     }}
     {# fmt:on #}


### PR DESCRIPTION
### What is the context of this PR?
The `BasePage` `get_breadcrumbs` method was intended to be used as the default method of getting the list of breadcrumbs to render for a page, but the Jinja template component was missed and still has its own (mostly duplicate) logic, which is used as the default in the page base Jinja template. This PR changes that template component to use the page's `get_breadcrumbs` method to ensure the proper default behaviour, and any page specific override is used, and ensure we're not duplicating the logic.

### How to review
This shouldn't result in any functional changes, check that the breadcrumbs for all pages are not changed.

### Follow-up Actions
None