### PR TITLE
Add workaround for live button URL in admin panel

### DIFF
--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -292,9 +292,6 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
 
         Note: while the method signature implies we get a request object, in reality it can be a model too.
         """
-        if not settings.CMS_USE_SUBDOMAIN_LOCALES:
-            return cast(list["SiteRootPath"], super()._get_site_root_paths(request=request))
-
         cache_object = request if request is not None else self
         try:
             # pylint: disable=protected-access
@@ -302,8 +299,11 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
             # pylint: enable=protected-access
             return cached_paths
         except AttributeError:
-            host = request.get_host() if isinstance(request, HttpRequest) else None
-            paths = get_mapped_site_root_paths(host)
+            if settings.CMS_USE_SUBDOMAIN_LOCALES:
+                host = request.get_host() if isinstance(request, HttpRequest) else None
+                paths = get_mapped_site_root_paths(host)
+            else:
+                paths = get_mapped_site_root_paths(default_site_only=True)
             # pylint: disable=protected-access,attribute-defined-outside-init
             cache_object._wagtail_cached_site_root_paths = paths  # type: ignore[union-attr]
             # pylint: enable=protected-access,attribute-defined-outside-init

--- a/cms/locale/tests/test_path_localisation.py
+++ b/cms/locale/tests/test_path_localisation.py
@@ -107,7 +107,7 @@ class PathBasedLocalisationTests(WagtailPageTestCase):
         response = self.client.get(welsh_page.get_url())
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-        self.assertIn(welsh_page.get_site().root_url + "/cy/", welsh_page.get_full_url())
+        self.assertIn("/cy/", welsh_page.get_full_url())
         self.assertContains(response, f'<link rel="canonical" href="{welsh_page.get_full_url()}" />')
 
     def test_aliased_welsh_statistical_article_page_canonical_url(self):
@@ -129,7 +129,7 @@ class PathBasedLocalisationTests(WagtailPageTestCase):
         response = self.client.get(welsh_page.get_url(request=self.dummy_request))
         self.assertEqual(response.status_code, HTTPStatus.OK)
         welsh_series_url = welsh_page.get_parent().get_full_url(request=self.dummy_request)
-        self.assertIn(welsh_page.get_site().root_url + "/cy/", welsh_series_url)
+        self.assertIn("/cy/", welsh_series_url)
         self.assertContains(response, f'<link rel="canonical" href="{welsh_series_url}" />')
 
     @patch("cms.home.models.HomePage.serve")

--- a/cms/locale/tests/test_utils.py
+++ b/cms/locale/tests/test_utils.py
@@ -92,6 +92,30 @@ class LocaleUtilsTestCase(TestCase):
             ],
         )
 
+    @override_settings(WAGTAILADMIN_BASE_URL="http://localhost:8000")
+    def test_get_mapped_site_root_paths_default_site_only(self):
+        """When default_site_only=True, only the default site is returned
+        with WAGTAILADMIN_BASE_URL as root_url, and translations are expanded.
+        """
+        result = get_mapped_site_root_paths(default_site_only=True)
+        self.assertEqual(
+            result,
+            [
+                SiteRootPath(
+                    site_id=self.english_site.pk,
+                    root_path=self.english_site.root_page.url_path,
+                    root_url="http://localhost:8000",
+                    language_code=self.en_locale.language_code,
+                ),
+                SiteRootPath(
+                    site_id=self.english_site.pk,
+                    root_path=self.welsh_home.url_path,
+                    root_url="http://localhost:8000",
+                    language_code=self.welsh_locale.language_code,
+                ),
+            ],
+        )
+
     @patch("cms.locale.utils.cache.get")
     @patch("cms.locale.utils.cache.set")
     def test_get_mapped_site_root_paths_caches_results(self, mock_cache_set, mock_cache_get):

--- a/cms/locale/utils.py
+++ b/cms/locale/utils.py
@@ -20,13 +20,18 @@ def replace_hostname(url: str) -> str:
     return parsed_url.geturl()
 
 
-def get_mapped_site_root_paths(host: str | None = None) -> list[SiteRootPath]:
+def get_mapped_site_root_paths(host: str | None = None, *, default_site_only: bool = False) -> list[SiteRootPath]:
     """An expansion to Site.get_site_root_paths().
 
     Our version:
     - handles Sites mapped to localized root pages, rather than offer language alternatives for each Site.
     - expands to handle one Site with localized roots, like Site.get_site_root_paths
     - checks and replaces the base URL if the request is from one of the alternatives.
+
+    When default_site_only is True, only the default site is used and its root_url
+    is replaced with WAGTAILADMIN_BASE_URL. This is intended for use when subdomain
+    locales are disabled, ensuring URLs point to the correct host regardless of the
+    hostnames stored in the database Site records.
     """
     swap_domains: bool = host is not None and host in settings.CMS_HOSTNAME_ALTERNATIVES.values()
     cache_key = f"cms-{swap_domains}-{SITE_ROOT_PATHS_CACHE_KEY}"
@@ -34,32 +39,25 @@ def get_mapped_site_root_paths(host: str | None = None) -> list[SiteRootPath]:
 
     if result is None:
         result = []
-        sites = list(
-            Site.objects.select_related("root_page", "root_page__locale").order_by(
-                "-root_page__url_path", "-is_default_site", "hostname"
-            )
-        )
+        queryset = Site.objects.select_related("root_page", "root_page__locale")
+        if default_site_only:
+            queryset = queryset.filter(is_default_site=True)
+        sites = list(queryset.order_by("-root_page__url_path", "-is_default_site", "hostname"))
+
         for site in sites:
-            result.append(
-                SiteRootPath(
-                    site.id,
-                    site.root_page.url_path,
-                    replace_hostname(site.root_url) if swap_domains else site.root_url,
-                    site.root_page.locale.language_code,
-                )
-            )
+            if default_site_only:
+                root_url = getattr(settings, "WAGTAILADMIN_BASE_URL", site.root_url)
+            elif swap_domains:
+                root_url = replace_hostname(site.root_url)
+            else:
+                root_url = site.root_url
+            result.append(SiteRootPath(site.id, site.root_page.url_path, root_url, site.root_page.locale.language_code))
         if len(sites) == 1:
             # If we have only one site, expand to include the translated root pages as alternatives
             site = sites[0]
+            root_url = result[0].root_url
             for root_page in site.root_page.get_translations(inclusive=False).select_related("locale"):
-                result.append(
-                    SiteRootPath(
-                        site.id,
-                        root_page.url_path,
-                        replace_hostname(site.root_url) if swap_domains else site.root_url,
-                        root_page.locale.language_code,
-                    )
-                )
+                result.append(SiteRootPath(site.id, root_page.url_path, root_url, root_page.locale.language_code))
 
         cache.set(
             cache_key,

--- a/cms/locale/utils.py
+++ b/cms/locale/utils.py
@@ -34,7 +34,7 @@ def get_mapped_site_root_paths(host: str | None = None, *, default_site_only: bo
     hostnames stored in the database Site records.
     """
     swap_domains: bool = host is not None and host in settings.CMS_HOSTNAME_ALTERNATIVES.values()
-    cache_key = f"cms-{swap_domains}-{SITE_ROOT_PATHS_CACHE_KEY}"
+    cache_key = f"cms-{swap_domains}-{default_site_only}-{SITE_ROOT_PATHS_CACHE_KEY}"
     result = cache.get(cache_key, version=SITE_ROOT_PATHS_CACHE_VERSION)
 
     if result is None:


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses the bug raised in CMS-1140 and adds a workaround for the issue.

When `CMS_USE_SUBDOMAIN_LOCALES` is disabled (the default for local development), the admin "Live" button on pages pointed to the wrong host (e.g. http://cy.web.ons.orb.local:8000/) because `_get_site_root_paths` fell back to Wagtail's default `Site.get_site_root_paths()`, which returned all `Site` records from the database, including those with production/staging hostnames loaded from `CMS_HOSTNAME_LOCALE_MAP` in `.env`. Note that other "Live" buttons would work correctly.

The workaround routes the non-subdomain code path through `get_mapped_site_root_paths(default_site_only=True)` instead, which filters to the default site and uses `WAGTAILADMIN_BASE_URL` as the root URL. This ensures the Live button points to http://localhost:8000 (or whatever you use) in development, regardless of what hostnames are stored in the database. This works if and only if one domain is being used to access the site (which should be true when `CMS_USE_SUBDOMAIN_LOCALES` is disabled).

### How to review

1. Ensure that `CMS_USE_SUBDOMAIN_LOCALES` is disabled
2. Go to an admin view such as `/admin/pages/3/`
3. Click or inspect the "Live" button in the top right corner
4. Confirm that the correct URL is being used (e.g. "localhost:8000", not the subdomain)
5. Change your local settings to enable `CMS_USE_SUBDOMAIN_LOCALES` and reload the server
6. Return to the same admin view (or refresh the page)
7. Confirm that the correct URL is being used (e.g. "web.ons.orb.local:8000", the subdomain)

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Ensure this change introduces no regressions.
