### PR TITLE
Chore: Update Makefile install-dev Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ install:  ## Install the dependencies excluding dev.
 install-dev:  ## Install the dependencies including dev.
 	npm ci
 	poetry install --no-root
+	pip install pre-commit
+	pre-commit install
 
 .PHONY: megalint
 .PHONY: megalint

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,7 @@ install:  ## Install the dependencies excluding dev.
 install-dev:  ## Install the dependencies including dev.
 	npm ci
 	poetry install --no-root
-	pip install pre-commit
-	pre-commit install
+	pip install pre-commit && pre-commit install
 
 .PHONY: megalint
 .PHONY: megalint


### PR DESCRIPTION
### What is the context of this PR?

This PR updates the `makefile` `install-dev` target to include the commands to install `pre-commit` and install the `hooks` within the project. This is to reduce the chance of a new onboarding dev missing out on installing the `pre-commit` package and setup.
- There have been many incidents in the ONS where `pre-commit` could have prevented the exposure of a secret, API key, etc.
- Even though we have other tooling and measures in place for when there is a security incident, this PR change will reduce the chance of anything catastrophic happening even more.

Credit: @BJacksonONS for reviewing the starter guide and proposing this improvement. The confluence page, which contains the starter guide, has also been updated to reflect this change.


### How to review

- Review the `makefile` changes
- Make sure everything is working locally as expected, when using the updated makefile command

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
