### PR TITLE
Improve test reliability

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "cms/settings/test.py",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 97
       }
     ],
     "cms/users/tests/test_signal_handlers.py": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T07:31:22Z"
+  "generated_at": "2026-04-20T13:28:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "cms/settings/test.py",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 87
+        "line_number": 92
       }
     ],
     "cms/users/tests/test_signal_handlers.py": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-14T09:53:13Z"
+  "generated_at": "2026-04-20T07:31:22Z"
 }

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -17,6 +17,7 @@ from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.form_data import nested_form_data, rich_text, streamfield
 
 from cms.articles.enums import SortingChoices
+from cms.articles.models import StatisticalArticlePage
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
 from cms.core.analytics_utils import format_date_for_gtm
 from cms.core.blocks.constants import CHART_BLOCK_TYPES
@@ -1255,7 +1256,12 @@ class PreviousReleasesWithoutPaginationTestCase(TestCase):
                 self.assertContains(response, article.get_admin_display_title())
                 self.assertContains(response, article.get_url(request=self.dummy_request))
 
-        self.assertInHTML(str(RichText(self.articles[0].summary)), response.content.decode(encoding="utf-8"))
+        # articles are all created with the same release date (timezone.now().date()), so the order we have
+        # by primary keys in self.articles might not be the same as is loaded by the call to previous_releases_url
+        first_child = (
+            StatisticalArticlePage.objects.live().child_of(self.article_series).order_by("-release_date").first()
+        )
+        self.assertInHTML(str(RichText(first_child.summary)), response.content.decode(encoding="utf-8"))
         self.assertContains(response, 'class="ons-document-list__item"', count=self.total_batch)
         self.assertContains(response, "Latest release", count=1)
         self.assertContains(response, "Previous releases", count=1)

--- a/cms/articles/tests/test_series_models.py
+++ b/cms/articles/tests/test_series_models.py
@@ -9,7 +9,7 @@ from wagtail.test.utils import WagtailTestUtils
 
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
 from cms.core.permission_testers import BasePagePermissionTester
-from cms.core.tests.utils import TranslationResetMixin, reset_url_caches
+from cms.core.tests.utils import TranslationResetMixin
 from cms.datasets.blocks import DatasetStoryBlock
 from cms.datavis.tests.factories import TableDataFactory
 from cms.users.tests.factories import UserFactory
@@ -87,9 +87,6 @@ class ArticleSeriesEvergreenUrlTestCase(TranslationResetMixin, WagtailTestUtils,
             ],
         )
         self.article_with_datasets.save_revision().publish()
-
-    def tearDown(self):
-        reset_url_caches()
 
     def test_evergreen_route_links_to_evergreen_related_data(self):
         """Test that the evergreen page links to the evergreen related data page."""

--- a/cms/auth/tests/helpers.py
+++ b/cms/auth/tests/helpers.py
@@ -79,7 +79,6 @@ class DummyResponse:
     ACCESS_TOKEN_COOKIE_NAME="access",
     ID_TOKEN_COOKIE_NAME="id",
     WAGTAIL_CORE_ADMIN_LOGIN_ENABLED=True,
-    WAGTAILADMIN_HOME_PATH="/admin/",
     SESSION_RENEWAL_OFFSET_SECONDS=300,
 )
 class CognitoTokenTestCase(TestCase):
@@ -145,13 +144,13 @@ class CognitoTokenTestCase(TestCase):
         self.set_jwt_cookies(access, id_token)
 
     def assertLoggedOut(self, redirect="/admin/login/") -> None:  # pylint: disable=invalid-name
-        response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
         self.assertEqual(response.status_code, 302)
         self.assertIn(redirect, response["Location"])
         self.assertFalse(response.wsgi_request.user.is_authenticated)
 
     def assertLoggedIn(self) -> None:  # pylint: disable=invalid-name
-        response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.wsgi_request.user.is_authenticated)
         # User should now exist after login

--- a/cms/auth/tests/test_auth_integration.py
+++ b/cms/auth/tests/test_auth_integration.py
@@ -90,7 +90,7 @@ class AuthIntegrationTests(CognitoTokenTestCase):
 
         self.set_jwt_cookies(access, id_token)
         # Trigger authentication (middleware runs)
-        self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
 
         # Refresh from DB and check details updated
         user.refresh_from_db()
@@ -235,7 +235,7 @@ class AuthIntegrationTests(CognitoTokenTestCase):
         access_2, id_token_2 = self.generate_tokens(username=uuid_other)
         self.set_jwt_cookies(access_2, id_token_2)
 
-        response_2 = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response_2 = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
 
         self.assertEqual(response_2.status_code, 302)
         self.assertFalse(response_2.wsgi_request.user.is_authenticated)
@@ -332,14 +332,14 @@ class AuthIntegrationTests(CognitoTokenTestCase):
 
         # Now flip the flag to False and access the admin home
         with override_settings(WAGTAIL_CORE_ADMIN_LOGIN_ENABLED=False):
-            response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+            response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
             self.assertLoggedOut()
 
     @override_settings(WAGTAIL_CORE_ADMIN_LOGIN_ENABLED=False)
     def test_core_admin_unavailable_when_core_admin_disabled(self):
         """Test that the core admin login page is unavailable when WAGTAIL_CORE_ADMIN_LOGIN_ENABLED is False."""
         User.objects.create_superuser(username="test", email="test@example.com", password="password123")
-        response = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
         # Should redirect to florence login page or similar
         self.assertEqual(response.status_code, 302)
 
@@ -394,7 +394,7 @@ class WagtailHookTests(CognitoTokenTestCase):
             self.login_with_tokens()
             self.assertLoggedIn()
 
-            resp = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+            resp = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
             self.assertEqual(resp.status_code, 200)
             html = resp.content.decode()
 
@@ -418,7 +418,7 @@ class WagtailHookTests(CognitoTokenTestCase):
         # User with username 'test' should now exist after login
         self.assertTrue(User.objects.filter(username="test").exists())
 
-        response_admin = self.client.get(settings.WAGTAILADMIN_HOME_PATH)
+        response_admin = self.client.get(f"/{settings.WAGTAILADMIN_HOME_PATH}")
         html = response_admin.content.decode()
 
         self.assertNotIn('id="auth-config"', html)

--- a/cms/bundles/tests/test_action_menu.py
+++ b/cms/bundles/tests/test_action_menu.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 from django.forms import Media
+from django.test import TestCase
 from wagtail.coreutils import get_dummy_request
 
 from cms.bundles.action_menu import (
@@ -20,6 +19,7 @@ from cms.bundles.tests.factories import BundleFactory
 class BundleActionMenuTests(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.draft_bundle = BundleFactory()
         cls.in_review_bundle = BundleFactory(in_review=True)
         cls.approved_scheduled_bundle = BundleFactory(approved=True)

--- a/cms/bundles/tests/test_action_menu.py
+++ b/cms/bundles/tests/test_action_menu.py
@@ -18,8 +18,7 @@ from cms.bundles.tests.factories import BundleFactory
 
 class BundleActionMenuTests(TestCase):
     @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
+    def setUpTestData(cls) -> None:
         cls.draft_bundle = BundleFactory()
         cls.in_review_bundle = BundleFactory(in_review=True)
         cls.approved_scheduled_bundle = BundleFactory(approved=True)

--- a/cms/core/tests/test_pages.py
+++ b/cms/core/tests/test_pages.py
@@ -13,7 +13,6 @@ from cms.core.tests.utils import (
     TranslationResetMixin,
     extract_datalayer_pushed_values,
     extract_response_jsonld,
-    reset_url_caches,
 )
 from cms.home.models import HomePage
 from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
@@ -22,9 +21,6 @@ from cms.standard_pages.tests.factories import IndexPageFactory, InformationPage
 class HomePageTests(TranslationResetMixin, WagtailPageTestCase):
     def setUp(self):
         self.page = HomePage.objects.first()
-
-    def tearDown(self):
-        reset_url_caches()
 
     def test_home_page_can_be_served(self):
         """Test that the home page can be served."""

--- a/cms/core/tests/test_tags.py
+++ b/cms/core/tests/test_tags.py
@@ -8,7 +8,6 @@ from cms.core.templatetags.util_tags import (
     get_hreflangs,
     get_translation_urls,
 )
-from cms.core.tests.utils import reset_url_caches
 from cms.home.models import HomePage
 
 
@@ -32,10 +31,6 @@ class LanguageTemplateTagTests(LocaleURLLookupMixin, TestCase):
 
     def setUp(self):
         self.dummy_request = get_dummy_request()
-        reset_url_caches()
-
-    def tearDown(self):
-        reset_url_caches()
 
     def test_get_translation_urls(self):
         """Test that get_translation_urls returns the correct URLs."""
@@ -210,12 +205,6 @@ class SubdomainLanguageTemplateTagTests(LocaleURLLookupMixin, TestCase):
         cls.welsh_site.hostname = "cy.ons.localhost"
         cls.welsh_site.port = 80
         cls.welsh_site.save(update_fields=["hostname", "port"])
-
-    def setUp(self):
-        reset_url_caches()
-
-    def tearDown(self):
-        reset_url_caches()
 
     def _make_request(self, hostname, path="/"):
         return RequestFactory(SERVER_NAME=hostname).get(path, SERVER_PORT=80)

--- a/cms/core/tests/utils.py
+++ b/cms/core/tests/utils.py
@@ -1,17 +1,14 @@
 import json
 import re
-import sys
 from io import StringIO
 from typing import TYPE_CHECKING
 from unittest import TestCase
 
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.conf.urls.i18n import is_language_prefix_patterns_used
 from django.core import management
 from django.core.files.base import ContentFile
 from django.test import SimpleTestCase
-from django.urls import clear_url_caches
 from django.utils import translation
 
 from cms.documents.models import CustomDocument
@@ -64,21 +61,6 @@ def extract_datalayer_pushed_values(html_content: str) -> dict[str, object]:
         arg_values = json.loads(datalayer_arg)
         datalayer_values.update(arg_values)
     return datalayer_values
-
-
-def reset_url_caches():
-    # Make sure the cache is empty before we are doing our tests.
-    clear_url_caches()
-    # Force reload of URLconf module to re-evaluate i18n_patterns
-    root_urlconf = getattr(settings, "ROOT_URLCONF", None)
-    if root_urlconf and root_urlconf in sys.modules:
-        del sys.modules[root_urlconf]
-        # Also delete any submodules
-        modules_to_delete = [mod for mod in sys.modules if mod.startswith(root_urlconf + ".")]
-        for mod in modules_to_delete:
-            del sys.modules[mod]
-
-    is_language_prefix_patterns_used.cache_clear()
 
 
 class PanelBlockAssertions(SimpleTestCase):

--- a/cms/locale/tests/test_domain_localisation.py
+++ b/cms/locale/tests/test_domain_localisation.py
@@ -5,7 +5,6 @@ from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Site
 from wagtail.test.utils import WagtailPageTestCase
 
-from cms.core.tests.utils import reset_url_caches
 from cms.home.models import HomePage
 from cms.standard_pages.tests.factories import InformationPageFactory
 
@@ -44,13 +43,9 @@ class SubdomainLocalisationTests(WagtailPageTestCase):
     def setUp(self):
         self.dummy_request = get_dummy_request()
 
-        reset_url_caches()
-
     def tearDown(self):
         # Clear translation caches
         translation.deactivate()
-
-        reset_url_caches()
 
     def test_full_url(self):
         self.assertEqual(self.page.get_full_url(request=self.dummy_request), "http://ons.localhost/about")

--- a/cms/locale/tests/test_path_localisation.py
+++ b/cms/locale/tests/test_path_localisation.py
@@ -10,7 +10,6 @@ from wagtail.models import Locale, Site
 from wagtail.test.utils import WagtailPageTestCase
 
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
-from cms.core.tests.utils import reset_url_caches
 from cms.standard_pages.tests.factories import InformationPageFactory
 
 
@@ -40,13 +39,9 @@ class PathBasedLocalisationTests(WagtailPageTestCase):
     def setUp(self):
         self.dummy_request = get_dummy_request()
 
-        reset_url_caches()
-
     def tearDown(self):
         # Clear translation caches
         translation.deactivate()
-
-        reset_url_caches()
 
     def get_template_side_effect(self, template_name, *args, **kwargs):
         """Side effect function to simulate template loading failures."""

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -103,7 +103,7 @@ CMS_HOSTNAME_LOCALE_MAP = {
 }
 CMS_HOSTNAME_ALTERNATIVES = {"ons.localhost": "pub.ons.localhost", "cy.ons.localhost": "cy.pub.ons.localhost"}
 
-URL_CONFIG_SETTINGS = (
+URL_CONFIG_SETTINGS = {
     "IS_EXTERNAL_ENV",
     "CMS_USE_SUBDOMAIN_LOCALES",
     "LANGUAGE",
@@ -112,7 +112,7 @@ URL_CONFIG_SETTINGS = (
     "AWS_COGNITO_TEAM_SYNC_ENABLED",
     "WAGTAIL_CORE_ADMIN_LOGIN_ENABLED",
     "WAGTAILADMIN_HOME_PATH",
-)
+}
 
 
 def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: Any) -> None:

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -1,4 +1,9 @@
 import os
+from typing import Any
+
+from django.conf.urls.i18n import is_language_prefix_patterns_used
+from django.core.signals import setting_changed
+from django.urls import clear_url_caches
 
 # Force logs to JSON in tests, to match production behaviour
 os.environ.setdefault("LOG_AS_JSON", "true")
@@ -97,3 +102,41 @@ CMS_HOSTNAME_LOCALE_MAP = {
     "cy.pub.ons.localhost": "cy",
 }
 CMS_HOSTNAME_ALTERNATIVES = {"ons.localhost": "pub.ons.localhost", "cy.ons.localhost": "cy.pub.ons.localhost"}
+
+URL_CONFIG_SETTINGS = (
+    "IS_EXTERNAL_ENV",
+    "CMS_USE_SUBDOMAIN_LOCALES",
+    "LANGUAGE",
+    "LANGUAGE_CODES_PATTERN",
+    "ALLOW_TEAM_MANAGEMENT",
+    "AWS_COGNITO_TEAM_SYNC_ENABLED",
+    "WAGTAIL_CORE_ADMIN_LOGIN_ENABLED",
+    "WAGTAILADMIN_HOME_PATH",
+)
+
+
+# we can't just import reset_url_caches from the utils file
+# as it relies on settings and apps already being set up
+def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: Any) -> None:
+    """Resets the url cache if `setting` is any of URL_CONFIG_SETTINGS.
+
+    Extends django's own approach to settings being changed during test runs to CMS
+    specific settings that affect url config.
+
+    This helps prevent issues with url config pollution between tests if reset_url_caches
+    isn't manually called.
+    """
+    if setting not in URL_CONFIG_SETTINGS:
+        return
+    clear_url_caches()
+    if ROOT_URLCONF and ROOT_URLCONF in sys.modules:  # noqa: F405
+        del sys.modules[ROOT_URLCONF]  # noqa: F405
+        # Also delete any submodules
+        modules_to_delete = [mod for mod in sys.modules if mod.startswith(ROOT_URLCONF + ".")]  # noqa: F405
+        for mod in modules_to_delete:
+            del sys.modules[mod]  # noqa: F405
+
+    is_language_prefix_patterns_used.cache_clear()
+
+
+setting_changed.connect(_reset_url_caches_on_setting_changed_signal_handler)

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -71,7 +71,7 @@ TASKS = {
     }
 }
 
-# Explicitly set some settings used for convenience in development, that some settings assume a default for
+# Explicitly set some settings used for convenience in development, that some tests assume a default for
 ALLOW_TEAM_MANAGEMENT = False
 ALLOW_DIRECT_PUBLISHING_IN_DEVELOPMENT = False
 

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -115,8 +115,6 @@ URL_CONFIG_SETTINGS = (
 )
 
 
-# we can't just import reset_url_caches from the utils file
-# as it relies on settings and apps already being set up
 def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: Any) -> None:
     """Resets the url cache if `setting` is any of URL_CONFIG_SETTINGS.
 

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -71,6 +71,11 @@ TASKS = {
     }
 }
 
+# Explicitly set some settings used for convenience in development, that some settings assume a default for
+ALLOW_TEAM_MANAGEMENT = False
+ALLOW_DIRECT_PUBLISHING_IN_DEVELOPMENT = False
+
+
 # Silence Slack notifications by default
 SLACK_NOTIFICATIONS_WEBHOOK_URL = None
 

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -125,9 +125,6 @@ def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: An
 
     Extends django's own approach to settings being changed during test runs to CMS
     specific settings that affect url config.
-
-    This helps prevent issues with url config pollution between tests if reset_url_caches
-    isn't manually called.
     """
     if setting not in URL_CONFIG_SETTINGS:
         return

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -136,7 +136,7 @@ def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: An
         for mod in modules_to_delete:
             del sys.modules[mod]  # noqa: F405
 
-    is_language_prefix_patterns_used.cache_clear()
+    is_language_prefix_patterns_used.cache_clear()  # type: ignore
 
 
 setting_changed.connect(_reset_url_caches_on_setting_changed_signal_handler)

--- a/cms/standard_pages/tests/test_pages.py
+++ b/cms/standard_pages/tests/test_pages.py
@@ -4,7 +4,7 @@ from django.utils import translation
 from wagtail.models import Site
 from wagtail.test.utils import WagtailPageTestCase
 
-from cms.core.tests.utils import TranslationResetMixin, reset_url_caches
+from cms.core.tests.utils import TranslationResetMixin
 from cms.standard_pages.models import CookiesPage
 from cms.standard_pages.utils import SUPPORTED_LANGUAGE_CODES
 
@@ -90,7 +90,6 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
     def test_view_cookies_link_is_localised_subdomain_routing_off(self):
         # remove all but the default site
         Site.objects.filter(is_default_site=False).delete()
-        reset_url_caches()
 
         response = self.client.get("/cy")
         self.assertContains(response, 'href="/cy/cookies"')

--- a/cms/teams/tests/test_redirect.py
+++ b/cms/teams/tests/test_redirect.py
@@ -4,8 +4,6 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail.test.utils import WagtailTestUtils
 
-from cms.core.tests.utils import reset_url_caches
-
 
 class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
     @classmethod
@@ -15,16 +13,12 @@ class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
     def setUp(self):
         self.client.force_login(self.superuser)
 
-    def tearDown(self):
-        reset_url_caches()
-
     @override_settings(
         ALLOW_TEAM_MANAGEMENT=False,
         AWS_COGNITO_TEAM_SYNC_ENABLED=True,
         FLORENCE_GROUPS_PATH="/florence/groups",
     )
     def test_teams_index_redirects_to_florence_when_sync_enabled(self):
-        reset_url_caches()
         response = self.client.get(reverse("teams:index"))
         self.assertRedirects(response, "/florence/groups", fetch_redirect_response=False)
 
@@ -34,7 +28,6 @@ class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
         FLORENCE_GROUPS_PATH="/florence/groups",
     )
     def test_teams_subpath_redirects_to_florence_when_sync_enabled(self):
-        reset_url_caches()
         response = self.client.get("/admin/teams/add/")
         self.assertRedirects(response, "/florence/groups", fetch_redirect_response=False)
 
@@ -43,7 +36,6 @@ class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
         AWS_COGNITO_TEAM_SYNC_ENABLED=True,
     )
     def test_no_redirect_when_team_management_enabled(self):
-        reset_url_caches()
         response = self.client.get(reverse("teams:index"))
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
@@ -52,7 +44,6 @@ class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
         AWS_COGNITO_TEAM_SYNC_ENABLED=False,
     )
     def test_no_redirect_when_team_management_enabled_but_no_sync(self):
-        reset_url_caches()
         response = self.client.get(reverse("teams:index"))
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
@@ -61,6 +52,5 @@ class TeamsRedirectTestCase(WagtailTestUtils, TestCase):
         AWS_COGNITO_TEAM_SYNC_ENABLED=False,
     )
     def test_no_redirect_when_cognito_sync_disabled(self):
-        reset_url_caches()
         response = self.client.get(reverse("teams:index"))
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/functional_tests/features/information_page.feature
+++ b/functional_tests/features/information_page.feature
@@ -12,7 +12,7 @@ Feature: A general use information page
         Then the new information page with the added content is displayed
         And  the user can see the breadcrumbs
 
-    Scenario: A CMS user can add an equation an information page
+    Scenario: A CMS user can add an equation to an information page
         Given an information page exists
         When the user edits the information page
         And  the user adds an equation

--- a/functional_tests/steps/information_page.py
+++ b/functional_tests/steps/information_page.py
@@ -151,7 +151,7 @@ def user_adds_info_page_contents(context: Context) -> None:
     context.page.get_by_role("region", name="Rich text *").get_by_role("textbox").fill("Some example rich text content")
 
     context.page.get_by_role("button", name="Insert a block").nth(2).click()
-    context.page.get_by_text("Related links", exact=True).click()
+    context.page.get_by_text("Related links", exact=True).last.click()
     context.page.get_by_role("button", name="Choose a page").click()
     context.page.get_by_role("cell", name="Home English", exact=True).get_by_role("link").click()
     context.page.get_by_role("textbox", name="Title", exact=True).fill("Test Home")
@@ -328,4 +328,4 @@ def preview_index_page_lists_live_and_draft_information_pages(context: Context) 
 
 @then("the equation is rendered")
 def the_equation_is_rendered(context: Context) -> None:
-    expect(context.page.get_by_text("n∑i=0i2=(n2+n)(2n+1)")).to_be_visible()
+    expect(context.page.get_by_text("n∑i=0i2=(n2+n)(2n+1)").last).to_be_visible()


### PR DESCRIPTION
### What is the context of this PR?

Makes a handful of small changes to improve test reliability.

- Updates a test that used `unittest.Testcase` rather than `django.test.TestCase` but accessed the database
- Use a database query to fetch a page when ordering by `-release_date` was unpredictable. Pages with identical release dates returned by a model factory are not necessarily in the order the database fetches them in.
- Updates two functional tests that would fail when there were multiple element matches on the page

The main change is centralising management of url configuration using the `setting_changed` signal. The primary cause of test instability I've been able to find was due to url config being lazily loaded after a `reset_url_caches` while settings were being overridden. Due to the shuffling of tests this could unpredictably lead to failures.

- `IS_EXTERNAL_ENV`: Affects whether wagtail urls loaded. Some tests were not cleaning up urls after setting this `True`.
- `WAGTAILADMIN_HOME_URL`: Some tests were overriding this to `/admin/`, and the leading `/` would lead to django setting the url to `/%2fadmin/`, breaking future tests.

### How to review

Run the full test suite a few times with different seeds, verify that there are no unexpected failures.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
