### PR TITLE
feat(i18n): add feature flag for cookies page untranslated notice

### DIFF
--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -203,6 +203,10 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
             return request.build_absolute_uri(request.get_full_path())
         return cast(str, canonical_page.get_full_url(request=request))
 
+    def show_localised_version_not_available_notice(self, request: HttpRequest) -> bool:
+        """Return whether to show a notice that this page is not available in the active language."""
+        return bool(self.alias_of and self.alias_of.locale.language_code != request.LANGUAGE_CODE)
+
     def get_url_parts(self, request: HttpRequest | None = None) -> tuple[int, str | None, str | None] | None:
         """Override get_url_parts to generate URLs without trailing slashes."""
         parts = super().get_url_parts(request)

--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -72,7 +72,7 @@
     {# Changes the location of the <main> tag from the base template - ensures it surrounds the header area #}
     {# This change should be adopted by the design system soon #}
     <main id="main-content">
-        {% if page.show_localised_version_not_available_notice(request) %}
+        {% if page and page.show_localised_version_not_available_notice(request) %}
             {% from "components/panel/_macro.njk" import onsPanel %}
             {# fmt:off #}
             {{-

--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -1,11 +1,6 @@
 {% extends "templates/base.html" %}
 {% from "components/back-to-top/_macro.njk" import onsBackToTop %}
 
-{#- Untranslated pages will have aliases to the original page -#}
-{%- if page.alias_of and request.LANGUAGE_CODE != page.alias_of.locale.language_code -%}
-    {%- set localised_version_not_available = true -%}
-{%- endif -%}
-
 {% block meta %}
     {{ super() }}
     {% if page %}
@@ -77,7 +72,7 @@
     {# Changes the location of the <main> tag from the base template - ensures it surrounds the header area #}
     {# This change should be adopted by the design system soon #}
     <main id="main-content">
-        {% if localised_version_not_available %}
+        {% if page.show_localised_version_not_available_notice(request) %}
             {% from "components/panel/_macro.njk" import onsPanel %}
             {# fmt:off #}
             {{-

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-21 08:40+0100\n"
+"POT-Creation-Date: 2026-04-21 09:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -174,15 +174,15 @@ msgstr "Mae’r holl gynnwys ar gael o dan y"
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
-#: cms/jinja2/templates/base_page.html:66
+#: cms/jinja2/templates/base_page.html:61
 msgid "in English"
 msgstr "yn Saesneg"
 
-#: cms/jinja2/templates/base_page.html:67
+#: cms/jinja2/templates/base_page.html:62
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:74
+#: cms/jinja2/templates/base_page.html:69
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "
@@ -260,31 +260,27 @@ msgstr "Rheswm dros newid"
 #: cms/jinja2/templates/pages/cookies.html:9
 #, python-format
 msgid "Cookies on %(service_name)s"
-msgstr "Cwcis ar %(service_name)s"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:30
 msgid "Your cookie settings have been saved"
-msgstr "Mae eich gosodiadau cwcis wedi’u cadw"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:32
 msgid ""
 "Some parts of this website may use additional cookies and will have their "
 "own cookie policy and banner."
 msgstr ""
-"Efallai y bydd rhai rhannau o’r wefan hon yn defnyddio cwcis ychwanegol ac "
-"yn cynnwyseu polisi cwcis a’u baner eu hunain."
 
 #: cms/jinja2/templates/pages/cookies.html:34
 msgid "Return to previous page"
-msgstr "Dychwelyd i’r dudalen flaenorol"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:38
 msgid ""
 "Cookies are files saved on your phone, tablet or computer when you visit a "
 "website."
 msgstr ""
-"Mae cwcis yn ffeiliau sy’n cael eu cadw are eich ffôn, llechen neu "
-"gyfrifiadur pan fyddwch yn ymweld â gwefan."
 
 #: cms/jinja2/templates/pages/cookies.html:39
 msgid ""
@@ -302,20 +298,19 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:43
 msgid "Cookie settings"
-msgstr "Gosodiadau cwcis"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:50
 msgid "You can try:"
-msgstr "Gallwch geisio:"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:52
 msgid "turning on JavaScript in your browser"
-msgstr "galluogi JavaScript yn eich porwr"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:53
 msgid "reloading the page in case there was a temporary fault with JavaScript"
 msgstr ""
-"ail-lwytho’r dudalen rhag ofn bod gwall dros dro wedi digwydd gyda JavaScript"
 
 #: cms/jinja2/templates/pages/cookies.html:59
 msgid ""
@@ -325,7 +320,7 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:63
 msgid "Cookies that measure website use"
-msgstr "Cwcis sy’n mesur defnydd o’r wefan"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:65
 msgid ""
@@ -339,7 +334,7 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:69
 msgid "how you got to the site"
-msgstr "sut y daethoch chi i’r wefan"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:70
 msgid "the pages you visit and how long you spend on each page"
@@ -347,15 +342,15 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:71
 msgid "what you click on while you are visiting the site"
-msgstr "yr hyn rydych yn clicio arno tra byddwch yn ymweld â’r wefan"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:72
 msgid "the way in which you interact with a page"
-msgstr "y ffordd rydych yn rhyngweithio â thudalen"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:73
 msgid "whether you have participated in a Hotjar survey"
-msgstr "p’un a ydych wedi cymryd rhan mewn arolwg Hotjar"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:75
 msgid ""
@@ -413,25 +408,24 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:173
 msgid "Strictly necessary cookies"
-msgstr "Cwcis hollol angenrheidiol"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:174
 msgid "These essential cookies do things like:"
-msgstr "Mae’r cwcis hollol angenrheidiol hyn yn gwneud pethau fel:"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:176
 msgid ""
 "remember the notifications you’ve seen so we do not show them to you again"
 msgstr ""
-"cofio’r hysbysiadau rydych wedi’u gweld fel na fyddwn yn eu dangos i chi eto"
 
 #: cms/jinja2/templates/pages/cookies.html:177
 msgid "remember your progress through a form (for example, an ONS study)"
-msgstr "cofio’ch cynnydd trwy ffurflen (er enghraifft, astudiaeth SYG)"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:178
 msgid "improve performance and identify potential security threats"
-msgstr "gwella perfformiad ac adnabod bygythiadau diogelwch posibl"
+msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:180
 msgid "They always need to be on."
@@ -439,7 +433,7 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:182
 msgid "Save changes"
-msgstr "Cadw newidiadau"
+msgstr ""
 
 #: cms/jinja2/templates/pages/defender/lockout.html:6
 #: cms/jinja2/templates/pages/defender/lockout.html:8

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -958,6 +958,11 @@ DATETIME_FORMAT = "j F Y g:ia"  # 1 November 2024, 1 p.m.
 ONS_COOKIE_BANNER_SERVICE_NAME = env.get("ONS_COOKIE_BANNER_SERVICE_NAME", "ons.gov.uk")
 ONS_COOKIES_PAGE_SLUG = "cookies"
 
+# Feature flag to suppress the untranslated-page notice on CookiesPage aliases.
+CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED = (
+    env.get("CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED", "true").lower() == "true"
+)
+
 # Search redirect path
 ONS_WEBSITE_SEARCH_PATH = env.get("ONS_WEBSITE_SEARCH_PATH", "/search")
 

--- a/cms/standard_pages/models.py
+++ b/cms/standard_pages/models.py
@@ -150,3 +150,8 @@ class CookiesPage(BasePage):  # type: ignore[django-manager-missing]
 
     parent_page_types: ClassVar[list[str]] = ["home.HomePage"]
     _analytics_content_type = "cookies"
+
+    def show_localised_version_not_available_notice(self, request: HttpRequest) -> bool:
+        if settings.CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED:
+            return super().show_localised_version_not_available_notice(request)
+        return False

--- a/cms/standard_pages/tests/test_pages.py
+++ b/cms/standard_pages/tests/test_pages.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import override_settings
+from django.test import RequestFactory, override_settings
 from django.utils import translation
 from wagtail.models import Site
 from wagtail.test.utils import WagtailPageTestCase
@@ -22,6 +22,19 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
     def tearDown(self):
         # Clear translation caches
         translation.deactivate()
+
+    def test_welsh_cookies_page_shows_localised_version_notice_by_default(self):
+        request = RequestFactory().get(self.welsh_cookies_page.url)
+        request.LANGUAGE_CODE = "cy"
+
+        self.assertTrue(self.welsh_cookies_page.show_localised_version_not_available_notice(request))
+
+    @override_settings(CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED=False)
+    def test_welsh_cookies_page_can_hide_localised_version_notice_with_feature_flag(self):
+        request = RequestFactory().get(self.welsh_cookies_page.url)
+        request.LANGUAGE_CODE = "cy"
+
+        self.assertFalse(self.welsh_cookies_page.show_localised_version_not_available_notice(request))
 
     def test_get_cookies_page(self):
         response = self.client.get(self.cookies_page.url)

--- a/cms/standard_pages/tests/test_pages.py
+++ b/cms/standard_pages/tests/test_pages.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from django.conf import settings
 from django.test import RequestFactory, override_settings
 from django.utils import translation
@@ -58,7 +60,20 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
             html=True,
         )
 
-    def test_get_welsh_cookies_page(self):
+    def test_welsh_cookies_page_renders_translated_furniture(self):
+        response = self.client.get(self.welsh_cookies_page.url, headers={"host": "cy.ons.localhost"})
+        self.assertEqual(response.status_code, 200)
+
+        # Check the breadcrumbs include the home page link
+        self.assertContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{self.welsh_site.root_url}">Cartref</a>',
+            html=True,
+        )
+
+    # TODO: Remove skip when translations for Cookies page are available
+    @skip("Welsh cookies page content translations temporarily disabled until full translations are available")
+    def test_welsh_cookies_page_renders_translated_content(self):
         response = self.client.get(self.welsh_cookies_page.url, headers={"host": "cy.ons.localhost"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(
@@ -73,12 +88,6 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
             html=True,
         )
         self.assertContains(response, "Gosodiadau cwcis")
-        # Check the breadcrumbs include the home page link
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{self.welsh_site.root_url}">Cartref</a>',
-            html=True,
-        )
 
     def test_cookies_page_exists_for_all_supported_language(self):
         # The english cookies page should be the original


### PR DESCRIPTION
### What is the context of this PR?

1. Moves the untranslated-page notice check out of the base page template and onto the page model, so the behaviour can be overridden per page type.
2. It also adds a feature flag to suppress the notice on `CookiesPage` when needed. By default, the existing behaviour is unchanged and Welsh cookies page aliases will still show the notice. When `CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED` is set to `false`, the notice is hidden for `CookiesPage`.
3. Removes the translations for the Cookies page until we get the full translations back. We cannot have the page be partially translated. `CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED` should be set to `False` once we add the full translation for CookiesPage in.

### How to review

Ensure:
- changes make sense
- untranslated banner behaviour is unchanged for all pages except the cookies page
- you can toggle the notice on the cookies page by setting `CMS_COOKIES_PAGE_UNTRANSLATED_NOTICE_ENABLED`
- No welsh translation of cookies page exist (page furniture/breadcrumb is fine)

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
