### PR TITLE
Header: Main Menu Translation Config Bugfix - CMS-1056

### DIFF
--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -226,7 +226,7 @@ class ONSTableBlock(TinyTableBlock):
 
         return {
             "title": _("Download this table"),
-            "itemsList": [{"text": f"{_('Download CSV')}{size_suffix}", "url": csv_url}],
+            "itemsList": [{"text": _("Download CSV %(size)s") % {"size": size_suffix}, "url": csv_url}],
         }
 
     @staticmethod

--- a/cms/core/static/js/blocks/headline-figures-item-block.js
+++ b/cms/core/static/js/blocks/headline-figures-item-block.js
@@ -5,7 +5,7 @@ class HeadlineFiguresItemBlock extends window.wagtailStreamField.blocks.StructBl
     try {
       const usedFigures = document.getElementById('figures-used-by-ancestor');
       this.usedFigures = JSON.parse(usedFigures.innerText) || [];
-    } catch (e) {
+    } catch {
       this.usedFigures = [];
     }
   }

--- a/cms/core/static/js/blocks/release-date-change-block.js
+++ b/cms/core/static/js/blocks/release-date-change-block.js
@@ -8,7 +8,7 @@ class ReleaseDateChangeBlockDefinition extends ReadonlyStructBlockDefinition {
     try {
       const previousReleaseDateJson = document.getElementById('previous-release-date');
       this.previous_date = JSON.parse(previousReleaseDateJson.innerText);
-    } catch (e) {
+    } catch {
       this.previous_date = null;
     }
   }

--- a/cms/core/templatetags/page_config_tags.py
+++ b/cms/core/templatetags/page_config_tags.py
@@ -136,7 +136,7 @@ def _get_base_page_config(context: jinja2.runtime.Context, site: Site, request: 
                 "id": "nav-links-external",
                 "ariaLabel": _("Main menu"),
                 "ariaListLabel": _("Main menu"),
-                "toggleNavButton": {"text": _("Main menu"), "ariaLabel": _("Toggle main menu")},
+                "toggleMenuButton": {"text": _("Main menu"), "ariaLabel": _("Toggle main menu")},
                 "keyLinks": main_menu_highlights(request, main_menu),
                 "columns": main_menu_columns(request, main_menu),
             },

--- a/cms/core/templatetags/page_config_tags.py
+++ b/cms/core/templatetags/page_config_tags.py
@@ -134,9 +134,9 @@ def _get_base_page_config(context: jinja2.runtime.Context, site: Site, request: 
             "mastheadLogoUrl": "/",
             "menuLinks": {
                 "id": "nav-links-external",
-                "ariaLabel": _("Main menu"),
-                "ariaListLabel": _("Main menu"),
-                "toggleMenuButton": {"text": _("Main menu"), "ariaLabel": _("Toggle main menu")},
+                "ariaLabel": _("Menu links navigation"),
+                "ariaListLabel": _("Menu links"),
+                "toggleMenuButton": {"text": _("Menu"), "ariaLabel": _("Toggle menu")},
                 "keyLinks": main_menu_highlights(request, main_menu),
                 "columns": main_menu_columns(request, main_menu),
             },

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-19 10:27+0000\n"
+"POT-Creation-Date: 2026-03-25 16:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,27 +19,27 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: cms/articles/models.py:211 cms/core/enums.py:8
+#: cms/articles/models.py:220 cms/core/enums.py:8
 #: cms/core/formatting_utils.py:44
 msgid "Article"
 msgstr "Erthygl"
 
-#: cms/articles/models.py:443
+#: cms/articles/models.py:452
 msgid "Cite this article"
 msgstr "Dyfynnwch yr erthygl hon"
 
-#: cms/articles/models.py:445
+#: cms/articles/models.py:454
 #: cms/jinja2/templates/components/contact_details/contact_details.html:6
-#: cms/methodology/models.py:198 cms/release_calendar/models.py:246
+#: cms/methodology/models.py:195 cms/release_calendar/models.py:246
 msgid "Contact details"
 msgstr "Manylion cyswllt"
 
-#: cms/articles/models.py:512
+#: cms/articles/models.py:521
 #, python-format
 msgid "All data related to %(article_title)s"
 msgstr "Yr holl ddata sy'n gysylltiedig â %(article_title)s"
 
-#: cms/articles/models.py:571
+#: cms/articles/models.py:580
 msgid "Release date"
 msgstr "Dyddiad y datganiad"
 
@@ -55,11 +55,11 @@ msgstr "Hysbysiad"
 msgid "View superseded version"
 msgstr "Gweld fersiwn wedi’i disodli"
 
-#: cms/bundles/utils.py:27
+#: cms/bundles/utils.py:28
 msgid "Publications"
 msgstr "Cyhoeddiadau"
 
-#: cms/bundles/utils.py:28
+#: cms/bundles/utils.py:29
 msgid "Quality and methodology"
 msgstr "Ansawdd a methodoleg"
 
@@ -73,11 +73,11 @@ msgstr "Dangos popeth"
 msgid "Hide all"
 msgstr "Cuddio popeth"
 
-#: cms/core/blocks/markup.py:224
+#: cms/core/blocks/markup.py:228
 msgid "Download this table"
 msgstr ""
 
-#: cms/core/blocks/markup.py:225
+#: cms/core/blocks/markup.py:229
 msgid "Download CSV"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr "Set ddata"
 msgid "Methodology"
 msgstr "Methodoleg"
 
-#: cms/core/enums.py:11 cms/topics/models.py:249
+#: cms/core/enums.py:11 cms/topics/models.py:251
 msgid "Time series"
 msgstr "Cyfres amser"
 
@@ -123,7 +123,7 @@ msgstr "Tudalen"
 msgid "Released"
 msgstr "Rhyddhawyd"
 
-#: cms/core/models/base.py:156
+#: cms/core/models/base.py:153
 msgid "Home"
 msgstr "Cartref"
 
@@ -132,10 +132,10 @@ msgstr "Cartref"
 msgid "Footnotes"
 msgstr "Troednodiadau"
 
-#: cms/datavis/blocks/table.py:57
+#: cms/datavis/blocks/table.py:58
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:94
 #: cms/jinja2/templates/pages/topic_page.html:113
-#: cms/release_calendar/models.py:235 cms/topics/models.py:247
+#: cms/release_calendar/models.py:235 cms/topics/models.py:249
 msgid "Data"
 msgstr "Data"
 
@@ -171,15 +171,15 @@ msgstr "Mae’r holl gynnwys ar gael o dan y"
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
-#: cms/jinja2/templates/base_page.html:64
+#: cms/jinja2/templates/base_page.html:66
 msgid "in English"
 msgstr "yn Saesneg"
 
-#: cms/jinja2/templates/base_page.html:65
+#: cms/jinja2/templates/base_page.html:67
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:72
+#: cms/jinja2/templates/base_page.html:74
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "
@@ -481,7 +481,7 @@ msgid "Save or print this page"
 msgstr "Adrannau ar y dudalen hon"
 
 #: cms/jinja2/templates/pages/methodology_page.html:113
-#: cms/methodology/models.py:196
+#: cms/methodology/models.py:193
 msgid "Cite this methodology"
 msgstr "Dyfynnwch y fethodoleg hon"
 
@@ -697,11 +697,11 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: cms/jinja2/templates/pages/topic_page.html:67 cms/topics/models.py:239
+#: cms/jinja2/templates/pages/topic_page.html:67 cms/topics/models.py:241
 msgid "Featured"
 msgstr "Dan Sylw"
 
-#: cms/jinja2/templates/pages/topic_page.html:77 cms/topics/models.py:241
+#: cms/jinja2/templates/pages/topic_page.html:77 cms/topics/models.py:243
 msgid "Related articles"
 msgstr "Erthyglau cysylltiedig"
 
@@ -709,7 +709,7 @@ msgstr "Erthyglau cysylltiedig"
 msgid "View all related articles"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:95 cms/topics/models.py:243
+#: cms/jinja2/templates/pages/topic_page.html:95 cms/topics/models.py:245
 msgid "Methods and quality information"
 msgstr "Dulliau a gwybodaeth o ansawdd"
 
@@ -729,8 +729,8 @@ msgstr ""
 msgid "View all related time series"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:149 cms/topics/models.py:245
-#: cms/topics/tests/test_models.py:548 cms/topics/tests/test_models.py:552
+#: cms/jinja2/templates/pages/topic_page.html:149 cms/topics/models.py:247
+#: cms/topics/tests/test_models.py:556 cms/topics/tests/test_models.py:560
 msgid "Explore more"
 msgstr "Archwilio mwy"
 
@@ -738,7 +738,7 @@ msgstr "Archwilio mwy"
 msgid "Continue"
 msgstr "Parhau"
 
-#: cms/methodology/models.py:184 cms/methodology/models.py:194
+#: cms/methodology/models.py:181 cms/methodology/models.py:191
 msgid "Related publications"
 msgstr "Cyhoeddiadau cysylltiedig"
 
@@ -746,20 +746,16 @@ msgstr "Cyhoeddiadau cysylltiedig"
 msgid "To be confirmed"
 msgstr "I’w gadarnhau"
 
-#: cms/settings/base.py:383
+#: cms/settings/base.py:408
 msgid "English"
 msgstr "Saesneg"
 
-#: cms/settings/base.py:384
+#: cms/settings/base.py:409
 msgid "Welsh"
 msgstr "Cymraeg"
 
 #: cms/workflows/templates/wagtailadmin/workflows/workflow_status.html:13
 msgid "Not started"
-msgstr ""
-
-#: cms/workflows/templates/workflows/confirm_unlock.html:12
-msgid "No, don't unlock"
 msgstr ""
 
 #, fuzzy

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-19 10:27+0000\n"
+"POT-Creation-Date: 2026-03-26 12:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,27 +19,27 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: cms/articles/models.py:211 cms/core/enums.py:8
+#: cms/articles/models.py:220 cms/core/enums.py:8
 #: cms/core/formatting_utils.py:44
 msgid "Article"
 msgstr "Erthygl"
 
-#: cms/articles/models.py:443
+#: cms/articles/models.py:452
 msgid "Cite this article"
 msgstr "Dyfynnwch yr erthygl hon"
 
-#: cms/articles/models.py:445
+#: cms/articles/models.py:454
 #: cms/jinja2/templates/components/contact_details/contact_details.html:6
-#: cms/methodology/models.py:198 cms/release_calendar/models.py:246
+#: cms/methodology/models.py:195 cms/release_calendar/models.py:246
 msgid "Contact details"
 msgstr "Manylion cyswllt"
 
-#: cms/articles/models.py:512
+#: cms/articles/models.py:521
 #, python-format
 msgid "All data related to %(article_title)s"
 msgstr "Yr holl ddata sy'n gysylltiedig â %(article_title)s"
 
-#: cms/articles/models.py:571
+#: cms/articles/models.py:580
 msgid "Release date"
 msgstr "Dyddiad y datganiad"
 
@@ -55,11 +55,11 @@ msgstr "Hysbysiad"
 msgid "View superseded version"
 msgstr "Gweld fersiwn wedi’i disodli"
 
-#: cms/bundles/utils.py:27
+#: cms/bundles/utils.py:28
 msgid "Publications"
 msgstr "Cyhoeddiadau"
 
-#: cms/bundles/utils.py:28
+#: cms/bundles/utils.py:29
 msgid "Quality and methodology"
 msgstr "Ansawdd a methodoleg"
 
@@ -73,12 +73,13 @@ msgstr "Dangos popeth"
 msgid "Hide all"
 msgstr "Cuddio popeth"
 
-#: cms/core/blocks/markup.py:224
+#: cms/core/blocks/markup.py:228
 msgid "Download this table"
 msgstr ""
 
-#: cms/core/blocks/markup.py:225
-msgid "Download CSV"
+#: cms/core/blocks/markup.py:229
+#, python-format
+msgid "Download CSV %(size)s"
 msgstr ""
 
 #: cms/core/blocks/related.py:60
@@ -93,7 +94,7 @@ msgstr "Set ddata"
 msgid "Methodology"
 msgstr "Methodoleg"
 
-#: cms/core/enums.py:11 cms/topics/models.py:249
+#: cms/core/enums.py:11 cms/topics/models.py:251
 msgid "Time series"
 msgstr "Cyfres amser"
 
@@ -123,63 +124,67 @@ msgstr "Tudalen"
 msgid "Released"
 msgstr "Rhyddhawyd"
 
-#: cms/core/models/base.py:156
+#: cms/core/models/base.py:153
 msgid "Home"
 msgstr "Cartref"
+
+#: cms/core/templatetags/page_config_tags.py:133
+msgid "Beta"
+msgstr "Beta"
+
+#: cms/core/templatetags/page_config_tags.py:133
+msgid "This is a new service."
+msgstr "Mae hwn yn wasanaeth newydd."
+
+#: cms/core/templatetags/page_config_tags.py:137
+msgid "Menu links navigation"
+msgstr ""
+
+#: cms/core/templatetags/page_config_tags.py:138
+msgid "Menu links"
+msgstr "Dolenni cysylltiedig"
+
+#: cms/core/templatetags/page_config_tags.py:139
+msgid "Menu"
+msgstr "Dewislen"
+
+#: cms/core/templatetags/page_config_tags.py:139
+msgid "Toggle menu"
+msgstr "Togl y brif ddewislen"
+
+#: cms/core/templatetags/page_config_tags.py:148
+msgid "All content is available under the"
+msgstr "Mae’r holl gynnwys ar gael o dan y"
+
+#: cms/core/templatetags/page_config_tags.py:151
+msgid ", except where otherwise stated"
+msgstr ", ac eithrio lle y nodir fel arall"
 
 #: cms/datavis/blocks/base.py:416
 #: cms/jinja2/templates/components/streamfield/table_block.html:13
 msgid "Footnotes"
 msgstr "Troednodiadau"
 
-#: cms/datavis/blocks/table.py:57
+#: cms/datavis/blocks/table.py:58
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:94
 #: cms/jinja2/templates/pages/topic_page.html:113
-#: cms/release_calendar/models.py:235 cms/topics/models.py:247
+#: cms/release_calendar/models.py:235 cms/topics/models.py:249
 msgid "Data"
 msgstr "Data"
 
-#: cms/jinja2/templates/base.html:34
-msgid "Beta"
-msgstr "Beta"
-
-#: cms/jinja2/templates/base.html:35
-msgid "This is a new service."
-msgstr "Mae hwn yn wasanaeth newydd."
-
-#: cms/jinja2/templates/base.html:36
-msgid "Menu"
-msgstr "Dewislen"
-
-#: cms/jinja2/templates/base.html:37
-msgid "Main menu"
-msgstr "Prif ddewislen"
-
-#: cms/jinja2/templates/base.html:38
-msgid "Toggle main menu"
-msgstr "Togl y brif ddewislen"
-
-#: cms/jinja2/templates/base.html:39
+#: cms/jinja2/templates/base.html:6
 msgid "Breadcrumbs"
 msgstr "Briwsion bara"
 
-#: cms/jinja2/templates/base.html:41
-msgid "All content is available under the"
-msgstr "Mae’r holl gynnwys ar gael o dan y"
-
-#: cms/jinja2/templates/base.html:44
-msgid ", except where otherwise stated"
-msgstr ", ac eithrio lle y nodir fel arall"
-
-#: cms/jinja2/templates/base_page.html:64
+#: cms/jinja2/templates/base_page.html:66
 msgid "in English"
 msgstr "yn Saesneg"
 
-#: cms/jinja2/templates/base_page.html:65
+#: cms/jinja2/templates/base_page.html:67
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:72
+#: cms/jinja2/templates/base_page.html:74
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "
@@ -481,7 +486,7 @@ msgid "Save or print this page"
 msgstr "Adrannau ar y dudalen hon"
 
 #: cms/jinja2/templates/pages/methodology_page.html:113
-#: cms/methodology/models.py:196
+#: cms/methodology/models.py:193
 msgid "Cite this methodology"
 msgstr "Dyfynnwch y fethodoleg hon"
 
@@ -553,9 +558,9 @@ msgid ""
 msgstr ""
 "Mae’r rhain yn ystadegau swyddogol achrededig. Adolygwyd yn annibynnolgan y "
 "Swyddfa Rheoleiddio Ystadegau (OSR) ac a ganfuwyd ei fod yn cydymffurfio "
-"gyda safonau dibynadwyedd, ansawdd a gwerth yn y <a href='https://"
-"code.statisticsauthority.gov.uk/the-code/'>Cod Ymarfer ar gyfer Ystadegau</"
-"a>. Mae hyn yn golygu yn fras bod yr ystadegau:"
+"gyda safonau dibynadwyedd, ansawdd a gwerth yn y <a href='https://code."
+"statisticsauthority.gov.uk/the-code/'>Cod Ymarfer ar gyfer Ystadegau</a>. "
+"Mae hyn yn golygu yn fras bod yr ystadegau:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:138
 msgid "meet user needs"
@@ -697,11 +702,11 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: cms/jinja2/templates/pages/topic_page.html:67 cms/topics/models.py:239
+#: cms/jinja2/templates/pages/topic_page.html:67 cms/topics/models.py:241
 msgid "Featured"
 msgstr "Dan Sylw"
 
-#: cms/jinja2/templates/pages/topic_page.html:77 cms/topics/models.py:241
+#: cms/jinja2/templates/pages/topic_page.html:77 cms/topics/models.py:243
 msgid "Related articles"
 msgstr "Erthyglau cysylltiedig"
 
@@ -709,7 +714,7 @@ msgstr "Erthyglau cysylltiedig"
 msgid "View all related articles"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:95 cms/topics/models.py:243
+#: cms/jinja2/templates/pages/topic_page.html:95 cms/topics/models.py:245
 msgid "Methods and quality information"
 msgstr "Dulliau a gwybodaeth o ansawdd"
 
@@ -729,8 +734,8 @@ msgstr ""
 msgid "View all related time series"
 msgstr ""
 
-#: cms/jinja2/templates/pages/topic_page.html:149 cms/topics/models.py:245
-#: cms/topics/tests/test_models.py:548 cms/topics/tests/test_models.py:552
+#: cms/jinja2/templates/pages/topic_page.html:149 cms/topics/models.py:247
+#: cms/topics/tests/test_models.py:556 cms/topics/tests/test_models.py:560
 msgid "Explore more"
 msgstr "Archwilio mwy"
 
@@ -738,7 +743,7 @@ msgstr "Archwilio mwy"
 msgid "Continue"
 msgstr "Parhau"
 
-#: cms/methodology/models.py:184 cms/methodology/models.py:194
+#: cms/methodology/models.py:181 cms/methodology/models.py:191
 msgid "Related publications"
 msgstr "Cyhoeddiadau cysylltiedig"
 
@@ -746,11 +751,11 @@ msgstr "Cyhoeddiadau cysylltiedig"
 msgid "To be confirmed"
 msgstr "I’w gadarnhau"
 
-#: cms/settings/base.py:383
+#: cms/settings/base.py:407
 msgid "English"
 msgstr "Saesneg"
 
-#: cms/settings/base.py:384
+#: cms/settings/base.py:408
 msgid "Welsh"
 msgstr "Cymraeg"
 
@@ -761,13 +766,3 @@ msgstr ""
 #: cms/workflows/templates/workflows/confirm_unlock.html:12
 msgid "No, don't unlock"
 msgstr ""
-
-#, fuzzy
-#~| msgid "Changes to this release date"
-#~ msgid "Changes requested"
-#~ msgstr "Newidiadau i’r dyddiad rhyddhau hwn"
-
-#, fuzzy
-#~| msgid "Published:"
-#~ msgid "Published"
-#~ msgstr "Cyhoeddwyd"

--- a/cms/workflows/templates/workflows/confirm_unlock.html
+++ b/cms/workflows/templates/workflows/confirm_unlock.html
@@ -1,5 +1,6 @@
 {% extends "wagtailadmin/generic/base.html" %}
-{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{{ page_title }}: {{ page_subtitle }}{% endblock %}
 
 {% block main_content %}
     <p>This page is currently ready to be published. Are you sure you want to unlock editing for this page?</p>
@@ -9,7 +10,7 @@
 
         <div>
             <button class="button" type="submit">Yes, unlock it</button>
-            <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unlock" %}</a>
+            <a href="{{ next }}" class="button button-secondary">No, don’t unlock</a>
         </div>
     </form>
 {% endblock %}

--- a/cms/workflows/tests/test_views.py
+++ b/cms/workflows/tests/test_views.py
@@ -80,6 +80,20 @@ class UnlockWorkflowViewTestCase(WagtailTestUtils, TestCase):
 
         self._assert_happy_path()
 
+    def test_page_title(self):
+        mark_page_as_ready_to_publish(self.page)
+
+        response = self.client.get(self.unlock_url)
+        expected_title = f"Unlock: {self.page.get_admin_display_title()}"
+        self.assertContains(response, f"<title>{expected_title} - Wagtail</title>", html=True)
+
+    def test_cancel_link_points_to_edit_page(self):
+        mark_page_as_ready_to_publish(self.page)
+
+        response = self.client.get(self.unlock_url)
+        edit_url = reverse("wagtailadmin_pages:edit", args=(self.page.pk,))
+        self.assertContains(response, f'<a href="{edit_url}" class="button button-secondary">No, don’t unlock</a>')
+
     def test_post(self):
         mark_page_as_ready_to_publish(self.page)
 

--- a/functional_tests/features/navigation_menus.feature
+++ b/functional_tests/features/navigation_menus.feature
@@ -21,15 +21,19 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
     Scenario: A publishing admin sees the main menu rendered correctly on the home page
         Given the main menu is populated with columns, sections, and topic links
         When the publishing admin visits the home page
+        And the menu button has the correct button text "Menu"
         And the user toggles the main menu
         Then the main menu displays the configured columns, sections, and topic links
-            And the expanded menu pushes the content down and does not overlay it
+        And the expanded menu pushes the content down and does not overlay it
 
     # Switching to Welsh locale and verifying main menu and footer menu rendering
+    @smoke
     Scenario: An external user sees the Welsh main menu on the home page
         Given the main menu is populated with columns, sections, and topic links for the Welsh locale
         When An external user navigates to the homepage
         And the user switches the page language to Welsh
+        And the menu button has the correct button text "Dewislen"
+        And the user toggles the main menu
         Then the Welsh main menu displays the configured columns, sections, and topic links
 
     Scenario: An external user sees the Welsh footer menu on the home page

--- a/functional_tests/features/navigation_menus.feature
+++ b/functional_tests/features/navigation_menus.feature
@@ -27,7 +27,6 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
         And the expanded menu pushes the content down and does not overlay it
 
     # Switching to Welsh locale and verifying main menu and footer menu rendering
-    @smoke
     Scenario: An external user sees the Welsh main menu on the home page
         Given the main menu is populated with columns, sections, and topic links for the Welsh locale
         When An external user navigates to the homepage

--- a/functional_tests/features/navigation_menus.feature
+++ b/functional_tests/features/navigation_menus.feature
@@ -21,9 +21,9 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
     Scenario: A publishing admin sees the main menu rendered correctly on the home page
         Given the main menu is populated with columns, sections, and topic links
         When the publishing admin visits the home page
-        And the menu button has the correct button text "Menu"
-        And the user toggles the main menu
-        Then the main menu displays the configured columns, sections, and topic links
+        When the user toggles the main menu
+        Then the menu button has the button text "Menu"
+        And the main menu displays the configured columns, sections, and topic links
         And the expanded menu pushes the content down and does not overlay it
 
     # Switching to Welsh locale and verifying main menu and footer menu rendering
@@ -31,9 +31,9 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
         Given the main menu is populated with columns, sections, and topic links for the Welsh locale
         When An external user navigates to the homepage
         And the user switches the page language to Welsh
-        And the menu button has the correct button text "Dewislen"
-        And the user toggles the main menu
-        Then the Welsh main menu displays the configured columns, sections, and topic links
+        When the user toggles the main menu
+        Then the menu button has the button text "Dewislen"
+        And the Welsh main menu displays the configured columns, sections, and topic links
 
     Scenario: An external user sees the Welsh footer menu on the home page
         Given the footer menu is populated with columns and links for the Welsh locale

--- a/functional_tests/features/navigation_menus.feature
+++ b/functional_tests/features/navigation_menus.feature
@@ -23,13 +23,14 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
         When the publishing admin visits the home page
         And the user toggles the main menu
         Then the main menu displays the configured columns, sections, and topic links
-            And the expanded menu pushes the content down and does not overlay it
+        And the expanded menu pushes the content down and does not overlay it
 
     # Switching to Welsh locale and verifying main menu and footer menu rendering
     Scenario: An external user sees the Welsh main menu on the home page
         Given the main menu is populated with columns, sections, and topic links for the Welsh locale
         When An external user navigates to the homepage
         And the user switches the page language to Welsh
+        And the user toggles the main menu
         Then the Welsh main menu displays the configured columns, sections, and topic links
 
     Scenario: An external user sees the Welsh footer menu on the home page

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -19,6 +19,7 @@ from functional_tests.step_helpers.navigation_menus_helpers import (
 
 
 def _assert_main_menu_content(
+    *,
     page,
     highlights: list,
     aria_label: str,
@@ -235,13 +236,19 @@ def create_populated_main_menu(context: Context) -> None:
 @when("the user toggles the main menu")
 def user_toggles_main_menu(context: Context) -> None:
     context.main_content_bounding_box_before_toggle = context.page.locator("#main-content").bounding_box()
+    context.page.wait_for_timeout(3000)
     context.page.get_by_role("button", name="Toggle menu").click()
-    context.page.locator('nav[aria-label="Main menu"]').wait_for(state="visible")
+    context.page.locator('nav[aria-label="Menu links navigation"]').wait_for(state="visible")
 
 
 @then("the main menu displays the configured columns, sections, and topic links")
 def main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.main_menu_highlights, "Menu links navigation", "English")
+    _assert_main_menu_content(
+        page=context.page,
+        highlights=context.main_menu_highlights,
+        aria_label="Menu links navigation",
+        locale_suffix="English",
+    )
 
 
 @given("the main menu is populated with columns, sections, and topic links for the Welsh locale")
@@ -266,7 +273,12 @@ def create_populated_welsh_main_menu(context: Context) -> None:
 
 @then("the Welsh main menu displays the configured columns, sections, and topic links")
 def welsh_main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Menu links navigation", "Welsh")
+    _assert_main_menu_content(
+        page=context.page,
+        highlights=context.welsh_main_menu_highlights,
+        aria_label="Menu links navigation",
+        locale_suffix="Welsh",
+    )
 
 
 @given("the footer menu is populated with columns and links for the Welsh locale")
@@ -316,7 +328,7 @@ def menu_button_has_correct_text(context: Context, button_text: str) -> None:
 @then("the expanded menu pushes the content down and does not overlay it")
 def content_is_pushed_down(context: Context) -> None:
     main_content = context.page.locator("#main-content")
-    menu = context.page.get_by_role("navigation", name="Menu")
+    menu = context.page.get_by_role("navigation", name="Menu links navigation")
 
     before = context.main_content_bounding_box_before_toggle
     after = main_content.bounding_box()

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -24,7 +24,6 @@ def _assert_main_menu_content(
     aria_label: str,
     locale_suffix: str = "",
 ) -> None:
-    page.get_by_role("button", name="Toggle menu").click()
     nav = page.locator(f'nav[aria-label="{aria_label}"]')
     expect(nav).to_be_visible()
 
@@ -237,6 +236,7 @@ def create_populated_main_menu(context: Context) -> None:
 def user_toggles_main_menu(context: Context) -> None:
     context.main_content_bounding_box_before_toggle = context.page.locator("#main-content").bounding_box()
     context.page.get_by_role("button", name="Toggle menu").click()
+    context.page.locator('nav[aria-label="Main menu"]').wait_for(state="visible")
 
 
 @then("the main menu displays the configured columns, sections, and topic links")
@@ -266,7 +266,7 @@ def create_populated_welsh_main_menu(context: Context) -> None:
 
 @then("the Welsh main menu displays the configured columns, sections, and topic links")
 def welsh_main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Prif ddewislen", "Welsh")
+    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Main menu", "Welsh")
 
 
 @given("the footer menu is populated with columns and links for the Welsh locale")

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -24,7 +24,6 @@ def _assert_main_menu_content(
     aria_label: str,
     locale_suffix: str = "",
 ) -> None:
-    page.get_by_role("button", name="Toggle menu").click()
     nav = page.locator(f'nav[aria-label="{aria_label}"]')
     expect(nav).to_be_visible()
 
@@ -241,7 +240,7 @@ def user_toggles_main_menu(context: Context) -> None:
 
 @then("the main menu displays the configured columns, sections, and topic links")
 def main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.main_menu_highlights, "Main menu", "English")
+    _assert_main_menu_content(context.page, context.main_menu_highlights, "Menu links navigation", "English")
 
 
 @given("the main menu is populated with columns, sections, and topic links for the Welsh locale")
@@ -266,7 +265,7 @@ def create_populated_welsh_main_menu(context: Context) -> None:
 
 @then("the Welsh main menu displays the configured columns, sections, and topic links")
 def welsh_main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Prif ddewislen", "Welsh")
+    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Menu links navigation", "Welsh")
 
 
 @given("the footer menu is populated with columns and links for the Welsh locale")
@@ -306,10 +305,17 @@ def welsh_footer_menu_displays_configured_content(context: Context) -> None:
         expect(contentinfo).to_contain_text(f"Welsh Link Title {i}")
 
 
+@when('the menu button has the correct button text "{button_text}"')
+def menu_button_has_correct_text(context: Context, button_text: str) -> None:
+    button = context.page.locator('button[aria-label="Toggle menu"]')
+    expect(button).to_be_visible()
+    expect(button.locator(".ons-btn__text")).to_have_text(button_text)
+
+
 @then("the expanded menu pushes the content down and does not overlay it")
 def content_is_pushed_down(context: Context) -> None:
     main_content = context.page.locator("#main-content")
-    menu = context.page.get_by_role("navigation", name="Main menu")
+    menu = context.page.get_by_role("navigation", name="Menu")
 
     before = context.main_content_bounding_box_before_toggle
     after = main_content.bounding_box()

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -305,7 +305,7 @@ def welsh_footer_menu_displays_configured_content(context: Context) -> None:
         expect(contentinfo).to_contain_text(f"Welsh Link Title {i}")
 
 
-@when('the menu button has the correct button text "{button_text}"')
+@then('the menu button has the button text "{button_text}"')
 def menu_button_has_correct_text(context: Context, button_text: str) -> None:
     button = context.page.locator('button[aria-label="Toggle menu"]')
     expect(button).to_be_visible()

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.6",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@wagtail/eslint-config-wagtail": "^0.4.0",
         "@wagtail/stylelint-config-wagtail": "^0.8.0",
         "autoprefixer": "^10.4.20",
@@ -821,10 +821,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -839,10 +840,11 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1401,9 +1403,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3190,12 +3192,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -3301,120 +3297,160 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
       "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3422,73 +3458,125 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -9610,9 +9698,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10817,12 +10905,13 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11508,10 +11597,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -14683,9 +14773,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14815,15 +14905,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.6",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@wagtail/eslint-config-wagtail": "^0.4.0",
     "@wagtail/stylelint-config-wagtail": "^0.8.0",
     "autoprefixer": "^10.4.20",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');


### PR DESCRIPTION
### What is the context of this PR?

The `Menu` button in the page header is not currently translating when a website user toggles to the Welsh language.

We do have a `Menu` label correctly marked for translation in our Jinja template; however, we have a mistake in our header component config here: [dis-wagtail/cms/jinja2/templates/base.html at d73dca99e491afd4f6a637560e64cb7a235be3d8 · ONSdigital/dis-wagtail](https://github.com/ONSdigital/dis-wagtail/blob/d73dca99e491afd4f6a637560e64cb7a235be3d8/cms/jinja2/templates/base.html#L63) 

Currently, it is falling back on the default button text, which has no translation.

The key `toggleNavButton` is incorrect; it should be `toggleMenuButton`. This has been corrected on this PR, so our value will be passed through as expected, and translation will work the same as all other page furniture.

This PR also makes sure we are aligning with the ONS DS defaults for the menus, as there are no requirements to change them otherwise. ONS DS docs don't show the defaults, see: https://github.com/search?q=repo%3AONSdigital%2Fdesign-system%20toggleMenuButton&type=code

I also made a tiny update to the `markup.py` in how we mark computed values for translations:
- Without this change, `Download CSV...` is being removed from the `.po` file when we run `make makemessages` command.

I also fixed this test failure: https://github.com/ONSdigital/dis-wagtail/actions/runs/23548629557/job/68556380726

To understand the changes, see the Django docs on:
<details>
<summary>Named-string interpolation</summary>

```
The strings you pass to _() or gettext() can take placeholders, specified with Python’s standard named-string interpolation syntax. Example:

def my_view(request, m, d):
    output = _("Today is %(month)s %(day)s.") % {"month": m, "day": d}
    return HttpResponse(output)

This technique lets language-specific translations reorder the placeholder text.
For example, an English translation may be "Today is November 26.", while a Spanish
translation may be "Hoy es 26 de noviembre." – with the month and the day placeholders swapped.

For this reason, you should use named-string interpolation (e.g., %(day)s) instead of
positional interpolation (e.g., %s or %d) whenever you have more than a single parameter.
If you used positional interpolation, translations wouldn’t be able to reorder placeholder text.

Since string extraction is done by the xgettext command, only syntaxes supported by gettext
are supported by Django.
Python [f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)
cannot be used directly with gettext functions because f-string expressions are evaluated
before they reach gettext. This means _(f"Welcome {name}") will not work as expected,
as the variable is substituted before translation occurs. Instead, use named-string interpolation:
```

</details>

https://docs.djangoproject.com/en/6.0/topics/i18n/translation/

### How to review

- Check the JIRA card and make sure all the changes are in place.
- Cross-check with the ONS DS docs: https://service-manual.ons.gov.uk/design-system/components/header to see that the config is correctly used/ set.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
