### PR TITLE
Ensure consistent wagtail admin home path in tests

### DIFF
--- a/cms/auth/tests/helpers.py
+++ b/cms/auth/tests/helpers.py
@@ -145,13 +145,13 @@ class CognitoTokenTestCase(TestCase):
         self.set_jwt_cookies(access, id_token)
 
     def assertLoggedOut(self, redirect="/admin/login/") -> None:  # pylint: disable=invalid-name
-        response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH.lstrip('/')}")
         self.assertEqual(response.status_code, 302)
         self.assertIn(redirect, response["Location"])
         self.assertFalse(response.wsgi_request.user.is_authenticated)
 
     def assertLoggedIn(self) -> None:  # pylint: disable=invalid-name
-        response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH.lstrip('/')}")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.wsgi_request.user.is_authenticated)
         # User should now exist after login

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -73,7 +73,7 @@ if not settings.IS_EXTERNAL_ENV:
         ]
 
     wagtail_admin_patterns += wagtailadmin_urls.urlpatterns
-    private_urlpatterns.append(path(settings.WAGTAILADMIN_HOME_PATH, include(wagtail_admin_patterns)))
+    private_urlpatterns.append(path(settings.WAGTAILADMIN_HOME_PATH.lstrip("/"), include(wagtail_admin_patterns)))
 
 if apps.is_installed("django.contrib.admin") and settings.WAGTAIL_CORE_ADMIN_LOGIN_ENABLED:
     from django.contrib import admin  # pylint: disable=ungrouped-imports


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses flaky tests around `AuthIntegrationTests`.

[Example of failed run](https://github.com/ONSdigital/dis-wagtail/actions/runs/24183466270/job/70582379157)

Under certain circumstances, requests made to `WAGTAILADMIN_HOME_PATH` would fail and return a 404. This was likely due to a discrepancy between the url patterns registered in `urls.py` and the settings value of `WAGTAILADMIN_HOME_PATH`, which would be affected by test cross-contamination.

### Passed tests

* [Attempt 1](https://github.com/ONSdigital/dis-wagtail/actions/runs/24244906019/job/70788817100?pr=576) - seed `1451822021` ✅

### How to review

Ensure that tests pass.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Fully validate assumption and consider removing `WAGTAILADMIN_HOME_PATH` overrides all together.
