### PR TITLE
ci(github-actions): block merges for PRs with blocking labels

### DIFF
--- a/.github/workflows/pr-blocked-labels.yml
+++ b/.github/workflows/pr-blocked-labels.yml
@@ -27,5 +27,5 @@ jobs:
             On Hold ✋
           add_comment: true
           message:
-            "This PR is being prevented from merging because you have added one of our blocking labels: `{{ applied }}`\n\n
+            "This PR is being prevented from merging because you have added one of our blocking labels: {{ applied }}\n\n
             You'll need to remove it before this PR can be merged."

--- a/.github/workflows/pr-blocked-labels.yml
+++ b/.github/workflows/pr-blocked-labels.yml
@@ -1,0 +1,31 @@
+name: Block merge on blocking labels
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+
+jobs:
+  label-check:
+    name: label-check
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: |
+            do not merge
+            status: Blocked
+            status: In-progress
+            status: Needs tests
+            status: Needs functional/UI tests
+            invalid
+            On Hold ✋
+          add_comment: true
+          message:
+            "This PR is being prevented from merging because you have added one of our blocking labels: `{{ applied }}`\n\n
+            You'll need to remove it before this PR can be merged."


### PR DESCRIPTION
### What is the context of this PR?

Adds a GitHub Actions workflow that prevents PRs from being merged when any blocking label is present.

### How to review

Ensure workflow makes sense and whether any other changes are needed.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
