### PR TITLE
CMS-789 linter for django translation files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ makemessages:  ## We currently just require Welsh (cy), change to -a for all lan
 	poetry run python ./manage.py makemessages --locale cy --ignore "node_modules/*" --ignore ".venv"
 
 .PHONY: makemessages-check
-makemessages:  ## We currently just require Welsh (cy), change to -a for all languages
+makemessages-check:  ## We currently just require Welsh (cy), change to -a for all languages
 	poetry run python ./manage.py makemessages --locale cy --ignore "node_modules/*" --ignore ".venv" --check
 
 .PHONY: compilemessages

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,10 @@ playwright-install:  ## Install Playwright dependencies
 makemessages:  ## We currently just require Welsh (cy), change to -a for all languages
 	poetry run python ./manage.py makemessages --locale cy --ignore "node_modules/*" --ignore ".venv"
 
+.PHONY: makemessages-check
+makemessages:  ## We currently just require Welsh (cy), change to -a for all languages
+	poetry run python ./manage.py makemessages --locale cy --ignore "node_modules/*" --ignore ".venv" --check
+
 .PHONY: compilemessages
 compilemessages:
 	poetry run python ./manage.py compilemessages

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -15,8 +15,6 @@ _POT_CREATION_DATE_RE = re.compile(r'^"POT-Creation-Date: .*?\\n"\n', re.MULTILI
 
 
 class Command(MakeMessagesCommand):
-    _check_mode = False
-
     @override
     def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -38,14 +38,14 @@ class Command(MakeMessagesCommand):
         if self._check_mode:
             if self._modified_po_files:
                 self.stderr.write("The following .po files are not up to date:\n")
-                for path in self._modified_po_files.keys():
+                for path in self._modified_po_files:
                     self.stderr.write(f"  {path}\n")
                     if len(self._modified_po_files[path]) > 0:
-                        self.stderr.write(f"    The following msgids have changed\n")
+                        self.stderr.write("    The following msgids have changed\n")
                         for item in self._modified_po_files[path]:
                             self.stderr.write(f"    {item}\n")
                     else:
-                        self.stderr.write(f"    new file\n")
+                        self.stderr.write("    new file\n")
                 self.stderr.write("\nRun `makemessages` to update them.\n")
                 raise SystemExit(1)
             if self.verbosity > 0:
@@ -106,8 +106,7 @@ class Command(MakeMessagesCommand):
             # for empties after we've joined and cleaned
             if clean_id == "":
                 continue
-            clean_id = clean_id.replace('\\"', '"').replace('\\n', '\n')
+            clean_id = clean_id.replace('\\"', '"').replace("\\n", "\n")
             id_set.add(clean_id)
 
         return id_set
-

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -27,9 +27,9 @@ class Command(MakeMessagesCommand):
 
     @override
     def handle(self, *args: Any, **options: Any) -> None:
-        self._check_mode = options.get("check", False) #pylint: disable=W0201
-        self._modified_po_files: set[str] = set() #pylint: disable=W0201
-        self.verbosity = options["verbosity"] #pylint: disable=W0201
+        self._check_mode = options.get("check", False)  # pylint: disable=W0201
+        self._modified_po_files: set[str] = set()  # pylint: disable=W0201
+        self.verbosity = options["verbosity"]  # pylint: disable=W0201
 
         super().handle(*args, **options)
 

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -28,7 +28,7 @@ class Command(MakeMessagesCommand):
     @override
     def handle(self, *args: Any, **options: Any) -> None:
         self._check_mode = options.get("check", False)
-        self._modified_po_files = set()
+        self._modified_po_files: set[str] = set()
         self.verbosity = options["verbosity"]
 
         super().handle(*args, **options)
@@ -77,6 +77,6 @@ class Command(MakeMessagesCommand):
             self._modified_po_files.add(pofile)
 
     @staticmethod
-    def _normalize(content) -> str:
+    def _normalize(content: str) -> str:
         """Strip out POT-Creation-Date from gettext output."""
         return _POT_CREATION_DATE_RE.sub("", content)

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -56,7 +56,7 @@ class Command(MakeMessagesCommand):
             return
 
         # Get all options to msgmerge except --update so no files on disk are touched
-        check_options = [opt for opt in self.msgmerge_options if opt != "--update"]
+        check_options = [opt for opt in self.msgmerge_options if opt not in ("--update", "--backup=none")]
         args = ["msgmerge"] + check_options + [pofile, potfile]
         msgs, errors, status = popen_wrapper(args)
         if errors:

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -27,9 +27,9 @@ class Command(MakeMessagesCommand):
 
     @override
     def handle(self, *args: Any, **options: Any) -> None:
-        self._check_mode = options.get("check", False)
-        self._modified_po_files: set[str] = set()
-        self.verbosity = options["verbosity"]
+        self._check_mode = options.get("check", False) #pylint: disable=W0201
+        self._modified_po_files: set[str] = set() #pylint: disable=W0201
+        self.verbosity = options["verbosity"] #pylint: disable=W0201
 
         super().handle(*args, **options)
 
@@ -40,13 +40,14 @@ class Command(MakeMessagesCommand):
                     self.stderr.write(f"  {path}\n")
                 self.stderr.write("\nRun `makemessages` to update them.\n")
                 raise SystemExit(1)
-            elif self.verbosity > 0:
+            if self.verbosity > 0:
                 self.stdout.write("All .po files are up to date.\n")
 
     @override
     def write_po_file(self, potfile: str, locale: str) -> None:
         if not self._check_mode:
-            return super().write_po_file(potfile, locale)
+            super().write_po_file(potfile, locale)
+            return
 
         basedir = os.path.join(os.path.dirname(potfile), locale, "LC_MESSAGES")
         pofile = os.path.join(basedir, f"{self.domain}.po")
@@ -64,7 +65,7 @@ class Command(MakeMessagesCommand):
         if errors:
             if status != STATUS_OK:
                 raise CommandError(f"errors happened wile running msgmerge\n{errors}")
-            elif self.verbosity > 0:
+            if self.verbosity > 0:
                 self.stderr.write(errors)
 
         # Apply same formatting that makemessages usually does

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -1,0 +1,82 @@
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, override
+
+from django.core.management.base import CommandError
+from django.core.management.commands.makemessages import Command as MakeMessagesCommand, normalize_eols
+from django.core.management.utils import popen_wrapper
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
+STATUS_OK = 0
+_POT_CREATION_DATE_RE = re.compile(r'^"POT-Creation-Date: .*?\\n"\n', re.MULTILINE)
+
+
+class Command(MakeMessagesCommand):
+    _check_mode = False
+
+    @override
+    def add_arguments(self, parser: CommandParser) -> None:
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help=("Returns a non-zero exit code if .po file(s) would be modified. Does not modify file system."),
+        )
+
+    @override
+    def handle(self, *args: Any, **options: Any) -> None:
+        self._check_mode = options.get("check", False)
+        self._modified_po_files = set()
+        self.verbosity = options["verbosity"]
+
+        super().handle(*args, **options)
+
+        if self._check_mode:
+            if self._modified_po_files:
+                self.stderr.write("The following .po files are not up to date:\n")
+                for path in self._modified_po_files:
+                    self.stderr.write(f"  {path}\n")
+                self.stderr.write("\nRun `makemessages` to update them.\n")
+                raise SystemExit(1)
+            elif self.verbosity > 0:
+                self.stdout.write("All .po files are up to date.\n")
+
+    @override
+    def write_po_file(self, potfile: str, locale: str) -> None:
+        if not self._check_mode:
+            return super().write_po_file(potfile, locale)
+
+        basedir = os.path.join(os.path.dirname(potfile), locale, "LC_MESSAGES")
+        pofile = os.path.join(basedir, f"{self.domain}.po")
+
+        # if the path doesn't already exist this must be a modification
+        if not os.path.exists(pofile):
+            self._modified_po_files.add(pofile)
+            return
+
+        # Get all options to msgmerge except --update so no files on disk are touched
+        check_options = [opt for opt in self.msgmerge_options if opt != "--update"]
+        args = ["msgmerge"] + check_options + [pofile, potfile]
+        msgs, errors, status = popen_wrapper(args)
+        if errors:
+            if status != STATUS_OK:
+                raise CommandError(f"errors happened wile running msgmerge\n{errors}")
+            elif self.verbosity > 0:
+                self.stdout.write(errors)
+
+        # Apply same formatting that makemessages usually does
+        msgs = normalize_eols(msgs)
+        msgs = msgs.replace(f"#. #-#-#-#-#  {self.domain}.pot (PACKAGE VERSION)  #-#-#-#-#\n", "")
+
+        existing = Path(pofile).read_text(encoding="utf-8")
+
+        if self._normalize(existing) != self._normalize(msgs):
+            self._modified_po_files.add(pofile)
+
+    @staticmethod
+    def _normalize(content) -> str:
+        """Strip out POT-Creation-Date from gettext output"""
+        return _POT_CREATION_DATE_RE.sub("", content)

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from django.core.management.base import CommandParser
 
 STATUS_OK = 0
-_POT_CREATION_DATE_RE = re.compile(r'^"POT-Creation-Date: .*?\\n"\n', re.MULTILINE)
+_POT_CREATION_DATE_RE = re.compile(r'^"POT-Creation-Date: [^"]+\\n"', re.MULTILINE)
 
 
 class Command(MakeMessagesCommand):

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 STATUS_OK = 0
 _POT_CREATION_DATE_RE = re.compile(r'^"POT-Creation-Date: [^"]+\\n"', re.MULTILINE)
+_MSGID_RE = re.compile(r'^msgid\s+((?:"[^"\\]*(?:\\.[^"\\]*)*"\s*)+)', re.MULTILINE)
+_MSGID_CONTENTS_RE = re.compile(r'"([^\\]*(?:\\.[^"\\]*)*)"')
 
 
 class Command(MakeMessagesCommand):
@@ -28,7 +30,7 @@ class Command(MakeMessagesCommand):
     @override
     def handle(self, *args: Any, **options: Any) -> None:
         self._check_mode = options.get("check", False)  # pylint: disable=W0201
-        self._modified_po_files: set[str] = set()  # pylint: disable=W0201
+        self._modified_po_files: dict[str, set[str]] = {}  # pylint: disable=W0201
         self.verbosity = options["verbosity"]  # pylint: disable=W0201
 
         super().handle(*args, **options)
@@ -36,8 +38,14 @@ class Command(MakeMessagesCommand):
         if self._check_mode:
             if self._modified_po_files:
                 self.stderr.write("The following .po files are not up to date:\n")
-                for path in self._modified_po_files:
+                for path in self._modified_po_files.keys():
                     self.stderr.write(f"  {path}\n")
+                    if len(self._modified_po_files[path]) > 0:
+                        self.stderr.write(f"    The following msgids have changed\n")
+                        for item in self._modified_po_files[path]:
+                            self.stderr.write(f"    {item}\n")
+                    else:
+                        self.stderr.write(f"    new file\n")
                 self.stderr.write("\nRun `makemessages` to update them.\n")
                 raise SystemExit(1)
             if self.verbosity > 0:
@@ -54,7 +62,7 @@ class Command(MakeMessagesCommand):
 
         # if the path doesn't already exist this must be a modification
         if not os.path.exists(pofile):
-            self._modified_po_files.add(pofile)
+            self._modified_po_files[pofile] = set()
             return
 
         # Get all options to msgmerge except --update (and --backup) so no files on disk
@@ -74,10 +82,32 @@ class Command(MakeMessagesCommand):
 
         existing = Path(pofile).read_text(encoding="utf-8")
 
-        if self._normalize(existing) != self._normalize(msgs):
-            self._modified_po_files.add(pofile)
+        previous_msgids = self._extract_msgids(existing)
+        new_msgids = self._extract_msgids(msgs)
+
+        if previous_msgids != new_msgids:
+            self._modified_po_files[potfile] = set(previous_msgids ^ new_msgids)
 
     @staticmethod
     def _normalize(content: str) -> str:
         """Strip out POT-Creation-Date from gettext output."""
         return _POT_CREATION_DATE_RE.sub("", content)
+
+    @staticmethod
+    def _extract_msgids(content: str) -> set[str]:
+        id_set = set()
+        matches = _MSGID_RE.findall(content)
+
+        for match in matches:
+            # joins multiline strings and removes surrounding quotes
+            clean_id = "".join(_MSGID_CONTENTS_RE.findall(match))
+
+            # Sometimes multiline msgids can start a line with "" so we need to check
+            # for empties after we've joined and cleaned
+            if clean_id == "":
+                continue
+            clean_id = clean_id.replace('\\"', '"').replace('\\n', '\n')
+            id_set.add(clean_id)
+
+        return id_set
+

--- a/cms/locale/management/commands/makemessages.py
+++ b/cms/locale/management/commands/makemessages.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, override
 
 from django.core.management.base import CommandError
-from django.core.management.commands.makemessages import Command as MakeMessagesCommand, normalize_eols
+from django.core.management.commands.makemessages import Command as MakeMessagesCommand
+from django.core.management.commands.makemessages import normalize_eols
 from django.core.management.utils import popen_wrapper
 
 if TYPE_CHECKING:
@@ -55,15 +56,16 @@ class Command(MakeMessagesCommand):
             self._modified_po_files.add(pofile)
             return
 
-        # Get all options to msgmerge except --update so no files on disk are touched
+        # Get all options to msgmerge except --update (and --backup) so no files on disk
+        # are touched and we get the updated contents as the first return value
         check_options = [opt for opt in self.msgmerge_options if opt not in ("--update", "--backup=none")]
-        args = ["msgmerge"] + check_options + [pofile, potfile]
+        args = ["msgmerge", *check_options, pofile, potfile]
         msgs, errors, status = popen_wrapper(args)
         if errors:
             if status != STATUS_OK:
                 raise CommandError(f"errors happened wile running msgmerge\n{errors}")
             elif self.verbosity > 0:
-                self.stdout.write(errors)
+                self.stderr.write(errors)
 
         # Apply same formatting that makemessages usually does
         msgs = normalize_eols(msgs)
@@ -76,5 +78,5 @@ class Command(MakeMessagesCommand):
 
     @staticmethod
     def _normalize(content) -> str:
-        """Strip out POT-Creation-Date from gettext output"""
+        """Strip out POT-Creation-Date from gettext output."""
         return _POT_CREATION_DATE_RE.sub("", content)

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -1,0 +1,297 @@
+from tabnanny import verbose
+import tempfile
+import os
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.core.management.commands.makemessages import Command as MakeMessagesCommand
+from django.test import SimpleTestCase
+
+from cms.locale.management.commands.makemessages import Command
+
+SAMPLE_PO_CONTENT = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 00:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Hello"
+msgstr "Helo"
+"""
+
+SAMPLE_PO_CONTENT_NEW_DATE = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 12:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Hello"
+msgstr "Helo"
+"""
+
+
+SAMPLE_PO_CONTENT_NEW_ENTRY = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 00:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Hello"
+msgstr "Helo"
+
+msgid "Goodbye"
+msgid "Hwyl fawr"
+"""
+
+class NormalizeTests(SimpleTestCase):
+    """Tests for Command._normalize, which strips POT-Creation-Date headers."""
+
+    def test_strips_pot_creation_date(self):
+        content = (
+            'msgid ""\n'
+            'msgstr ""\n'
+            '"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n'
+            '"Language: cy\\n"\n'
+        )
+        result = Command._normalize(content)
+        self.assertNotIn("POT-Creation-Date", result)
+
+    def test_preserves_other_metadata(self):
+        content = (
+            'msgid ""\n'
+            'msgstr ""\n'
+            '"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n'
+            '"PO-Revision-Date: 2026-01-01 00:00+0000\\n"\n'
+            '"Last-Translator: someone\\n"\n'
+            '"Language: cy\\n"\n'
+        )
+        result = Command._normalize(content)
+        self.assertIn("PO-Revision-Date", result)
+        self.assertIn("Last-Translator", result)
+        self.assertIn("Language", result)
+
+    def test_content_with_no_date_header_is_unchanged(self):
+        content = 'msgid "Hello"\nmsgstr "Helo"\n'
+        self.assertEqual(Command._normalize(content), content)
+
+class WritePOFileCheckModeTests(SimpleTestCase):
+    """Tests for write_po_file when _check_mode is True."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.potfile = os.path.join(self.tmpdir, "django.pot")
+        Path(self.potfile).write_text("", encoding="utf8")
+
+        self.pofile_dir = os.path.join(self.tmpdir, "cy", "LC_MESSAGES")
+        self.pofile = os.path.join(self.pofile_dir, "django.po")
+
+        self.command = Command()
+        # enable _check_mode
+        self.command._check_mode = True
+        self.command._modified_po_files = set()
+        self.command.domain = "django"
+        self.command.msgmerge_options = ["-q", "--backup=none", "--previous", "--update"]
+        self.command.verbosity = 0
+        self.command.invoked_for_django = False
+        self.command.stdout = StringIO()
+        self.command.stderr = StringIO()
+
+    def _create_po_file(self, content=SAMPLE_PO_CONTENT):
+        os.makedirs(self.pofile_dir, exist_ok=True)
+        Path(self.pofile).write_text(content, encoding="utf-8")
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_missing_po_file_detected_as_change(self, mock_popen):
+        # .po file does not exist
+        self.command.write_po_file(self.potfile, "cy")
+
+        self.assertIn(self.pofile, self.command._modified_po_files)
+        # we don't attempt to call msgmerge if the file didn't already exist
+        mock_popen.assert_not_called()
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_unchanged_content_not_flagged(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+        # returns stdout, stderr and status code
+        mock_popen.return_value = (SAMPLE_PO_CONTENT, "", 0)
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        # assert modified files is an empty set
+        self.assertEqual(self.command._modified_po_files, set())
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_changed_content_flagged(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+
+        # stdout from msgmerge is different
+        mock_popen.return_value = (SAMPLE_PO_CONTENT_NEW_ENTRY, "", 0)
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        # new file should be in modififed set
+        self.assertIn(self.pofile, self.command._modified_po_files)
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+
+        # only date is different from initial content
+        mock_popen.return_value = (SAMPLE_PO_CONTENT_NEW_DATE, "", 0)
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        # assert modified files is an empty set
+        self.assertEqual(self.command._modified_po_files, set())
+
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_msgmerge_called_without_update_arg(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+        mock_popen.return_value = (SAMPLE_PO_CONTENT, "", 0)
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        args = mock_popen.call_args[0][0]
+        self.assertEqual(args[0], "msgmerge")
+        self.assertNotIn("--update", args)
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_additional_options_preserved(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+        mock_popen.return_value = (SAMPLE_PO_CONTENT, "", 0)
+        self.command.msgmerge_options = [
+            "-q",
+            "--backup=none",
+            "--previous",
+            "--update",
+            "--no-wrap"
+        ]
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        args = mock_popen.call_args[0][0]
+        self.assertIn("-q", args)
+        self.assertIn("--backup=none", args)
+        self.assertIn("--previous", args)
+        self.assertIn("--no-wrap", args)
+        self.assertNotIn("--update", args)
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_existing_po_files_not_modified(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+        mock_popen.return_value = (SAMPLE_PO_CONTENT_NEW_ENTRY, "", 0)
+
+        content_before = Path(self.potfile).read_text(encoding="utf-8")
+        self.command.write_po_file(self.potfile, "cy")
+        content_after = Path(self.potfile).read_text(encoding="utf-8")
+
+        self.assertEqual(content_before, content_after)
+
+    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    def test_raises_command_error_if_popen_returns_non_zero_code(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+        mock_popen.return_value = ("", "fatal error in msgmerge", 2)
+
+        with self.assertRaises(CommandError) as ctx:
+            self.command.write_po_file(self.potfile, "cy")
+
+        self.assertIn("msgmerge", str(ctx.exception))
+
+class WritePOFileNormalModeTests(SimpleTestCase):
+    """Tests for write_po_file when _check_mode is False"""
+
+    @patch.object(MakeMessagesCommand, 'write_po_file')
+    def test_delegates_to_parent(self, mock_write_parent):
+        command = Command()
+        command._check_mode = False
+
+        command.write_po_file("/tmp/django.pot", "cy")
+
+        mock_write_parent.assert_called_once_with("/tmp/django.pot", "cy")
+
+class HandleCheckModeTests(SimpleTestCase):
+    """Tests for handle() with --check flag.
+
+    Mock out the parent MakeMessagesCommand.handle() to avoid full gettext extraction.
+    Use the mock's side effect to populate _modified_po_files to simulate detecting changes.
+    """
+
+    def setUp(self):
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+
+    def _make_command(self):
+        """Create a Command with captured stdout/stderr."""
+        command = Command()
+        command.stdout = self.stdout
+        command.stderr = self.stderr
+        return command
+
+    @patch.object(MakeMessagesCommand, "handle")
+    def test_no_changes_exists_zero(self, _):
+        command = self._make_command()
+        command.handle(check=True, verbosity=1)
+
+        self.assertIn("All .po files are up to date.", self.stdout.getvalue())
+
+    @patch.object(MakeMessagesCommand, "handle")
+    def test_changes_detected_exits_non_zero(self, mock_parent_handle):
+        command = self._make_command()
+
+        def simulate_changes(*args, **options):
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")
+
+        mock_parent_handle.side_effect = simulate_changes
+
+        with self.assertRaises(SystemExit) as ctx:
+            command.handle(check=True, verbosity=1)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch.object(MakeMessagesCommand, "handle")
+    def test_changes_listed_in_stderr(self, mock_parent_handle):
+        command = self._make_command()
+        changed_path = "/some/locale/cy/LC_MESSAGES/django.po"
+
+        def simulate_changes(*args, **options):
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")
+
+        mock_parent_handle.side_effect = simulate_changes
+
+        with self.assertRaises(SystemExit):
+            command.handle(check=True, verbosity=1)
+
+        stderr_output = self.stderr.getvalue()
+        self.assertIn(changed_path, stderr_output)
+        self.assertIn("The following .po files are not up to date:", stderr_output)
+        self.assertIn("Run `makemessages` to update them.", stderr_output)
+
+    @patch.object(MakeMessagesCommand, 'handle')
+    def test_without_check_delegates_to_default_makemessages(self, mock_parent_handle):
+        command = self._make_command()
+        command.handle(check=False, verbosity=1)
+
+        mock_parent_handle.assert_called_once()
+
+        self.assertNotIn("up to date", self.stdout.getvalue())
+        self.assertEqual(self.stderr.getvalue(), "")
+
+    @patch.object(MakeMessagesCommand, 'handle')
+    def test_quiet_mode_suppresses_success_message(self, mock_parent_handle):
+        command = self._make_command()
+        command.handle(check=False, verbosity=0)
+
+        self.assertEqual(self.stdout.getvalue(), "")

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -59,7 +59,7 @@ class NormalizeTests(SimpleTestCase):
 
     def test_strips_pot_creation_date(self):
         content = 'msgid ""\nmsgstr ""\n"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n"Language: cy\\n"\n'
-        result = Command._normalize(content)
+        result = Command._normalize(content) #pylint: disable=W0212
         self.assertNotIn("POT-Creation-Date", result)
 
     def test_preserves_other_metadata(self):
@@ -71,14 +71,15 @@ class NormalizeTests(SimpleTestCase):
             '"Last-Translator: someone\\n"\n'
             '"Language: cy\\n"\n'
         )
-        result = Command._normalize(content)
+        result = Command._normalize(content) #pylint: disable=W0212
         self.assertIn("PO-Revision-Date", result)
         self.assertIn("Last-Translator", result)
         self.assertIn("Language", result)
 
     def test_content_with_no_date_header_is_unchanged(self):
         content = 'msgid "Hello"\nmsgstr "Helo"\n'
-        self.assertEqual(Command._normalize(content), content)
+        self.assertEqual(Command._normalize(content), content) # pylint: disable=W0212
+
 
 
 class WritePOFileCheckModeTests(SimpleTestCase):
@@ -94,8 +95,8 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.command = Command()
         # enable _check_mode
-        self.command._check_mode = True
-        self.command._modified_po_files = set()
+        self.command._check_mode = True #pylint: disable=W0212
+        self.command._modified_po_files = set() #pylint: disable=W0212
         self.command.domain = "django"
         self.command.msgmerge_options = ["-q", "--backup=none", "--previous", "--update"]
         self.command.verbosity = 0
@@ -112,7 +113,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # .po file does not exist
         self.command.write_po_file(self.potfile, "cy")
 
-        self.assertIn(self.pofile, self.command._modified_po_files)
+        self.assertIn(self.pofile, self.command._modified_po_files) # pylint: disable=W0212
         # we don't attempt to call msgmerge if the file didn't already exist
         mock_popen.assert_not_called()
 
@@ -125,7 +126,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set())
+        self.assertEqual(self.command._modified_po_files, set()) #pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_changed_content_flagged(self, mock_popen):
@@ -137,7 +138,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # new file should be in modififed set
-        self.assertIn(self.pofile, self.command._modified_po_files)
+        self.assertIn(self.pofile, self.command._modified_po_files) #pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
@@ -149,7 +150,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set())
+        self.assertEqual(self.command._modified_po_files, set()) #pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_msgmerge_called_without_update_arg(self, mock_popen):
@@ -206,7 +207,7 @@ class WritePOFileNormalModeTests(SimpleTestCase):
     @patch.object(MakeMessagesCommand, "write_po_file")
     def test_delegates_to_parent(self, mock_write_parent):
         command = Command()
-        command._check_mode = False
+        command._check_mode = False # pylint: disable=W0212
 
         # disable qa as using mocked version of function
         command.write_po_file("/tmp/django.pot", "cy")  # noqa: S108
@@ -244,8 +245,8 @@ class HandleCheckModeTests(SimpleTestCase):
     def test_changes_detected_exits_non_zero(self, mock_parent_handle):
         command = self._make_command()
 
-        def simulate_changes(*args, **options):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")
+        def simulate_changes(*args, **_):
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po") # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 
@@ -259,8 +260,8 @@ class HandleCheckModeTests(SimpleTestCase):
         command = self._make_command()
         changed_path = "/some/locale/cy/LC_MESSAGES/django.po"
 
-        def simulate_changes(*args, **options):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")
+        def simulate_changes(*args, **_):
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po") # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 
@@ -283,7 +284,7 @@ class HandleCheckModeTests(SimpleTestCase):
         self.assertEqual(self.stderr.getvalue(), "")
 
     @patch.object(MakeMessagesCommand, "handle")
-    def test_quiet_mode_suppresses_success_message(self, mock_parent_handle):
+    def test_quiet_mode_suppresses_success_message(self, _):
         command = self._make_command()
         command.handle(check=False, verbosity=0)
 

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -141,25 +141,23 @@ class NormalizeTests(SimpleTestCase):
         content = 'msgid "Hello"\nmsgstr "Helo"\n'
         self.assertEqual(Command._normalize(content), content)  # pylint: disable=W0212
 
+
 class ExtractMsgidTests(SimpleTestCase):
     """Tests for Command._extract_msgids, which pulls only clean, non-empty msgids from .po contents."""
 
     def test_gets_clean_ids(self):
-        inputs = (
-            (SAMPLE_PO_CONTENT, 2),
-            (SAMPLE_PO_CONTENT_WITH_MULTILINE, 3)
-        )
-        for input in inputs:
-            result = Command._extract_msgids(input[0])
+        inputs = ((SAMPLE_PO_CONTENT, 2), (SAMPLE_PO_CONTENT_WITH_MULTILINE, 3))
+        for item in inputs:
+            result = Command._extract_msgids(item[0])  # pylint: disable=W0212
 
-            self.assertEqual(len(result), input[1])
+            self.assertEqual(len(result), item[1])
 
     def test_multiline_strings_cleaned_and_joined(self):
-        result = Command._extract_msgids(SAMPLE_PO_CONTENT_MULTILINE)
+        result = Command._extract_msgids(SAMPLE_PO_CONTENT_MULTILINE)  # pylint: disable=W0212
 
         cleaned = result.pop()
 
-        self.assertEqual(cleaned, '"\n"second line"\n"third line\n\"')
+        self.assertEqual(cleaned, '"\n"second line"\n"third line\n"')
 
 
 class WritePOFileCheckModeTests(SimpleTestCase):
@@ -218,7 +216,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # new file should be in modififed dict
-        self.assertIn("Good Morning", self.command._modified_po_files[self.potfile])
+        self.assertIn("Good Morning", self.command._modified_po_files[self.potfile])  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
@@ -230,7 +228,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # assert modified files is an empty dict
-        self.assertEqual(self.command._modified_po_files, {})
+        self.assertEqual(self.command._modified_po_files, {})  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_does_not_flag_if_only_order_is_different(self, mock_popen):
@@ -338,7 +336,7 @@ class HandleCheckModeTests(SimpleTestCase):
         command = self._make_command()
 
         def simulate_changes(*args, **_):
-            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()
+            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()  # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 
@@ -353,7 +351,7 @@ class HandleCheckModeTests(SimpleTestCase):
         changed_path = "/some/locale/cy/LC_MESSAGES/django.po"
 
         def simulate_changes(*args, **_):
-            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()
+            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()  # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -21,6 +21,25 @@ msgstr ""
 
 msgid "Hello"
 msgstr "Helo"
+
+msgid "Goodbye"
+msgstr "Hwyl fawr"
+"""
+
+SAMPLE_PO_CONTENT_DIFFERENT_ORDER = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 00:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Goodbye"
+msgstr "Hwyl fawr"
+
+msgid "Hello"
+msgstr "Helo"
 """
 
 SAMPLE_PO_CONTENT_NEW_DATE = """msgid ""
@@ -34,6 +53,9 @@ msgstr ""
 
 msgid "Hello"
 msgstr "Helo"
+
+msgid "Goodbye"
+msgstr "Hwyl fawr"
 """
 
 
@@ -50,7 +72,10 @@ msgid "Hello"
 msgstr "Helo"
 
 msgid "Goodbye"
-msgid "Hwyl fawr"
+msgstr "Hwyl fawr"
+
+msgid "Good Morning"
+msgstr "Bore da"
 """
 
 

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -1,11 +1,9 @@
-from tabnanny import verbose
-import tempfile
 import os
+import tempfile
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.core.management.commands.makemessages import Command as MakeMessagesCommand
 from django.test import SimpleTestCase
@@ -55,16 +53,12 @@ msgid "Goodbye"
 msgid "Hwyl fawr"
 """
 
+
 class NormalizeTests(SimpleTestCase):
     """Tests for Command._normalize, which strips POT-Creation-Date headers."""
 
     def test_strips_pot_creation_date(self):
-        content = (
-            'msgid ""\n'
-            'msgstr ""\n'
-            '"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n'
-            '"Language: cy\\n"\n'
-        )
+        content = 'msgid ""\nmsgstr ""\n"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n"Language: cy\\n"\n'
         result = Command._normalize(content)
         self.assertNotIn("POT-Creation-Date", result)
 
@@ -85,6 +79,7 @@ class NormalizeTests(SimpleTestCase):
     def test_content_with_no_date_header_is_unchanged(self):
         content = 'msgid "Hello"\nmsgstr "Helo"\n'
         self.assertEqual(Command._normalize(content), content)
+
 
 class WritePOFileCheckModeTests(SimpleTestCase):
     """Tests for write_po_file when _check_mode is True."""
@@ -112,7 +107,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         os.makedirs(self.pofile_dir, exist_ok=True)
         Path(self.pofile).write_text(content, encoding="utf-8")
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_missing_po_file_detected_as_change(self, mock_popen):
         # .po file does not exist
         self.command.write_po_file(self.potfile, "cy")
@@ -121,7 +116,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # we don't attempt to call msgmerge if the file didn't already exist
         mock_popen.assert_not_called()
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_unchanged_content_not_flagged(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
         # returns stdout, stderr and status code
@@ -132,7 +127,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # assert modified files is an empty set
         self.assertEqual(self.command._modified_po_files, set())
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_changed_content_flagged(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
 
@@ -144,7 +139,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # new file should be in modififed set
         self.assertIn(self.pofile, self.command._modified_po_files)
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
 
@@ -156,8 +151,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # assert modified files is an empty set
         self.assertEqual(self.command._modified_po_files, set())
 
-
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_msgmerge_called_without_update_arg(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
         mock_popen.return_value = (SAMPLE_PO_CONTENT, "", 0)
@@ -169,17 +163,11 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.assertNotIn("--update", args)
         self.assertNotIn("--backup=none", args)
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_additional_options_preserved(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
         mock_popen.return_value = (SAMPLE_PO_CONTENT, "", 0)
-        self.command.msgmerge_options = [
-            "-q",
-            "--backup=none",
-            "--previous",
-            "--update",
-            "--no-wrap"
-        ]
+        self.command.msgmerge_options = ["-q", "--backup=none", "--previous", "--update", "--no-wrap"]
 
         self.command.write_po_file(self.potfile, "cy")
 
@@ -190,7 +178,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.assertNotIn("--backup=none", args)
         self.assertNotIn("--update", args)
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_existing_po_files_not_modified(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
         mock_popen.return_value = (SAMPLE_PO_CONTENT_NEW_ENTRY, "", 0)
@@ -201,7 +189,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.assertEqual(content_before, content_after)
 
-    @patch('cms.locale.management.commands.makemessages.popen_wrapper')
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_raises_command_error_if_popen_returns_non_zero_code(self, mock_popen):
         self._create_po_file(SAMPLE_PO_CONTENT)
         mock_popen.return_value = ("", "fatal error in msgmerge", 2)
@@ -211,17 +199,21 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.assertIn("msgmerge", str(ctx.exception))
 
-class WritePOFileNormalModeTests(SimpleTestCase):
-    """Tests for write_po_file when _check_mode is False"""
 
-    @patch.object(MakeMessagesCommand, 'write_po_file')
+class WritePOFileNormalModeTests(SimpleTestCase):
+    """Tests for write_po_file when _check_mode is False."""
+
+    @patch.object(MakeMessagesCommand, "write_po_file")
     def test_delegates_to_parent(self, mock_write_parent):
         command = Command()
         command._check_mode = False
 
-        command.write_po_file("/tmp/django.pot", "cy")
+        # disable qa as using mocked version of function
+        command.write_po_file("/tmp/django.pot", "cy")  # noqa: S108
 
-        mock_write_parent.assert_called_once_with("/tmp/django.pot", "cy")
+        # disable qa as using mocked version of function
+        mock_write_parent.assert_called_once_with("/tmp/django.pot", "cy")  # noqa: S108
+
 
 class HandleCheckModeTests(SimpleTestCase):
     """Tests for handle() with --check flag.
@@ -280,7 +272,7 @@ class HandleCheckModeTests(SimpleTestCase):
         self.assertIn("The following .po files are not up to date:", stderr_output)
         self.assertIn("Run `makemessages` to update them.", stderr_output)
 
-    @patch.object(MakeMessagesCommand, 'handle')
+    @patch.object(MakeMessagesCommand, "handle")
     def test_without_check_delegates_to_default_makemessages(self, mock_parent_handle):
         command = self._make_command()
         command.handle(check=False, verbosity=1)
@@ -290,7 +282,7 @@ class HandleCheckModeTests(SimpleTestCase):
         self.assertNotIn("up to date", self.stdout.getvalue())
         self.assertEqual(self.stderr.getvalue(), "")
 
-    @patch.object(MakeMessagesCommand, 'handle')
+    @patch.object(MakeMessagesCommand, "handle")
     def test_quiet_mode_suppresses_success_message(self, mock_parent_handle):
         command = self._make_command()
         command.handle(check=False, verbosity=0)

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -26,6 +26,42 @@ msgid "Goodbye"
 msgstr "Hwyl fawr"
 """
 
+SAMPLE_PO_CONTENT_WITH_MULTILINE = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 00:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Hello"
+msgstr "Helo"
+
+msgid "Goodbye"
+msgstr "Hwyl fawr"
+
+msgid ""
+"second line"
+"third line\\n\\""
+msgstr ""
+"""
+
+SAMPLE_PO_CONTENT_MULTILINE = """msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-01-01 00:00+0000\\n"
+"PO-Revision-Date: 2026-01-01 00:00+0000\\n"
+"Language: cy\\n"
+"MIME-Version: 1.0\\n
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid ""
+"second line"
+"third line\\n\\""
+msgstr ""
+"""
+
 SAMPLE_PO_CONTENT_DIFFERENT_ORDER = """msgid ""
 msgstr ""
 "POT-Creation-Date: 2026-01-01 00:00+0000\\n"
@@ -105,6 +141,26 @@ class NormalizeTests(SimpleTestCase):
         content = 'msgid "Hello"\nmsgstr "Helo"\n'
         self.assertEqual(Command._normalize(content), content)  # pylint: disable=W0212
 
+class ExtractMsgidTests(SimpleTestCase):
+    """Tests for Command._extract_msgids, which pulls only clean, non-empty msgids from .po contents."""
+
+    def test_gets_clean_ids(self):
+        inputs = (
+            (SAMPLE_PO_CONTENT, 2),
+            (SAMPLE_PO_CONTENT_WITH_MULTILINE, 3)
+        )
+        for input in inputs:
+            result = Command._extract_msgids(input[0])
+
+            self.assertEqual(len(result), input[1])
+
+    def test_multiline_strings_cleaned_and_joined(self):
+        result = Command._extract_msgids(SAMPLE_PO_CONTENT_MULTILINE)
+
+        cleaned = result.pop()
+
+        self.assertEqual(cleaned, '"\n"second line"\n"third line\n\"')
+
 
 class WritePOFileCheckModeTests(SimpleTestCase):
     """Tests for write_po_file when _check_mode is True."""
@@ -120,7 +176,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command = Command()
         # enable _check_mode
         self.command._check_mode = True  # pylint: disable=W0212
-        self.command._modified_po_files = set()  # pylint: disable=W0212
+        self.command._modified_po_files = {}  # pylint: disable=W0212
         self.command.domain = "django"
         self.command.msgmerge_options = ["-q", "--backup=none", "--previous", "--update"]
         self.command.verbosity = 0
@@ -149,8 +205,8 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.command.write_po_file(self.potfile, "cy")
 
-        # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set())  # pylint: disable=W0212
+        # assert modified files is an empty dict
+        self.assertEqual(self.command._modified_po_files, {})  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_changed_content_flagged(self, mock_popen):
@@ -161,8 +217,8 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.command.write_po_file(self.potfile, "cy")
 
-        # new file should be in modififed set
-        self.assertIn(self.pofile, self.command._modified_po_files)  # pylint: disable=W0212
+        # new file should be in modififed dict
+        self.assertIn("Good Morning", self.command._modified_po_files[self.potfile])
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
@@ -173,8 +229,20 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.command.write_po_file(self.potfile, "cy")
 
-        # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set())  # pylint: disable=W0212
+        # assert modified files is an empty dict
+        self.assertEqual(self.command._modified_po_files, {})
+
+    @patch("cms.locale.management.commands.makemessages.popen_wrapper")
+    def test_does_not_flag_if_only_order_is_different(self, mock_popen):
+        self._create_po_file(SAMPLE_PO_CONTENT)
+
+        # only date is different from initial content
+        mock_popen.return_value = (SAMPLE_PO_CONTENT_DIFFERENT_ORDER, "", 0)
+
+        self.command.write_po_file(self.potfile, "cy")
+
+        # assert modified files is an empty dict
+        self.assertEqual(self.command._modified_po_files, {})  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_msgmerge_called_without_update_arg(self, mock_popen):
@@ -270,7 +338,7 @@ class HandleCheckModeTests(SimpleTestCase):
         command = self._make_command()
 
         def simulate_changes(*args, **_):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")  # pylint: disable=W0212
+            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()
 
         mock_parent_handle.side_effect = simulate_changes
 
@@ -285,7 +353,7 @@ class HandleCheckModeTests(SimpleTestCase):
         changed_path = "/some/locale/cy/LC_MESSAGES/django.po"
 
         def simulate_changes(*args, **_):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")  # pylint: disable=W0212
+            command._modified_po_files["/some/locale/cy/LC_MESSAGES/django.po"] = set()
 
         mock_parent_handle.side_effect = simulate_changes
 

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -167,6 +167,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         args = mock_popen.call_args[0][0]
         self.assertEqual(args[0], "msgmerge")
         self.assertNotIn("--update", args)
+        self.assertNotIn("--backup=none", args)
 
     @patch('cms.locale.management.commands.makemessages.popen_wrapper')
     def test_additional_options_preserved(self, mock_popen):
@@ -184,9 +185,9 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         args = mock_popen.call_args[0][0]
         self.assertIn("-q", args)
-        self.assertIn("--backup=none", args)
         self.assertIn("--previous", args)
         self.assertIn("--no-wrap", args)
+        self.assertNotIn("--backup=none", args)
         self.assertNotIn("--update", args)
 
     @patch('cms.locale.management.commands.makemessages.popen_wrapper')

--- a/cms/locale/tests/test_makemessages.py
+++ b/cms/locale/tests/test_makemessages.py
@@ -59,7 +59,7 @@ class NormalizeTests(SimpleTestCase):
 
     def test_strips_pot_creation_date(self):
         content = 'msgid ""\nmsgstr ""\n"POT-Creation-Date: 2026-04-07 12:00+0000\\n"\n"Language: cy\\n"\n'
-        result = Command._normalize(content) #pylint: disable=W0212
+        result = Command._normalize(content)  # pylint: disable=W0212
         self.assertNotIn("POT-Creation-Date", result)
 
     def test_preserves_other_metadata(self):
@@ -71,15 +71,14 @@ class NormalizeTests(SimpleTestCase):
             '"Last-Translator: someone\\n"\n'
             '"Language: cy\\n"\n'
         )
-        result = Command._normalize(content) #pylint: disable=W0212
+        result = Command._normalize(content)  # pylint: disable=W0212
         self.assertIn("PO-Revision-Date", result)
         self.assertIn("Last-Translator", result)
         self.assertIn("Language", result)
 
     def test_content_with_no_date_header_is_unchanged(self):
         content = 'msgid "Hello"\nmsgstr "Helo"\n'
-        self.assertEqual(Command._normalize(content), content) # pylint: disable=W0212
-
+        self.assertEqual(Command._normalize(content), content)  # pylint: disable=W0212
 
 
 class WritePOFileCheckModeTests(SimpleTestCase):
@@ -95,8 +94,8 @@ class WritePOFileCheckModeTests(SimpleTestCase):
 
         self.command = Command()
         # enable _check_mode
-        self.command._check_mode = True #pylint: disable=W0212
-        self.command._modified_po_files = set() #pylint: disable=W0212
+        self.command._check_mode = True  # pylint: disable=W0212
+        self.command._modified_po_files = set()  # pylint: disable=W0212
         self.command.domain = "django"
         self.command.msgmerge_options = ["-q", "--backup=none", "--previous", "--update"]
         self.command.verbosity = 0
@@ -113,7 +112,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         # .po file does not exist
         self.command.write_po_file(self.potfile, "cy")
 
-        self.assertIn(self.pofile, self.command._modified_po_files) # pylint: disable=W0212
+        self.assertIn(self.pofile, self.command._modified_po_files)  # pylint: disable=W0212
         # we don't attempt to call msgmerge if the file didn't already exist
         mock_popen.assert_not_called()
 
@@ -126,7 +125,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set()) #pylint: disable=W0212
+        self.assertEqual(self.command._modified_po_files, set())  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_changed_content_flagged(self, mock_popen):
@@ -138,7 +137,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # new file should be in modififed set
-        self.assertIn(self.pofile, self.command._modified_po_files) #pylint: disable=W0212
+        self.assertIn(self.pofile, self.command._modified_po_files)  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_if_only_diff_is_creation_date_not_flagged(self, mock_popen):
@@ -150,7 +149,7 @@ class WritePOFileCheckModeTests(SimpleTestCase):
         self.command.write_po_file(self.potfile, "cy")
 
         # assert modified files is an empty set
-        self.assertEqual(self.command._modified_po_files, set()) #pylint: disable=W0212
+        self.assertEqual(self.command._modified_po_files, set())  # pylint: disable=W0212
 
     @patch("cms.locale.management.commands.makemessages.popen_wrapper")
     def test_msgmerge_called_without_update_arg(self, mock_popen):
@@ -207,7 +206,7 @@ class WritePOFileNormalModeTests(SimpleTestCase):
     @patch.object(MakeMessagesCommand, "write_po_file")
     def test_delegates_to_parent(self, mock_write_parent):
         command = Command()
-        command._check_mode = False # pylint: disable=W0212
+        command._check_mode = False  # pylint: disable=W0212
 
         # disable qa as using mocked version of function
         command.write_po_file("/tmp/django.pot", "cy")  # noqa: S108
@@ -246,7 +245,7 @@ class HandleCheckModeTests(SimpleTestCase):
         command = self._make_command()
 
         def simulate_changes(*args, **_):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po") # pylint: disable=W0212
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")  # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 
@@ -261,7 +260,7 @@ class HandleCheckModeTests(SimpleTestCase):
         changed_path = "/some/locale/cy/LC_MESSAGES/django.po"
 
         def simulate_changes(*args, **_):
-            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po") # pylint: disable=W0212
+            command._modified_po_files.add("/some/locale/cy/LC_MESSAGES/django.po")  # pylint: disable=W0212
 
         mock_parent_handle.side_effect = simulate_changes
 


### PR DESCRIPTION
### What is the context of this PR?

Relates to CMS-789.

Add a `--check` flag to `makemessages` management command to warn if there would be any updates to .po files. Intended to be used in pre-commit and CI to ensure translations aren't missed.

### How to review

1. Try running `make make messages-check` without any code changes.
2. Try running after changing a string in a call to `gettext` and sense check returns correct value.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [ x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

Will need to be added to CI and as a pre commit hook.
