### PR TITLE
Disable account editing in Wagtail

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -14,6 +14,7 @@ from cms.core import views as core_views
 from cms.core.cache import get_default_cache_control_decorator
 from cms.home.views import serve_localized_homepage
 from cms.private_media import views as private_media_views
+from cms.users.views import ONSAccountView
 
 # Internal URLs are not intended for public use.
 internal_urlpatterns = [
@@ -41,6 +42,7 @@ if not settings.IS_EXTERNAL_ENV:
 
     # Conditionally include Wagtail admin URLs
     wagtail_admin_patterns = [
+        path("account/", ONSAccountView.as_view(), name="wagtailadmin_account"),
         path(
             "logout/",
             ONSLogoutView.as_view(),

--- a/cms/users/templates/wagtailadmin/account/settings_panels/avatar_readonly.html
+++ b/cms/users/templates/wagtailadmin/account/settings_panels/avatar_readonly.html
@@ -1,0 +1,8 @@
+{% load wagtailadmin_tags %}
+{% block content %}
+    <div class="w-avatar-panel w-flex w-flex-wrap w-items-center">
+        <div class="w-avatar-panel__image w-mr-9 w-mb-5">
+            {% avatar user=request.user classname="avatar-span w-block w-mt-3" size="large" %}
+        </div>
+    </div>
+{% endblock %}

--- a/cms/users/tests/test_account_view.py
+++ b/cms/users/tests/test_account_view.py
@@ -1,0 +1,106 @@
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.test.utils import WagtailTestUtils
+from wagtail.users.models import UserProfile
+
+from cms.users.views import (
+    ReadOnlyAvatarSettingsPanel,
+    ReadOnlyNameEmailSettingsPanel,
+)
+
+
+class AccountViewPanelsTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = cls.create_superuser(username="admin", password="password")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+        self.url = reverse("wagtailadmin_account")
+
+    def _get_panels(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        panels = []
+        for tab_panels in response.context["panels_by_tab"].values():
+            panels.extend(tab_panels)
+        return panels
+
+    def test_get_returns_200(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_panel_absent(self):
+        panels = self._get_panels()
+        panel_names = [p.name for p in panels]
+        self.assertNotIn("password", panel_names)
+
+    def test_name_email_panel_is_read_only(self):
+        panels = self._get_panels()
+        name_email_panel = next(p for p in panels if p.name == "name_email")
+        self.assertIsInstance(name_email_panel, ReadOnlyNameEmailSettingsPanel)
+
+    def test_avatar_panel_is_read_only(self):
+        panels = self._get_panels()
+        avatar_panel = next(p for p in panels if p.name == "avatar")
+        self.assertIsInstance(avatar_panel, ReadOnlyAvatarSettingsPanel)
+
+    def test_name_email_fields_are_disabled(self):
+        panels = self._get_panels()
+        name_email_panel = next(p for p in panels if p.name == "name_email")
+        form = name_email_panel.get_form()
+        for field in form.fields.values():
+            self.assertTrue(field.disabled)
+
+    def test_name_not_updated_on_post(self):
+        self.user.first_name = "Original"
+        self.user.save(update_fields=["first_name"])
+
+        self.client.post(
+            self.url,
+            {
+                "name_email-first_name": "Changed",
+                "name_email-last_name": self.user.last_name,
+                "name_email-email": self.user.email,
+                "theme-theme": "light",
+                "theme-contrast": "system",
+                "theme-density": "default",
+                "theme-keyboard_shortcuts": "false",
+                "notifications-approved_notifications": "true",
+                "notifications-rejected_notifications": "true",
+                "notifications-updated_comments_notifications": "true",
+            },
+        )
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Original")
+
+    def test_theme_updated_on_post(self):
+        profile = UserProfile.get_for_user(self.user)
+        self.assertNotEqual(profile.theme, "dark")
+
+        self.client.post(
+            self.url,
+            {
+                "name_email-first_name": self.user.first_name,
+                "name_email-last_name": self.user.last_name,
+                "name_email-email": self.user.email,
+                "theme-theme": "dark",
+                "theme-contrast": "system",
+                "theme-density": "default",
+                "theme-keyboard_shortcuts": "false",
+                "notifications-approved_notifications": "true",
+                "notifications-rejected_notifications": "true",
+                "notifications-updated_comments_notifications": "true",
+            },
+        )
+
+        profile.refresh_from_db()
+        self.assertEqual(profile.theme, "dark")
+
+    def test_avatar_panel_form_never_bound_on_post(self):
+        panels = self._get_panels()
+        avatar_panel = next(p for p in panels if p.name == "avatar")
+        form = avatar_panel.get_form()
+        # The form is not bound, i.e. not tied to POST data
+        self.assertFalse(form.is_bound)

--- a/cms/users/views.py
+++ b/cms/users/views.py
@@ -14,13 +14,17 @@ from wagtail.admin.views.account import (
 from wagtail.users.models import UserProfile
 
 
-class ReadOnlyNameEmailSettingsPanel(NameEmailSettingsPanel):
+class ReadOnlyFieldsMixin:
     def get_form(self) -> forms.BaseForm:
-        form = cast(forms.BaseForm, super().get_form())
+        form = cast(forms.BaseForm, super().get_form())  # type: ignore[misc]
         for field in form.fields.values():
             field.disabled = True
             field.required = False
         return form
+
+
+class ReadOnlyNameEmailSettingsPanel(ReadOnlyFieldsMixin, NameEmailSettingsPanel):
+    pass
 
 
 class ReadOnlyAvatarSettingsPanel(AvatarSettingsPanel):
@@ -30,13 +34,8 @@ class ReadOnlyAvatarSettingsPanel(AvatarSettingsPanel):
         return cast(forms.BaseForm, self.form_class(instance=self.profile, prefix=self.name))
 
 
-class ReadOnlyLocaleSettingsPanel(LocaleSettingsPanel):
-    def get_form(self) -> forms.BaseForm:
-        form = cast(forms.BaseForm, super().get_form())
-        for field in form.fields.values():
-            field.disabled = True
-            field.required = False
-        return form
+class ReadOnlyLocaleSettingsPanel(ReadOnlyFieldsMixin, LocaleSettingsPanel):
+    pass
 
 
 class ONSAccountView(AccountView):

--- a/cms/users/views.py
+++ b/cms/users/views.py
@@ -1,0 +1,61 @@
+from typing import cast
+
+from django import forms
+from wagtail import hooks
+from wagtail.admin.views.account import (
+    AccountView,
+    AvatarSettingsPanel,
+    BaseSettingsPanel,
+    LocaleSettingsPanel,
+    NameEmailSettingsPanel,
+    NotificationsSettingsPanel,
+    ThemeSettingsPanel,
+)
+from wagtail.users.models import UserProfile
+
+
+class ReadOnlyNameEmailSettingsPanel(NameEmailSettingsPanel):
+    def get_form(self) -> forms.BaseForm:
+        form = cast(forms.BaseForm, super().get_form())
+        for field in form.fields.values():
+            field.disabled = True
+            field.required = False
+        return form
+
+
+class ReadOnlyAvatarSettingsPanel(AvatarSettingsPanel):
+    template_name = "wagtailadmin/account/settings_panels/avatar_readonly.html"
+
+    def get_form(self) -> forms.BaseForm:
+        return cast(forms.BaseForm, self.form_class(instance=self.profile, prefix=self.name))
+
+
+class ReadOnlyLocaleSettingsPanel(LocaleSettingsPanel):
+    def get_form(self) -> forms.BaseForm:
+        form = cast(forms.BaseForm, super().get_form())
+        for field in form.fields.values():
+            field.disabled = True
+            field.required = False
+        return form
+
+
+class ONSAccountView(AccountView):
+    def get_panels(self) -> list[BaseSettingsPanel]:
+        request = self.request
+        user = request.user
+        profile = UserProfile.get_for_user(user)
+
+        panels = [
+            ReadOnlyNameEmailSettingsPanel(request, user, profile),
+            ReadOnlyAvatarSettingsPanel(request, user, profile),
+            NotificationsSettingsPanel(request, user, profile),
+            ReadOnlyLocaleSettingsPanel(request, user, profile),
+            ThemeSettingsPanel(request, user, profile),
+        ]
+
+        for fn in hooks.get_hooks("register_account_settings_panel"):
+            panel = fn(request, user, profile)
+            if panel and panel.is_active():
+                panels.append(panel)
+
+        return [panel for panel in panels if panel.is_active()]

--- a/functional_tests/features/user_account.feature
+++ b/functional_tests/features/user_account.feature
@@ -1,0 +1,25 @@
+Feature: A CMS user can view and edit their account details
+
+    Background:
+        Given a Publishing Admin logs into the admin site
+
+    Scenario: A CMS user can view their account details
+        When the user opens the account details page
+        Then they can see their account details
+
+    Scenario: A CMS user cannot edit their account details
+        When the user opens the account details page
+        Then they cannot edit their first name, last name or email
+
+    Scenario: A CMS user can change their theme
+        When the user opens the account details page
+        And the user changes their theme to "Dark"
+        And the user clicks "Save" to save the account details
+        Then the user's theme is updated to "Dark"
+
+    Scenario: A CMS user can change their notifications settings
+        When the user opens the account details page
+        And the user clicks on the Notifications tab
+        And the user toggles Submitted notifications on
+        And the user clicks "Save" to save the account details
+        Then the user's Submitted notifications setting is updated to on

--- a/functional_tests/steps/user_account.py
+++ b/functional_tests/steps/user_account.py
@@ -1,0 +1,66 @@
+# pylint: disable=not-callable
+
+from behave import then, when
+from behave.runner import Context
+from playwright.sync_api import expect
+
+
+@when("the user opens the account details page")
+def user_opens_account_details_page(context: Context) -> None:
+    """Navigate to the account details page."""
+    context.page.goto(f"{context.base_url}/admin/account/")
+
+
+@then("they can see their account details")
+def user_sees_account_details(context: Context) -> None:
+    """Assert the account details are visible."""
+    expect(context.page.get_by_role("heading", name="Name and Email")).to_be_visible()
+
+    expect(context.page.get_by_role("textbox", name="First Name")).to_have_value(context.user_data["user"].first_name)
+    expect(context.page.get_by_role("textbox", name="Last Name")).to_have_value(context.user_data["user"].last_name)
+    expect(context.page.get_by_role("textbox", name="Email")).to_have_value(context.user_data["user"].email)
+
+
+@then("they cannot edit their first name, last name or email")
+def user_cannot_edit_account_details(context: Context) -> None:
+    """Assert the account details fields are disabled."""
+    expect(context.page.get_by_role("textbox", name="First Name")).to_be_disabled()
+    expect(context.page.get_by_role("textbox", name="Last Name")).to_be_disabled()
+    expect(context.page.get_by_role("textbox", name="Email")).to_be_disabled()
+
+
+@when('the user changes their theme to "Dark"')
+def user_changes_theme(context: Context) -> None:
+    """Select a theme and save the form."""
+    context.page.get_by_label("Admin theme").select_option(label="Dark")
+
+
+@when('the user clicks "Save" to save the account details')
+def user_saves_account_details(context: Context) -> None:
+    """Click the save button to save the account details form."""
+    context.page.get_by_role("button", name="Save").click()
+
+
+@then('the user\'s theme is updated to "Dark"')
+def user_theme_is_updated(context: Context) -> None:
+    """Assert the theme select shows the chosen value."""
+    expect(context.page.get_by_label("Admin theme")).to_have_value("dark")
+
+
+@when("the user clicks on the Notifications tab")
+def user_clicks_notifications_tab(context: Context) -> None:
+    """Click the Notifications tab."""
+    context.page.get_by_role("tab", name="Notifications").click()
+
+
+@when("the user toggles Submitted notifications on")
+def user_toggles_submitted_notifications(context: Context) -> None:
+    """Check the Submitted notifications checkbox."""
+    context.page.get_by_label("Submitted notifications").check(force=True)
+
+
+@then("the user's Submitted notifications setting is updated to on")
+def user_submitted_notifications_is_on(context: Context) -> None:
+    """Assert the Submitted notifications checkbox is checked after saving."""
+    context.page.get_by_role("tab", name="Notifications").click()
+    expect(context.page.get_by_label("Submitted notifications")).to_be_checked()


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-1127 and selectively disables account editing.

It only allows you to change your theme and notification settings.

Note that the password change fields have been removed completely, while other fields have been kept as read only.

### How to review

1. Login to the CMS
2. Go to the account view at `/admin/account/`
3. Confirm that fields are disabled and you are unable to change your name, email-address or profile picture
4. Confirm that you are able to update your theme and notification settings

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
