### PR TITLE
Fix flaky functional tests - Navigation

### DIFF
--- a/cms/jinja2/templates/base.html
+++ b/cms/jinja2/templates/base.html
@@ -33,9 +33,10 @@
 {#- We set variables for text so that it gets picked up by makemessages -#}
 {%- set badge_label = _("Beta") -%}
 {%- set badge_html = _("This is a new service.") -%}
+{%- set menu_aria_label = _("Menu links navigation") -%}
+{%- set menu_list_aria_label = _("Menu links") -%}
 {%- set menu_label = _("Menu") -%}
-{%- set menu_label = _("Main menu") -%}
-{%- set menu_toggle_aria_label = _("Toggle main menu") -%}
+{%- set menu_toggle_aria_label = _("Toggle menu") -%}
 {%- set breadcrumbs_aria_label = _("Breadcrumbs") -%}
 
 {%- set ogl_pre = _('All content is available under the') -%}
@@ -58,9 +59,9 @@
         "mastheadLogoUrl": "/",
         "menuLinks": {
             "id": "nav-links-external",
-            "ariaLabel": menu_label,
-            "ariaListLabel": menu_label,
-            "toggleNavButton": {
+            "ariaLabel": menu_aria_label,
+            "ariaListLabel": menu_list_aria_label,
+            "toggleMenuButton": {
                 "text":menu_label,
                 "ariaLabel": menu_toggle_aria_label
             },

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-25 16:55+0000\n"
+"POT-Creation-Date: 2026-03-27 11:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,26 +148,34 @@ msgid "This is a new service."
 msgstr "Mae hwn yn wasanaeth newydd."
 
 #: cms/jinja2/templates/base.html:36
+msgid "Menu links navigation"
+msgstr ""
+
+#: cms/jinja2/templates/base.html:37
+#, fuzzy
+#| msgid "Related links"
+msgid "Menu links"
+msgstr "Dolenni cysylltiedig"
+
+#: cms/jinja2/templates/base.html:38
 msgid "Menu"
 msgstr "Dewislen"
 
-#: cms/jinja2/templates/base.html:37
-msgid "Main menu"
-msgstr "Prif ddewislen"
-
-#: cms/jinja2/templates/base.html:38
-msgid "Toggle main menu"
+#: cms/jinja2/templates/base.html:39
+#, fuzzy
+#| msgid "Toggle main menu"
+msgid "Toggle menu"
 msgstr "Togl y brif ddewislen"
 
-#: cms/jinja2/templates/base.html:39
+#: cms/jinja2/templates/base.html:40
 msgid "Breadcrumbs"
 msgstr "Briwsion bara"
 
-#: cms/jinja2/templates/base.html:41
+#: cms/jinja2/templates/base.html:42
 msgid "All content is available under the"
 msgstr "Mae’r holl gynnwys ar gael o dan y"
 
-#: cms/jinja2/templates/base.html:44
+#: cms/jinja2/templates/base.html:45
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
@@ -757,6 +765,9 @@ msgstr "Cymraeg"
 #: cms/workflows/templates/wagtailadmin/workflows/workflow_status.html:13
 msgid "Not started"
 msgstr ""
+
+#~ msgid "Main menu"
+#~ msgstr "Prif ddewislen"
 
 #, fuzzy
 #~| msgid "Changes to this release date"

--- a/functional_tests/features/navigation_menus.feature
+++ b/functional_tests/features/navigation_menus.feature
@@ -21,8 +21,9 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
     Scenario: A publishing admin sees the main menu rendered correctly on the home page
         Given the main menu is populated with columns, sections, and topic links
         When the publishing admin visits the home page
-        And the user toggles the main menu
-        Then the main menu displays the configured columns, sections, and topic links
+        When the user toggles the main menu
+        Then the menu button has the button text "Menu"
+        And the main menu displays the configured columns, sections, and topic links
         And the expanded menu pushes the content down and does not overlay it
 
     # Switching to Welsh locale and verifying main menu and footer menu rendering
@@ -30,8 +31,9 @@ Feature: CMS users can manage navigation menus via the Wagtail admin interface
         Given the main menu is populated with columns, sections, and topic links for the Welsh locale
         When An external user navigates to the homepage
         And the user switches the page language to Welsh
-        And the user toggles the main menu
-        Then the Welsh main menu displays the configured columns, sections, and topic links
+        When the user toggles the main menu
+        Then the menu button has the button text "Dewislen"
+        And the Welsh main menu displays the configured columns, sections, and topic links
 
     Scenario: An external user sees the Welsh footer menu on the home page
         Given the footer menu is populated with columns and links for the Welsh locale

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -19,6 +19,7 @@ from functional_tests.step_helpers.navigation_menus_helpers import (
 
 
 def _assert_main_menu_content(
+    *,
     page,
     highlights: list,
     aria_label: str,
@@ -235,13 +236,19 @@ def create_populated_main_menu(context: Context) -> None:
 @when("the user toggles the main menu")
 def user_toggles_main_menu(context: Context) -> None:
     context.main_content_bounding_box_before_toggle = context.page.locator("#main-content").bounding_box()
+    context.page.wait_for_timeout(3000)
     context.page.get_by_role("button", name="Toggle menu").click()
-    context.page.locator('nav[aria-label="Main menu"]').wait_for(state="visible")
+    context.page.locator('nav[aria-label="Menu links navigation"]').wait_for(state="visible")
 
 
 @then("the main menu displays the configured columns, sections, and topic links")
 def main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.main_menu_highlights, "Main menu", "English")
+    _assert_main_menu_content(
+        page=context.page,
+        highlights=context.main_menu_highlights,
+        aria_label="Menu links navigation",
+        locale_suffix="English",
+    )
 
 
 @given("the main menu is populated with columns, sections, and topic links for the Welsh locale")
@@ -266,7 +273,12 @@ def create_populated_welsh_main_menu(context: Context) -> None:
 
 @then("the Welsh main menu displays the configured columns, sections, and topic links")
 def welsh_main_menu_displays_configured_content(context: Context) -> None:
-    _assert_main_menu_content(context.page, context.welsh_main_menu_highlights, "Main menu", "Welsh")
+    _assert_main_menu_content(
+        page=context.page,
+        highlights=context.welsh_main_menu_highlights,
+        aria_label="Menu links navigation",
+        locale_suffix="Welsh",
+    )
 
 
 @given("the footer menu is populated with columns and links for the Welsh locale")
@@ -306,10 +318,17 @@ def welsh_footer_menu_displays_configured_content(context: Context) -> None:
         expect(contentinfo).to_contain_text(f"Welsh Link Title {i}")
 
 
+@then('the menu button has the button text "{button_text}"')
+def menu_button_has_correct_text(context: Context, button_text: str) -> None:
+    button = context.page.locator('button[aria-label="Toggle menu"]')
+    expect(button).to_be_visible()
+    expect(button.locator(".ons-btn__text")).to_have_text(button_text)
+
+
 @then("the expanded menu pushes the content down and does not overlay it")
 def content_is_pushed_down(context: Context) -> None:
     main_content = context.page.locator("#main-content")
-    menu = context.page.get_by_role("navigation", name="Main menu")
+    menu = context.page.get_by_role("navigation", name="Menu links navigation")
 
     before = context.main_content_bounding_box_before_toggle
     after = main_content.bounding_box()


### PR DESCRIPTION
### What is the context of this PR?

Pull in the functional tests updates from https://github.com/ONSdigital/dis-wagtail/pull/553 to reduce CI flakiness.
The HTML changes can be discarded when https://github.com/ONSdigital/dis-wagtail/pull/526 is rebased and tests can stay unchanged.

### How to review

Do the changes make sense?. The functional test changes should be identical to https://github.com/ONSdigital/dis-wagtail/pull/553

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
