### PR TITLE
Use design system social block in header

### DIFF
--- a/cms/core/tests/test_pages.py
+++ b/cms/core/tests/test_pages.py
@@ -239,14 +239,15 @@ class SocialMetaTests(WagtailPageTestCase):
     def setUpTestData(cls):
         cls.page = InformationPageFactory()
 
-    def test_social_meta_image_fallback(self):
-        """Test that the image meta tag falls back to the ONS logo from the CDN."""
+    def test_social_meta_image_url(self):
+        """Test that the image meta tag uses ONS logo from the design system CDN."""
         response = self.client.get(self.page.get_url(request=self.dummy_request))
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertContains(
             response,
-            f'<meta property="og:image" content="{settings.DEFAULT_OG_IMAGE_URL}" />',
+            '<meta property="og:image"'
+            'content="https://cdn.ons.gov.uk/sdc/design-system/73.4.1/favicons/opengraph.png" />',
         )
 
 

--- a/cms/jinja2/templates/base.html
+++ b/cms/jinja2/templates/base.html
@@ -23,6 +23,10 @@
 {%- endset -%}
 {%- set page_title = page_title | default(page_title_default) -%}
 
+{%- set social_settings = settings.core.SocialMediaSettings -%}
+{%- set description = page.social_text | default(social_settings.default_sharing_text, True) -%}
+{%- set site_name = social_settings.site_name -%}
+
 {% set navigation_settings = settings.navigation.NavigationSettings %}
 {% set main_menu = main_menu | default(navigation_settings.main_menu.localized) %}
 
@@ -44,10 +48,14 @@
 {%- set ogl_url = 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' -%}
 {%- set ogl_post = _(', except where otherwise stated') -%}
 
+{%- set social_image = page.social_image | default(social_settings.default_sharing_image, True) -%}
+
 {% set pageConfig = {
     "bodyClasses": body_class,
     "title": page_title,
+    "description": description,
     "header": {
+        "title": site_name,
         "variants": "basic",
         "phase": {
             "badge": badge_label,
@@ -88,6 +96,10 @@
     "meta": {
         "hrefLangs": hreflangs,
         "canonicalUrl": canonical_url,
+    },
+    "social": {
+        "xImage": image(social_image, "width-1000").url if social_image else False,
+        "xSite:": "@"
     }
 }
 %}

--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -18,39 +18,6 @@
     {% endif %}
 {% endblock meta %}
 
-{% block social %}
-    {% with current_site=wagtail_site() %}
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:site" content="@{{ settings.core.SocialMediaSettings.twitter_handle }}" />
-        <meta name="twitter:title" content="{{ page.seo_title or page.title }}" />
-        <meta name="twitter:description" content="{{ page.social_text|default or settings.core.SocialMediaSettings.default_sharing_text }}">
-        {% with social_image=page.social_image|default or settings.core.SocialMediaSettings.default_sharing_image %}
-            {% if social_image  %}
-                {% with twitter_img=image(social_image, "width-1000") %}
-                    <meta name="twitter:image" content="{{ twitter_img.url }}">
-                    {% if twitter_img.alt %}
-                        <meta name="twitter:image:alt" content="{{ twitter_img.alt }}">
-                    {% endif %}
-                {% endwith %}
-                {% with og_img=image(social_image, "fill-1200x630-c100") %}
-                    <meta property="og:image" content="{{ og_img.url }}" />
-                    <meta property="og:image:width" content="{{ og_img.width }}" />
-                    <meta property="og:image:height" content="{{ og_img.height }}" />
-                {% endwith %}
-            {% else %}
-                <meta property="og:image" content="{{ DEFAULT_OG_IMAGE_URL }}" />
-            {% endif %}
-        {% endwith %}
-        <meta property="og:type" content="website" />
-        {% if page %}
-            <meta property="og:url" content="{{ page.get_full_url(request) }}" />
-            <meta property="og:title" content="{{ page.seo_title or page.title }}" />
-        {% endif %}
-        <meta property="og:description" content="{{ page.social_text|default or settings.core.SocialMediaSettings.default_sharing_text }}" />
-        <meta property="og:site_name" content="{{ settings.core.SocialMediaSettings.site_name }}" />
-    {% endwith %}
-{% endblock social %}
-
 {%- block bodyStart -%}
     {%- if request.is_preview and request.preview_mode == "bundle-preview" -%}
         {% include "templates/components/preview-bar/preview-bar.html" %}

--- a/cms/jinja2/templates/pages/cookies.html
+++ b/cms/jinja2/templates/pages/cookies.html
@@ -9,7 +9,7 @@
     {% trans service_name=ONS_COOKIE_BANNER_SERVICE_NAME %}Cookies on {{ service_name }}{% endtrans %}
 {%- endset -%}
 
-{%- set page_title-%}
+{%- set page_title -%}
     {%- with current_site=wagtail_site() -%}
         {{ page_heading }} - {{ current_site.site_name }}
     {%- endwith -%}


### PR DESCRIPTION
### What is the context of this PR?

Addresses CMS-579

The design system page template already has a social block we are overriding with our own config. Ideally we want to be conforming to the design system as much as possible.

This PR removes the override and passes the extra values into the `pageConfig` to insert the correct social config.

### How to review

- Compare expected output from `_template.njk` with output in template.
- Test defaults from social media settings display correctly
- Test page specific images/share texts display correctly

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [ x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
