### PR TITLE
Workflow tweaks: admin dashboard panel updates

### DIFF
--- a/cms/workflows/action_menu.py
+++ b/cms/workflows/action_menu.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from wagtail.admin.action_menu import ActionMenuItem
+from wagtail.admin.action_menu import SubmitForModerationMenuItem as CoreSubmitForModerationMenuItem
 
 
 class UnlockWorkflowMenuItem(ActionMenuItem):
@@ -16,3 +17,14 @@ class UnlockWorkflowMenuItem(ActionMenuItem):
 
     def get_url(self, parent_context: Any) -> str:
         return self.item_url
+
+
+class SubmitForModerationMenuItem(CoreSubmitForModerationMenuItem):
+    def get_context_data(self, parent_context: dict) -> dict:
+        context = super().get_context_data(parent_context)
+
+        # update the resubmit label so it doesn't include the workflow name.
+        if context["label"].startswith("Resubmit to"):
+            context["label"] = "Resubmit for review"
+
+        return context

--- a/cms/workflows/action_menu.py
+++ b/cms/workflows/action_menu.py
@@ -1,7 +1,10 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from wagtail.admin.action_menu import ActionMenuItem
 from wagtail.admin.action_menu import SubmitForModerationMenuItem as CoreSubmitForModerationMenuItem
+
+if TYPE_CHECKING:
+    from laces.typing import RenderContext
 
 
 class UnlockWorkflowMenuItem(ActionMenuItem):
@@ -20,7 +23,7 @@ class UnlockWorkflowMenuItem(ActionMenuItem):
 
 
 class SubmitForModerationMenuItem(CoreSubmitForModerationMenuItem):
-    def get_context_data(self, parent_context: dict) -> dict:
+    def get_context_data(self, parent_context: RenderContext | None) -> RenderContext | None:
         context = super().get_context_data(parent_context)
 
         # update the resubmit label so it doesn't include the workflow name.

--- a/cms/workflows/panels.py
+++ b/cms/workflows/panels.py
@@ -1,0 +1,85 @@
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from laces.components import Component
+from wagtail.admin.views.home import WorkflowObjectsToModeratePanel
+from wagtail.models import Page, TaskState
+
+from cms.workflows.models import ReadyToPublishGroupTask
+
+if TYPE_CHECKING:
+    from laces.typing import RenderContext
+
+
+class ONSWorkflowObjectsToModeratePanel(WorkflowObjectsToModeratePanel):
+    order = 205
+
+    def get_context_data(self, parent_context: dict | None = None) -> RenderContext | None:
+        context = super().get_context_data(parent_context)
+
+        filtered_states = []
+        for state in context["states"]:
+            obj = state["obj"]
+            if obj.current_workflow_task and isinstance(obj.current_workflow_task, ReadyToPublishGroupTask):
+                continue
+            filtered_states.append(state)
+
+        context["states"] = filtered_states
+
+        return context
+
+
+class PagesReadyToBePublishedManuallyPanel(Component):
+    name = "pages_ready_to_publish"
+    order = 206
+    template_name = "workflows/panels/pages_ready_to_publish.html"
+
+    def get_context_data(self, parent_context: RenderContext | None = None) -> RenderContext | None:
+        # note: Wagtail passes the request in the context. Should it stop, we want this to error
+        request = parent_context["request"]  # type: ignore[index]
+        context = super().get_context_data(parent_context)
+        context["items"] = []
+        context["request"] = request
+        context["csrf_token"] = parent_context["csrf_token"]  # type: ignore[index]
+
+        if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
+            return context
+
+        states = (
+            TaskState.objects.reviewable_by(request.user)
+            .filter(
+                task__content_type_id=ReadyToPublishGroupTask().content_type_id,
+                revision__base_content_type__model=Page._meta.model_name.lower(),
+                revision__base_content_type__app_label=Page._meta.app_label.lower(),
+            )
+            .select_related(
+                "revision",
+                "revision__user",
+                "workflow_state",
+                "workflow_state__workflow",
+            )
+            .prefetch_related(
+                "revision__content_object",
+                "revision__content_object__latest_revision",
+            )
+            .order_by("-started_at")[:10]
+        )
+
+        for state in states:
+            # Skip task states where the revision's GenericForeignKey points to
+            # a nonexistent object. This can happen if the model does not define
+            # a GenericRelation to WorkflowState and/or Revision and the instance
+            # is deleted.
+            if not (page := state.revision.content_object):
+                continue
+
+            context["items"].append(
+                {
+                    "page": page,
+                    "revision": state.revision,
+                    "task_state": state,
+                    "actions": state.task.specific.get_actions(page, request.user),
+                }
+            )
+
+        return context

--- a/cms/workflows/templates/workflows/panels/pages_ready_to_publish.html
+++ b/cms/workflows/templates/workflows/panels/pages_ready_to_publish.html
@@ -1,0 +1,87 @@
+{% load i18n wagtailadmin_tags %}
+{% if items %}
+    {% panel id="awaiting-review" heading="Pages ready to publish" classname="w-panel--dashboard" %}
+        <table class="listing listing--dashboard">
+            <col />
+            <col width="10%"/>
+            <col width="7%"/>
+            <col width="10%"/>
+            <col width="15%"/>
+            <col width="10%"/>
+            <col width="10%"/>
+            <thead class="w-sr-only">
+                <tr>
+                    <th class="title">Title</th>
+                    <th>Language</th>
+                    <th>Privacy and access</th>
+                    <th>Approved by</th>
+                    <th>Approved at</th>
+                    <th aria-hidden="true">{% comment %} added for visual alignment only {% endcomment %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% i18n_enabled as show_locale_labels %}
+                {% for item in items %}
+                    {% with revision=item.task_state.revision page=item.page task_state=item.task_state actions=item.actions %}
+                        {% page_permissions page as page_perms %}
+                        <tr>
+                            <td class="title">
+                                <div class="title-wrapper">
+                                    {% admin_edit_url page as edit_url %}
+                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                        <a href="{{ edit_url }}" title="Edit">{% latest_str page %}</a>
+                                    {% else %}
+                                        {% latest_str page %}
+                                    {% endif %}
+                                </div>
+                            </td>
+                            <td>
+                                {% if show_locale_labels and page.locale_id %}
+                                    {% locale_label_from_id page.locale_id as locale_label %}
+                                    {% status locale_label classname="w-status--label" %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if is_page %}
+                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=obj %}
+                                {% endif %}
+                                {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=obj %}
+                            </td>
+                            <td>
+                                {% if page.active_bundle %}
+                                    {% status "In a bundle" %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if revision.user %}{{ revision.user|user_display_name }}{% endif %}
+                            </td>
+                            <td>{% human_readable_date task_state.started_at %}</td>
+                            <td class="actions-container">
+                                {% if actions %}
+                                    <ul class="actions">
+                                        <li>
+                                            {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") hide_on_click=True keep_mounted=True %}
+                                                {% for action_name, action_label, modal in actions %}
+                                                    {% if action_name == "unlock" %}
+                                                        <button data-workflow-action-url="{% url "workflows:unlock" page.pk|admin_urlquote %}">{{ action_label }}</button>
+                                                    {% else %}
+                                                        <button data-workflow-action-url="{% url "wagtailadmin_pages:workflow_action" page.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
+                                                    {% endif %}
+                                                {% endfor %}
+                                                {% if page_perms.can_edit or not is_page and edit_url %}
+                                                    <a href="{{ edit_url }}">Edit</a>
+                                                {% endif %}
+                                            {% enddropdown %}
+                                        </li>
+                                    </ul>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endwith %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endpanel %}
+
+    <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}" data-activate="dashboard"></script>
+{% endif %}

--- a/cms/workflows/tests/test_workflow_tweaks.py
+++ b/cms/workflows/tests/test_workflow_tweaks.py
@@ -453,6 +453,8 @@ class WorkflowTweaksTestCase(WorkflowTweaksBaseTestCase):
             with self.subTest(f"Test dashboard has publish action for {user}"):
                 self.client.force_login(user)
                 response = self.client.get(self.dashboard_url)
+                self.assertNotContains(response, "Awaiting your review")
+                self.assertContains(response, "Pages ready to publish")
                 self.assertRegex(
                     response.content.decode(encoding="utf-8"),
                     r"<button data-workflow-action-url=.*>\s?Publish\s?<\/button>",
@@ -472,6 +474,15 @@ class WorkflowTweaksTestCase(WorkflowTweaksBaseTestCase):
 
         actions = self.page.current_workflow_task.get_actions(self.page, self.publishing_admin)
         self.assertEqual(actions, [])
+
+    def test_ready_to_publish_task__not_in_awaiting_your_review_dashboard_panel(self):
+        self.client.force_login(self.publishing_admin)
+        mark_page_as_ready_to_publish(self.page)
+
+        response = self.client.get(self.dashboard_url)
+        self.assertNotContains(response, "Awaiting your review")
+        self.assertNotContains(response, "Publish")
+        self.assertNotContains(response, "locked-approve")
 
     @patch("cms.workflows.wagtail_hooks.update_action_menu")
     def test_workflow_page_action_hook_not_actioned_in_irrelevant_contexts(self, mocked_update):

--- a/cms/workflows/tests/test_workflow_tweaks.py
+++ b/cms/workflows/tests/test_workflow_tweaks.py
@@ -616,6 +616,26 @@ class WorkflowTweaksTestCase(WorkflowTweaksBaseTestCase):
 
         self.assertContains(response, "Could not perform the action as the page is no longer in a workflow.")
 
+    def test_restart_action_removed_and_resubmit_for_review_label_updated(self):
+        self.client.force_login(self.publishing_admin)
+        workflow_state = mark_page_as_ready_for_review(self.page, self.publishing_officer)
+        workflow_state.status = workflow_state.STATUS_NEEDS_CHANGES
+        workflow_state.save()
+
+        response = self.client.get(self.edit_url)
+        menu_items = response.context["action_menu"].menu_items
+
+        self.assertItemWithPropertyNotIn("name", "action-restart-workflow", menu_items)
+        self.assertItemWithPropertyNotIn("label", "Restart workflow", menu_items)
+        self.assertItemWithPropertyNotIn("label", "Resubmit for In review", menu_items)
+        self.assertNotContains(response, "Resubmit for In review")
+
+        self.assertItemWithPropertyIn("name", "action-submit", menu_items)
+        # alas, the SubmitForModerationMenuItem default label is "Submit for moderation", but
+        # that gets updated dynamically when the template is rendered, so we need to
+        self.assertItemWithPropertyIn("label", "Submit for moderation", menu_items)
+        self.assertContains(response, "Resubmit for review")
+
 
 class WorkflowTweaksNonBundledPageTestCase(WorkflowTweaksBaseTestCase):
     """Tests for workflow hook behaviour on pages without BundledPageMixin.

--- a/cms/workflows/wagtail_hooks.py
+++ b/cms/workflows/wagtail_hooks.py
@@ -10,6 +10,7 @@ from django.utils.html import format_html
 from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.action_menu import PageLockedMenuItem, WorkflowMenuItem
+from wagtail.admin.views.home import WorkflowObjectsToModeratePanel
 
 from cms.bundles.utils import in_active_bundle, in_bundle_ready_to_be_published
 
@@ -17,6 +18,7 @@ from . import admin_urls
 from .action_menu import SubmitForModerationMenuItem, UnlockWorkflowMenuItem
 from .admin_urls import path
 from .models import get_final_approve_label
+from .panels import ONSWorkflowObjectsToModeratePanel, PagesReadyToBePublishedManuallyPanel
 from .utils import is_page_ready_to_publish
 
 if TYPE_CHECKING:
@@ -25,6 +27,7 @@ if TYPE_CHECKING:
     from django.urls import URLPattern
     from django.urls.resolvers import URLResolver
     from wagtail.admin.action_menu import ActionMenuItem
+    from wagtail.admin.ui.components import Component
     from wagtail.models import Page
 
 
@@ -173,3 +176,11 @@ def register_admin_urls() -> list[URLPattern | URLResolver]:
     @see https://docs.wagtail.org/en/stable/reference/hooks.html#register-admin-urls.
     """
     return [path("workflows/", include(admin_urls))]
+
+
+@hooks.register("construct_homepage_panels", order=100)
+def alter_objects_to_moderate_panel(request: HttpRequest, panels: list[Component]) -> None:
+    panels[:] = [panel for panel in panels if not isinstance(panel, WorkflowObjectsToModeratePanel)]
+
+    panels.append(ONSWorkflowObjectsToModeratePanel())
+    panels.append(PagesReadyToBePublishedManuallyPanel())

--- a/cms/workflows/wagtail_hooks.py
+++ b/cms/workflows/wagtail_hooks.py
@@ -14,7 +14,7 @@ from wagtail.admin.action_menu import PageLockedMenuItem, WorkflowMenuItem
 from cms.bundles.utils import in_active_bundle, in_bundle_ready_to_be_published
 
 from . import admin_urls
-from .action_menu import UnlockWorkflowMenuItem
+from .action_menu import SubmitForModerationMenuItem, UnlockWorkflowMenuItem
 from .admin_urls import path
 from .models import get_final_approve_label
 from .utils import is_page_ready_to_publish
@@ -58,10 +58,16 @@ def update_action_menu(menu_items: list[ActionMenuItem], request: HttpRequest, c
     # Do a final relabel for the "approve" actions to prevent any inconsistencies.
     final_menu_items = []
     for item in updated_menu_items:
-        if item.name in ["approve", "locked-approve"]:
-            item.label = get_final_approve_label(page, item.label)
+        if item.name == "action-restart-workflow":
+            continue
 
-        final_menu_items.append(item)
+        if item.name == "action-submit":
+            # the submit/resubmit action menu item does the re-label in get_context_data, so we use our class
+            final_menu_items.append(SubmitForModerationMenuItem())
+        else:
+            if item.name in ["approve", "locked-approve"]:
+                item.label = get_final_approve_label(page, item.label)
+            final_menu_items.append(item)
 
     return final_menu_items
 


### PR DESCRIPTION
### What is the context of this PR?

This PR updates the "Awaiting your review" dashboard panel to exclude objects that are ready to publish, and adds a new panel that show the latest 10 pages that are ready to publish

[Relevant discussion](https://officefornationalstatistics.atlassian.net/browse/CMS-1043?focusedCommentId=731127)

### How to review

- add 3 pages and take them through the moderation workflow
  - one that is only in review, one that is ready to publish (but not in a bundle), and another that is ready to publish (but in a bundle)
- go to the admin dashboard
  - "awaiting your review" should only contain the first one
  - there should be a new panel titled "Pages ready to publish" that contains the other two. The first one has an action menu, the other doesn't but has a "in a bundle" label

<img width="2224" height="770" alt="Screenshot 2026-03-13 at 15 27 57" src="https://github.com/user-attachments/assets/aed66c5c-55c7-477e-a46b-6de444a7b2ec" />


### Follow-up Actions

Get final decision on this.
