### PR TITLE
Update Welsh Translations - CMS-1123

### DIFF
--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -226,7 +226,7 @@ class ONSTableBlock(TinyTableBlock):
 
         return {
             "title": _("Download this table"),
-            "itemsList": [{"text": f"{_('Download CSV')}{size_suffix}", "url": csv_url}],
+            "itemsList": [{"text": _("Download CSV %(size)s") % {"size": size_suffix}, "url": csv_url}],
         }
 
     @staticmethod

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-27 11:32+0000\n"
+"POT-Creation-Date: 2026-04-08 16:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,11 +75,12 @@ msgstr "Cuddio popeth"
 
 #: cms/core/blocks/markup.py:228
 msgid "Download this table"
-msgstr ""
+msgstr "Lawrlwythwch y tabl hwn"
 
 #: cms/core/blocks/markup.py:229
-msgid "Download CSV"
-msgstr ""
+#, python-format
+msgid "Download CSV %(size)s"
+msgstr "Lawrlwythwch CSV"
 
 #: cms/core/blocks/related.py:60
 msgid "Related links"
@@ -104,15 +105,15 @@ msgstr "Pwnc"
 
 #: cms/core/enums.py:13
 msgid "Information"
-msgstr ""
+msgstr "Gwybodaeth"
 
 #: cms/core/enums.py:14
 msgid "Report"
-msgstr ""
+msgstr "Adrodd"
 
 #: cms/core/enums.py:15
 msgid "Webpage"
-msgstr ""
+msgstr "Tudalen we"
 
 #: cms/core/formatting_utils.py:56
 msgid "Page"
@@ -152,8 +153,6 @@ msgid "Menu links navigation"
 msgstr ""
 
 #: cms/jinja2/templates/base.html:37
-#, fuzzy
-#| msgid "Related links"
 msgid "Menu links"
 msgstr "Dolenni cysylltiedig"
 
@@ -162,8 +161,6 @@ msgid "Menu"
 msgstr "Dewislen"
 
 #: cms/jinja2/templates/base.html:39
-#, fuzzy
-#| msgid "Toggle main menu"
 msgid "Toggle menu"
 msgstr "Togl y brif ddewislen"
 
@@ -243,16 +240,16 @@ msgstr "Ffynhonnell"
 
 #: cms/jinja2/templates/components/streamfield/image_block.html:37
 msgid "Notes"
-msgstr ""
+msgstr "Nodiadau"
 
 #: cms/jinja2/templates/components/streamfield/image_block.html:43
 #: cms/jinja2/templates/components/streamfield/image_block.html:45
 msgid "Download image"
-msgstr ""
+msgstr "Lawrlwythwch y ddelwedd"
 
 #: cms/jinja2/templates/components/streamfield/image_block.html:51
 msgid "Download this image"
-msgstr ""
+msgstr "Lawrlwythwch y ddelwedd hon"
 
 #: cms/jinja2/templates/components/streamfield/release_date_change_block.html:2
 msgid "Previous date"
@@ -268,29 +265,35 @@ msgstr "Cwcis ar"
 
 #: cms/jinja2/templates/pages/cookies.html:20
 msgid "Your cookie settings have been saved"
-msgstr ""
+msgstr "Mae eich gosodiadau cwcis wedi’u cadw"
 
 #: cms/jinja2/templates/pages/cookies.html:22
 msgid ""
 "Some parts of this website may use additional cookies and will have their "
 "own cookie policy and banner."
 msgstr ""
+"Efallai y bydd rhai rhannau o’r wefan hon yn defnyddio cwcis ychwanegol ac "
+"yn cynnwyseu polisi cwcis a’u baner eu hunain."
 
 #: cms/jinja2/templates/pages/cookies.html:24
 msgid "Return to previous page"
-msgstr ""
+msgstr "Dychwelyd i’r dudalen flaenorol"
 
 #: cms/jinja2/templates/pages/cookies.html:28
 msgid ""
 "Cookies are files saved on your phone, tablet or computer when you visit a "
 "website."
 msgstr ""
+"Mae cwcis yn ffeiliau sy’n cael eu cadw are eich ffôn, llechen neu "
+"gyfrifiadur pan fyddwch yn ymweld â gwefan"
 
 #: cms/jinja2/templates/pages/cookies.html:29
 msgid ""
 "We use cookies to store information about how you use the ONS website, such "
 "as the pages you visit."
 msgstr ""
+"Rydym yn defnyddio cwcis i storio gwybodaeth am sut rydych yn defnyddio "
+"gwefan y SYG, megis y tudalennau yr ydych yn ymweld â nhw"
 
 #: cms/jinja2/templates/pages/cookies.html:31
 msgid "Cookie settings"
@@ -298,110 +301,118 @@ msgstr "Gosodiadau cwcis"
 
 #: cms/jinja2/templates/pages/cookies.html:38
 msgid "You can try:"
-msgstr ""
+msgstr "Gallwch geisio"
 
 #: cms/jinja2/templates/pages/cookies.html:40
 msgid "turning on JavaScript in your browser"
-msgstr ""
+msgstr "galluogi JavaScript yn eich porwr"
 
 #: cms/jinja2/templates/pages/cookies.html:41
 msgid "reloading the page in case there was a temporary fault with JavaScript"
 msgstr ""
+"ail-lwytho’r dudalen rhag ofn bod gwall dros dro wedi digwydd gyda JavaScript"
 
 #: cms/jinja2/templates/pages/cookies.html:52
 msgid "Cookies that measure website use"
-msgstr ""
+msgstr "Cwcis sy’n mesur defnydd o’r wefan"
 
 #: cms/jinja2/templates/pages/cookies.html:58
 msgid "how you got to the site"
-msgstr ""
+msgstr "sut y daethoch chi i’r wefan"
 
 #: cms/jinja2/templates/pages/cookies.html:60
 msgid "the pages you visit on ons.gov.uk and how long you spend on each page"
 msgstr ""
+"y tudalennau yr ydych yn ymweld â nhw ar ons.gov.uk a pha mor hir rydych yn "
+"treulio ar bob tudalen"
 
 #: cms/jinja2/templates/pages/cookies.html:61
 msgid "what you click on while you are visiting the site"
-msgstr ""
+msgstr "yr hyn rydych yn clicio arno tra byddwch yn ymweld â’r wefan"
 
 #: cms/jinja2/templates/pages/cookies.html:62
 msgid "the way in which you interact with a page"
-msgstr ""
+msgstr "y ffordd rydych yn rhyngweithio â thudalen"
 
 #: cms/jinja2/templates/pages/cookies.html:63
 msgid "whether you have participated in a Hotjar survey"
-msgstr ""
+msgstr "p’un a ydych wedi cymryd rhan mewn arolwg Hotjar"
 
 #: cms/jinja2/templates/pages/cookies.html:66
 msgid "Do you want to allow usage tracking?"
-msgstr ""
+msgstr "Ydych chi am ganiatáu tracio defnydd?"
 
 #: cms/jinja2/templates/pages/cookies.html:67
 msgid "On"
-msgstr ""
+msgstr "Ymlaen"
 
 #: cms/jinja2/templates/pages/cookies.html:68
 msgid "Off"
-msgstr ""
+msgstr "I ffwrdd"
 
 #: cms/jinja2/templates/pages/cookies.html:94
 #: cms/jinja2/templates/pages/cookies.html:130
 #: cms/jinja2/templates/pages/cookies.html:169
 msgid "Your preference selection will expire after one year."
-msgstr ""
+msgstr "Bydd eich dewisiadau’n dod i ben ar ôl blwyddyn"
 
 #: cms/jinja2/templates/pages/cookies.html:96
 msgid "Cookies that help with our communications"
-msgstr ""
+msgstr "Cwcis sy’n helpu gyda’n cyfathrebu"
 
 #: cms/jinja2/templates/pages/cookies.html:103
 msgid "Do you want to allow third party usage tracking?"
-msgstr ""
+msgstr "Ydych chi am ganiatáu tracio defnydd gan drydydd parti?"
 
 #: cms/jinja2/templates/pages/cookies.html:136
 msgid ""
 "Cookies that remember your preference settings to tailor your experience"
-msgstr ""
+msgstr "Cwcis sy’n cofio’ch dewisiadau i deilwra’ch profiad"
 
 #: cms/jinja2/templates/pages/cookies.html:143
 msgid ""
 "Do you want to allow cookies for potential future use that tailor your "
 "experience?"
 msgstr ""
+"Ydych chi am ganiatáu cwcis ar gyfer defnydd posibl yn y dyfodol sy’n "
+"teilwra’ch profiad?"
 
 #: cms/jinja2/templates/pages/cookies.html:171
 msgid "Strictly necessary cookies"
-msgstr ""
+msgstr "Cwcis hollol angenrheidiol"
 
 #: cms/jinja2/templates/pages/cookies.html:172
 msgid "These essential cookies do things like:"
-msgstr ""
+msgstr "Mae’r cwcis hollol angenrheidiol hyn yn gwneud pethau fel:"
 
 #: cms/jinja2/templates/pages/cookies.html:174
 msgid ""
 "remember the notifications you’ve seen so we do not show them to you again"
 msgstr ""
+"cofio’r hysbysiadau rydych wedi’u gweld fel na fyddwn yn eu dangos i chi eto"
 
 #: cms/jinja2/templates/pages/cookies.html:175
 msgid "remember your progress through a form (for example, an ONS study)"
-msgstr ""
+msgstr "cofio’ch cynnydd trwy ffurflen (er enghraifft, astudiaeth SYG)"
 
 #: cms/jinja2/templates/pages/cookies.html:176
 msgid "improve performance and identify potential security threats"
-msgstr ""
+msgstr "gwella perfformiad ac adnabod bygythiadau diogelwch posibl"
 
 #: cms/jinja2/templates/pages/cookies.html:178
 msgid ""
 "They are necessary for proper website functionality and always need to be on."
 msgstr ""
+"Maent yn hanfodol i’r wefan i weithredu’n iawn ac mae’n rhaid iddynt fod "
+"ymlaen drwy’r amser."
 
 #: cms/jinja2/templates/pages/cookies.html:182
 msgid "Find out more about cookies on"
-msgstr ""
+msgstr "Dysgu ragor am gwcis ar"
 
 #: cms/jinja2/templates/pages/cookies.html:186
 msgid "Save changes"
-msgstr ""
+msgstr "Cadw newidiadau"
 
 #: cms/jinja2/templates/pages/defender/lockout.html:6
 #: cms/jinja2/templates/pages/defender/lockout.html:8
@@ -535,7 +546,7 @@ msgstr "Nid yw’r datganiad hwn wedi’i gyhoeddi eto"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page--provisional.html:6
 msgid "Provisional release date:"
-msgstr ""
+msgstr "Dyddiad rhyddhau dros dro:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:13
 msgid "Next release date:"
@@ -561,9 +572,9 @@ msgid ""
 msgstr ""
 "Mae’r rhain yn ystadegau swyddogol achrededig. Adolygwyd yn annibynnolgan y "
 "Swyddfa Rheoleiddio Ystadegau (OSR) ac a ganfuwyd ei fod yn cydymffurfio "
-"gyda safonau dibynadwyedd, ansawdd a gwerth yn y <a href='https://"
-"code.statisticsauthority.gov.uk/the-code/'>Cod Ymarfer ar gyfer Ystadegau</"
-"a>. Mae hyn yn golygu yn fras bod yr ystadegau:"
+"gyda safonau dibynadwyedd, ansawdd a gwerth yn y <a href='https://code."
+"statisticsauthority.gov.uk/the-code/'>Cod Ymarfer ar gyfer Ystadegau</a>. "
+"Mae hyn yn golygu yn fras bod yr ystadegau:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:138
 msgid "meet user needs"
@@ -699,7 +710,7 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/theme_index_page.html:8
 msgid "Browse"
-msgstr ""
+msgstr "Pori"
 
 #: cms/jinja2/templates/pages/theme_page.html:7
 msgid "Theme"
@@ -715,7 +726,7 @@ msgstr "Erthyglau cysylltiedig"
 
 #: cms/jinja2/templates/pages/topic_page.html:87
 msgid "View all related articles"
-msgstr ""
+msgstr "Gweld yr holl erthyglau cysylltiedig"
 
 #: cms/jinja2/templates/pages/topic_page.html:95 cms/topics/models.py:245
 msgid "Methods and quality information"
@@ -723,19 +734,19 @@ msgstr "Dulliau a gwybodaeth o ansawdd"
 
 #: cms/jinja2/templates/pages/topic_page.html:105
 msgid "View all related methodology"
-msgstr ""
+msgstr "Gweld yr holl fethodolegau cysylltiedig "
 
 #: cms/jinja2/templates/pages/topic_page.html:123
 msgid "View all related data"
-msgstr ""
+msgstr "Gweld yr holl ddata cysylltiedig"
 
 #: cms/jinja2/templates/pages/topic_page.html:131
 msgid "Time Series"
-msgstr ""
+msgstr "Cyfres amser"
 
 #: cms/jinja2/templates/pages/topic_page.html:141
 msgid "View all related time series"
-msgstr ""
+msgstr "Gweld yr holl gyfresi amser cysylltiedig"
 
 #: cms/jinja2/templates/pages/topic_page.html:149 cms/topics/models.py:247
 #: cms/topics/tests/test_models.py:556 cms/topics/tests/test_models.py:560
@@ -764,17 +775,4 @@ msgstr "Cymraeg"
 
 #: cms/workflows/templates/wagtailadmin/workflows/workflow_status.html:13
 msgid "Not started"
-msgstr ""
-
-#~ msgid "Main menu"
-#~ msgstr "Prif ddewislen"
-
-#, fuzzy
-#~| msgid "Changes to this release date"
-#~ msgid "Changes requested"
-#~ msgstr "Newidiadau i’r dyddiad rhyddhau hwn"
-
-#, fuzzy
-#~| msgid "Published:"
-#~ msgid "Published"
-#~ msgstr "Cyhoeddwyd"
+msgstr "Heb ei ddechrau"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -2,8 +2,7 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -162,7 +161,7 @@ msgstr "Dewislen"
 
 #: cms/jinja2/templates/base.html:39
 msgid "Toggle menu"
-msgstr "Togl y brif ddewislen"
+msgstr ""
 
 #: cms/jinja2/templates/base.html:40
 msgid "Breadcrumbs"
@@ -285,7 +284,7 @@ msgid ""
 "website."
 msgstr ""
 "Mae cwcis yn ffeiliau sy’n cael eu cadw are eich ffôn, llechen neu "
-"gyfrifiadur pan fyddwch yn ymweld â gwefan"
+"gyfrifiadur pan fyddwch yn ymweld â gwefan."
 
 #: cms/jinja2/templates/pages/cookies.html:29
 msgid ""
@@ -293,7 +292,7 @@ msgid ""
 "as the pages you visit."
 msgstr ""
 "Rydym yn defnyddio cwcis i storio gwybodaeth am sut rydych yn defnyddio "
-"gwefan y SYG, megis y tudalennau yr ydych yn ymweld â nhw"
+"gwefan y SYG, megis y tudalennau yr ydych yn ymweld â nhw."
 
 #: cms/jinja2/templates/pages/cookies.html:31
 msgid "Cookie settings"
@@ -301,7 +300,7 @@ msgstr "Gosodiadau cwcis"
 
 #: cms/jinja2/templates/pages/cookies.html:38
 msgid "You can try:"
-msgstr "Gallwch geisio"
+msgstr "Gallwch geisio:"
 
 #: cms/jinja2/templates/pages/cookies.html:40
 msgid "turning on JavaScript in your browser"
@@ -354,7 +353,7 @@ msgstr "I ffwrdd"
 #: cms/jinja2/templates/pages/cookies.html:130
 #: cms/jinja2/templates/pages/cookies.html:169
 msgid "Your preference selection will expire after one year."
-msgstr "Bydd eich dewisiadau’n dod i ben ar ôl blwyddyn"
+msgstr "Bydd eich dewisiadau’n dod i ben ar ôl blwyddyn."
 
 #: cms/jinja2/templates/pages/cookies.html:96
 msgid "Cookies that help with our communications"
@@ -455,7 +454,7 @@ msgid ""
 "href=\"%(backup_url)s\">backup site</a>."
 msgstr ""
 "Gellir dod o hyd i’n cyhoeddiadau wedi’u trefnu hefyd ar ein <a "
-"href=\"%(backup_url)s\">gwefan wrth gefn"
+"href=\"%(backup_url)s\">gwefan wrth gefn</a>."
 
 #: cms/jinja2/templates/pages/information_page.html:15
 msgid "Last updated:"
@@ -482,17 +481,17 @@ msgstr "Mewngofnodwch"
 
 #: cms/jinja2/templates/pages/methodology_page.html:9
 msgid "Last revised:"
-msgstr "Diwygiwyd ddiwethaf"
+msgstr "Diwygiwyd ddiwethaf:"
 
 #: cms/jinja2/templates/pages/methodology_page.html:10
 msgid "Published:"
-msgstr "Cyhoeddwyd"
+msgstr "Cyhoeddwyd:"
 
 #: cms/jinja2/templates/pages/methodology_page.html:11
 #: cms/jinja2/templates/pages/statistical_article_page.html:11
 #: cms/jinja2/templates/pages/statistical_article_page.html:15
 msgid "Contact:"
-msgstr "Cyswllt"
+msgstr "Cyswllt:"
 
 #: cms/jinja2/templates/pages/methodology_page.html:12
 #: cms/jinja2/templates/pages/statistical_article_page.html:16
@@ -526,7 +525,7 @@ msgstr "Rhyddhau"
 #: cms/jinja2/templates/pages/statistical_article_page.html:13
 #: cms/jinja2/templates/pages/statistical_article_page.html:20
 msgid "Release date:"
-msgstr "Dyddiad rhyddhau"
+msgstr "Dyddiad rhyddhau:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html:8
 msgid "Cancelled"
@@ -550,7 +549,7 @@ msgstr "Dyddiad rhyddhau dros dro:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:13
 msgid "Next release date:"
-msgstr "Rhyddhad nesaf"
+msgstr "Rhyddhad nesaf:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:85
 #: cms/release_calendar/models.py:228
@@ -636,7 +635,7 @@ msgstr "Erthygl ystadegol"
 #: cms/jinja2/templates/pages/statistical_article_page.html:14
 #: cms/jinja2/templates/pages/statistical_article_page.html:21
 msgid "Next release:"
-msgstr "Cyhoeddiad nesaf"
+msgstr "Cyhoeddiad nesaf:"
 
 #: cms/jinja2/templates/pages/statistical_article_page.html:25
 msgid "This version has been amended since publication"
@@ -734,7 +733,7 @@ msgstr "Dulliau a gwybodaeth o ansawdd"
 
 #: cms/jinja2/templates/pages/topic_page.html:105
 msgid "View all related methodology"
-msgstr "Gweld yr holl fethodolegau cysylltiedig "
+msgstr "Gweld yr holl fethodolegau cysylltiedig"
 
 #: cms/jinja2/templates/pages/topic_page.html:123
 msgid "View all related data"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -80,7 +80,7 @@ msgstr "Lawrlwythwch y tabl hwn"
 #: cms/core/blocks/markup.py:229
 #, python-format
 msgid "Download CSV %(size)s"
-msgstr "Lawrlwythwch CSV"
+msgstr "Lawrlwythwch CSV %(size)s"
 
 #: cms/core/blocks/related.py:60
 msgid "Related links"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -153,7 +153,7 @@ msgstr ""
 
 #: cms/jinja2/templates/base.html:37
 msgid "Menu links"
-msgstr "Dolenni cysylltiedig"
+msgstr ""
 
 #: cms/jinja2/templates/base.html:38
 msgid "Menu"


### PR DESCRIPTION
### What is the context of this PR?

This PR updates the `.po` file with the latest Welsh translations provided by the business.

I also made a tiny update to the markup.py in how we mark computed values for translations:

- Without this change, Download CSV... is being removed from the `.po` file when we run the `make makemessages` command.

See the PR description on https://github.com/ONSdigital/dis-wagtail/pull/553 for more in-depth details. The #553 did not make it into `main` as it's currently merged into #526.

JIRA Card: https://officefornationalstatistics.atlassian.net/browse/CMS-1123

### How to review

- Pull down the branch locally
- Run `make compilemessages`
- Ensure the new translations are working on the pages as expected

Currently, there is a slight discrepancy between the `translated_django.po` file provided.  According to our template labels for menus that we have now:

```
#: cms/jinja2/templates/base.html:36
msgid "Menu links navigation"
msgstr ""

#: cms/jinja2/templates/base.html:37
msgid "Menu links"
msgstr "Dolenni cysylltiedig"

#: cms/jinja2/templates/base.html:38
msgid "Menu"
msgstr "Dewislen"

#: cms/jinja2/templates/base.html:39
msgid "Toggle menu"
msgstr "Togl y brif ddewislen"
```

vs

In the `translated_django.po` file attached to the JIRA card, we have:

```
: cms/jinja2/templates/base.html:36
msgid "Menu"
msgstr "Dewislen"

#: cms/jinja2/templates/base.html:37
msgid "Main menu"
msgstr "Prif ddewislen"

#: cms/jinja2/templates/base.html:38
msgid "Toggle main menu"
msgstr "Togl y brif ddewislen"
```

This discrepancy could be when the file was sent to the business for translation. By the time it took to come back to us, our menu labels in the header in `base.html` ended up changing, as there were some changes that took place https://github.com/ONSdigital/dis-wagtail/pull/560/changes, which is in alignment with https://github.com/ONSdigital/dis-wagtail/pull/553/changes.

We are missing Welsh translations for `Menu links navigation` and `Toggle menu`, the translation doesn't seem right. Also, double-check the translation for `Menu links`.
- I will confirm with the DM tomorrow/ devs.


### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
