### PR TITLE
Sync slugs after page is published

### DIFF
--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -43,7 +43,11 @@ def reload_logging_config(*, setting: str, **kwargs: Any) -> None:
 
 
 def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> None:  # pylint: disable=unused-argument
-    if instance.locale.language_code != settings.LANGUAGE_CODE:
+    if not instance.locale_id or instance.locale.language_code != settings.LANGUAGE_CODE:
+        return
+
+    # Don't attempt to sync slugs for children of the root page
+    if instance.get_parent().is_root():
         return
 
     updatable_aliased_translations = (

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -8,6 +8,8 @@ from django.utils.log import configure_logging
 from wagtail.models import DraftStateMixin, Page, Revision
 from wagtail.signals import page_published
 
+HOME_PAGE_DEPTH = 2
+
 
 def remove_go_live_seconds(
     sender: Any,  # pylint: disable=unused-argument
@@ -47,7 +49,7 @@ def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> 
         return
 
     # Don't attempt to sync slugs for children of the root page
-    if instance.get_parent().is_root():
+    if instance.depth == HOME_PAGE_DEPTH:
         return
 
     updatable_aliased_translations = (
@@ -55,6 +57,7 @@ def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> 
     )
     for translation in updatable_aliased_translations:
         translation.slug = instance.slug
+        # Use save() to trigger any related functionality
         translation.save()
 
 

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -6,7 +6,7 @@ from django.core.signals import setting_changed
 from django.db.models.signals import pre_save
 from django.utils.log import configure_logging
 from wagtail.models import DraftStateMixin, Page, Revision
-from wagtail.signals import page_published
+from wagtail.signals import page_slug_changed
 
 HOME_PAGE_DEPTH = 2
 
@@ -68,6 +68,6 @@ def register_signal_handlers() -> None:
 
     pre_save.connect(remove_approved_go_live_seconds, sender=Revision)
 
-    page_published.connect(sync_alias_translation_slugs)
+    page_slug_changed.connect(sync_alias_translation_slugs)
 
     setting_changed.connect(reload_logging_config)

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -6,6 +6,7 @@ from django.core.signals import setting_changed
 from django.db.models.signals import pre_save
 from django.utils.log import configure_logging
 from wagtail.models import DraftStateMixin, Page, Revision
+from wagtail.signals import page_published
 
 
 def remove_go_live_seconds(
@@ -41,11 +42,25 @@ def reload_logging_config(*, setting: str, **kwargs: Any) -> None:
         configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
 
 
+def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    if instance.locale.language_code != settings.LANGUAGE_CODE:
+        return
+
+    updatable_aliased_translations = (
+        instance.get_translations().filter(alias_of__isnull=False).exclude(slug=instance.slug)
+    )
+    for translation in updatable_aliased_translations:
+        translation.slug = instance.slug
+        translation.save()
+
+
 def register_signal_handlers() -> None:
     for model in apps.get_models():
         if issubclass(model, DraftStateMixin):
             pre_save.connect(remove_go_live_seconds, sender=model)
 
     pre_save.connect(remove_approved_go_live_seconds, sender=Revision)
+
+    page_published.connect(sync_alias_translation_slugs)
 
     setting_changed.connect(reload_logging_config)

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -5,9 +5,10 @@ from django.conf import settings
 from django.core.signals import setting_changed
 from django.db.models.signals import pre_save
 from django.utils.log import configure_logging
-from wagtail.models import DraftStateMixin, Page, Revision
+from wagtail.models import DraftStateMixin, Locale, Page, Revision
 from wagtail.signals import page_slug_changed
 
+# Tree depth of the home page
 HOME_PAGE_DEPTH = 2
 
 
@@ -45,11 +46,13 @@ def reload_logging_config(*, setting: str, **kwargs: Any) -> None:
 
 
 def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> None:  # pylint: disable=unused-argument
-    if not instance.locale_id or instance.locale.language_code != settings.LANGUAGE_CODE:
-        return
-
     # Don't attempt to sync slugs for children of the root page
     if instance.depth == HOME_PAGE_DEPTH:
+        return
+
+    # Only process the signal for instances with a locale matching the default language,
+    # to avoid potential issues with circular updates between translations
+    if not instance.locale_id or instance.locale_id != Locale.get_default().pk:
         return
 
     updatable_aliased_translations = (

--- a/cms/core/tests/test_signal_handlers.py
+++ b/cms/core/tests/test_signal_handlers.py
@@ -92,3 +92,18 @@ class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
 
         cy_home.refresh_from_db()
         self.assertEqual(cy_home.slug, original_cy_slug)
+
+    def test_alias_url_path_gets_updated_on_publish(self):
+        self.cy_alias.slug = "different-slug"
+        # Save to ensure url_path is updated to match the slug before publish
+        # so we can confirm it gets changed after publish.
+        self.cy_alias.save()
+        self.cy_alias.refresh_from_db()
+        original_url_path = self.cy_alias.url_path
+
+        # Publish english version
+        self.en_page.save_revision().publish()
+
+        # URL path should be updated to match the new slug
+        self.cy_alias.refresh_from_db()
+        self.assertNotEqual(self.cy_alias.url_path, original_url_path)

--- a/cms/core/tests/test_signal_handlers.py
+++ b/cms/core/tests/test_signal_handlers.py
@@ -113,3 +113,37 @@ class SyncAliasTranslationSlugsOnSlugChangeTestCase(TestCase):
         # URL path should be updated to match the new slug
         self.cy_alias.refresh_from_db()
         self.assertNotEqual(self.cy_alias.url_path, original_url_path)
+
+    def test_alias_slug_sync_does_not_cause_further_saves(self):
+        """page_slug_changed fires for the alias too (its slug changed), but the handler
+        must not save any further pages when re-invoked for the alias.
+        """
+        self.cy_alias.slug = "different-slug"
+        self.cy_alias.save(update_fields=["slug"])
+
+        self.en_page.slug = "new-en-slug"
+        save_calls = []
+        original_save = Page.save
+
+        def tracking_save(instance, *args, **kwargs):
+            save_calls.append(instance.pk)
+            return original_save(instance, *args, **kwargs)
+
+        with patch.object(Page, "save", tracking_save), self.captureOnCommitCallbacks(execute=True):
+            self.en_page.save_revision().publish()
+
+        # Exactly 2 saves are expected for the alias:
+        # 1. Wagtail's update_aliases (content sync during publish)
+        # 2. Our handler's translation.save() (slug sync)
+        alias_save_count = save_calls.count(self.cy_alias.pk)
+        self.assertEqual(alias_save_count, 2)
+
+        save_calls = []
+
+        with patch.object(Page, "save", tracking_save), self.captureOnCommitCallbacks(execute=True):
+            self.en_page.save_revision().publish()
+
+        # No further saves should occur for the alias on subsequent publish since the slug is already in sync
+        # (just the update_aliases save, no handler-triggered saves)
+        alias_save_count = save_calls.count(self.cy_alias.pk)
+        self.assertEqual(alias_save_count, 1)

--- a/cms/core/tests/test_signal_handlers.py
+++ b/cms/core/tests/test_signal_handlers.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from wagtail.models import Locale, Page
+
+from cms.core.signal_handlers import sync_alias_translation_slugs
+from cms.home.models import HomePage
+from cms.standard_pages.tests.factories import IndexPageFactory
+
+
+class SyncAliasTranslationSlugsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.cy_locale = Locale.objects.get(language_code="cy")
+        cls.cy_home = HomePage.objects.get(locale=cls.cy_locale)
+
+    def setUp(self):
+        self.en_page = IndexPageFactory()
+        self.cy_alias = self.en_page.create_alias(
+            parent=self.cy_home,
+            update_locale=self.cy_locale,
+            reset_translation_key=False,
+        )
+
+    def test_syncs_slug_for_aliased_translation_with_different_slug(self):
+        self.cy_alias.slug = "different-slug"
+        self.cy_alias.save(update_fields=["slug"])
+
+        sync_alias_translation_slugs(None, instance=self.en_page)
+
+        self.cy_alias.refresh_from_db()
+        self.assertEqual(self.cy_alias.slug, self.en_page.slug)
+
+    def test_does_not_modify_alias_when_slug_already_matches(self):
+        self.cy_alias.slug = self.en_page.slug
+        self.cy_alias.save(update_fields=["slug"])
+
+        with patch.object(Page, "save") as mock_save:
+            sync_alias_translation_slugs(None, instance=self.en_page)
+
+        mock_save.assert_not_called()
+
+    def test_skips_for_non_default_locale_page(self):
+        with patch.object(Page, "save") as mock_save:
+            sync_alias_translation_slugs(None, instance=self.cy_alias)
+
+        mock_save.assert_not_called()
+
+    def test_proper_translation_slug_is_not_synced(self):
+        self.cy_alias.alias_of = None
+        self.cy_alias.slug = "different-slug"
+        self.cy_alias.save(update_fields=["alias_of", "slug"])
+
+        with patch.object(Page, "save") as mock_save:
+            sync_alias_translation_slugs(None, instance=self.en_page)
+
+        mock_save.assert_not_called()
+
+
+class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.cy_locale = Locale.objects.get(language_code="cy")
+        cls.cy_home = HomePage.objects.get(locale=cls.cy_locale)
+
+    def setUp(self):
+        self.en_page = IndexPageFactory()
+        self.cy_alias = self.en_page.create_alias(
+            parent=self.cy_home,
+            update_locale=self.cy_locale,
+            reset_translation_key=False,
+        )
+
+    def test_slug_synced_on_publish(self):
+        self.cy_alias.slug = "different-slug"
+        self.cy_alias.save(update_fields=["slug"])
+
+        self.en_page.save_revision().publish()
+
+        self.cy_alias.refresh_from_db()
+        self.assertNotEqual(self.cy_alias.slug, "different-slug")
+        self.assertEqual(self.cy_alias.slug, self.en_page.slug)

--- a/cms/core/tests/test_signal_handlers.py
+++ b/cms/core/tests/test_signal_handlers.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase
 from wagtail.models import Locale, Page
 
@@ -80,3 +81,14 @@ class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
         self.cy_alias.refresh_from_db()
         self.assertNotEqual(self.cy_alias.slug, "different-slug")
         self.assertEqual(self.cy_alias.slug, self.en_page.slug)
+
+    def test_root_level_page_slug_not_synced_on_publish(self):
+        en_home = HomePage.objects.get(locale__language_code=settings.LANGUAGE_CODE)
+        cy_home = HomePage.objects.get(locale=self.cy_locale)
+        original_cy_slug = cy_home.slug
+
+        en_home.slug = "new-home-slug"
+        en_home.save_revision().publish()
+
+        cy_home.refresh_from_db()
+        self.assertEqual(cy_home.slug, original_cy_slug)

--- a/cms/core/tests/test_signal_handlers.py
+++ b/cms/core/tests/test_signal_handlers.py
@@ -58,7 +58,7 @@ class SyncAliasTranslationSlugsTestCase(TestCase):
         mock_save.assert_not_called()
 
 
-class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
+class SyncAliasTranslationSlugsOnSlugChangeTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.cy_locale = Locale.objects.get(language_code="cy")
@@ -72,28 +72,32 @@ class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
             reset_translation_key=False,
         )
 
-    def test_slug_synced_on_publish(self):
+    def test_slug_synced_on_slug_change(self):
         self.cy_alias.slug = "different-slug"
         self.cy_alias.save(update_fields=["slug"])
 
-        self.en_page.save_revision().publish()
+        new_slug = "new-en-slug"
+        self.en_page.slug = new_slug
+        with self.captureOnCommitCallbacks(execute=True):
+            self.en_page.save_revision().publish()
 
         self.cy_alias.refresh_from_db()
         self.assertNotEqual(self.cy_alias.slug, "different-slug")
-        self.assertEqual(self.cy_alias.slug, self.en_page.slug)
+        self.assertEqual(self.cy_alias.slug, new_slug)
 
-    def test_root_level_page_slug_not_synced_on_publish(self):
+    def test_root_level_page_slug_not_synced_on_slug_change(self):
         en_home = HomePage.objects.get(locale__language_code=settings.LANGUAGE_CODE)
         cy_home = HomePage.objects.get(locale=self.cy_locale)
         original_cy_slug = cy_home.slug
 
         en_home.slug = "new-home-slug"
-        en_home.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            en_home.save_revision().publish()
 
         cy_home.refresh_from_db()
         self.assertEqual(cy_home.slug, original_cy_slug)
 
-    def test_alias_url_path_gets_updated_on_publish(self):
+    def test_alias_url_path_gets_updated_on_slug_change(self):
         self.cy_alias.slug = "different-slug"
         # Save to ensure url_path is updated to match the slug before publish
         # so we can confirm it gets changed after publish.
@@ -101,8 +105,10 @@ class SyncAliasTranslationSlugsOnPublishTestCase(TestCase):
         self.cy_alias.refresh_from_db()
         original_url_path = self.cy_alias.url_path
 
-        # Publish english version
-        self.en_page.save_revision().publish()
+        # Change en_page's slug and publish
+        self.en_page.slug = "new-en-slug"
+        with self.captureOnCommitCallbacks(execute=True):
+            self.en_page.save_revision().publish()
 
         # URL path should be updated to match the new slug
         self.cy_alias.refresh_from_db()


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-1155. After a page is published, if it has translations which are aliases, it ensures that the aliases use the same slug as the published page.

This is related to two Wagtail issues:
https://github.com/wagtail/wagtail/issues/7168
https://github.com/wagtail/wagtail/issues/14102

### How to review

1. Create a page in English
2. Ensure that an alias was created in the Welsh page tree
3. Change the slug of the original page
4. Ensure that the alias was not updated for the Welsh alias
5. Publish the English page
6. Ensure that the alias _was_ updated for the Welsh alias

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Monitor changes in core and adapt our code appropriately.
