### PR TITLE
chore(i18n): further app translations

### DIFF
--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-21 09:23+0100\n"
+"POT-Creation-Date: 2026-04-21 16:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,11 +148,11 @@ msgstr "Mae hwn yn wasanaeth newydd."
 
 #: cms/jinja2/templates/base.html:36
 msgid "Menu links navigation"
-msgstr ""
+msgstr "Llywio dolenni dewislen"
 
 #: cms/jinja2/templates/base.html:37
 msgid "Menu links"
-msgstr ""
+msgstr "Dolenni dewislen"
 
 #: cms/jinja2/templates/base.html:38
 msgid "Menu"
@@ -160,7 +160,7 @@ msgstr "Dewislen"
 
 #: cms/jinja2/templates/base.html:39
 msgid "Toggle menu"
-msgstr ""
+msgstr "Togl dewislen"
 
 #: cms/jinja2/templates/base.html:40
 msgid "Breadcrumbs"
@@ -231,21 +231,21 @@ msgstr "Dangos pob diffiniad"
 msgid "Hide all definitions"
 msgstr "Cuddio pob diffiniad"
 
-#: cms/jinja2/templates/components/streamfield/image_block.html:20
+#: cms/jinja2/templates/components/streamfield/image_block.html:19
 #: cms/jinja2/templates/components/streamfield/table_block.html:9
 msgid "Source"
 msgstr "Ffynhonnell"
 
-#: cms/jinja2/templates/components/streamfield/image_block.html:37
+#: cms/jinja2/templates/components/streamfield/image_block.html:35
 msgid "Notes"
 msgstr "Nodiadau"
 
+#: cms/jinja2/templates/components/streamfield/image_block.html:41
 #: cms/jinja2/templates/components/streamfield/image_block.html:43
-#: cms/jinja2/templates/components/streamfield/image_block.html:45
 msgid "Download image"
 msgstr "Lawrlwythwch y ddelwedd"
 
-#: cms/jinja2/templates/components/streamfield/image_block.html:51
+#: cms/jinja2/templates/components/streamfield/image_block.html:48
 msgid "Download this image"
 msgstr "Lawrlwythwch y ddelwedd hon"
 
@@ -592,6 +592,11 @@ msgid ""
 "href=\"%(stats_authority_url)s\">Code of Practice for Statistics</a>. This "
 "broadly means that the statistics:"
 msgstr ""
+"Mae'r rhain yn ystadegau swyddogol achrededig. Maent wedi cael eu hadolygu'n "
+"annibynnol gan y Swyddfa Rheoleiddio Ystadegau (OSR) a chanfuwyd eu bod yn "
+"cydymffurfio â safonau dibynadwyedd, ansawdd a gwerth yn y <a "
+"href=\"%(stats_authority_url)s\"> Cod Ymarfer ar gyfer Ystadegau</a>. Mae "
+"hyn yn golygu'n fras bod yr ystadegau:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:138
 msgid "meet user needs"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -595,7 +595,7 @@ msgstr ""
 "Mae'r rhain yn ystadegau swyddogol achrededig. Maent wedi cael eu hadolygu'n "
 "annibynnol gan y Swyddfa Rheoleiddio Ystadegau (OSR) a chanfuwyd eu bod yn "
 "cydymffurfio â safonau dibynadwyedd, ansawdd a gwerth yn y <a "
-"href=\"%(stats_authority_url)s\"> Cod Ymarfer ar gyfer Ystadegau</a>. Mae "
+"href=\"%(stats_authority_url)s\">Cod Ymarfer ar gyfer Ystadegau</a>. Mae "
 "hyn yn golygu'n fras bod yr ystadegau:"
 
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:138

--- a/functional_tests/steps/navigation_menus.py
+++ b/functional_tests/steps/navigation_menus.py
@@ -22,10 +22,9 @@ def _assert_main_menu_content(
     *,
     page,
     highlights: list,
-    aria_label: str,
     locale_suffix: str = "",
 ) -> None:
-    nav = page.locator(f'nav[aria-label="{aria_label}"]')
+    nav = page.locator("#nav-links-external")
     expect(nav).to_be_visible()
 
     for highlight in highlights:
@@ -237,8 +236,8 @@ def create_populated_main_menu(context: Context) -> None:
 def user_toggles_main_menu(context: Context) -> None:
     context.main_content_bounding_box_before_toggle = context.page.locator("#main-content").bounding_box()
     context.page.wait_for_timeout(3000)
-    context.page.get_by_role("button", name="Toggle menu").click()
-    context.page.locator('nav[aria-label="Menu links navigation"]').wait_for(state="visible")
+    context.page.locator('button[aria-controls="nav-links-external"]').click()
+    context.page.locator("#nav-links-external").wait_for(state="visible")
 
 
 @then("the main menu displays the configured columns, sections, and topic links")
@@ -246,7 +245,6 @@ def main_menu_displays_configured_content(context: Context) -> None:
     _assert_main_menu_content(
         page=context.page,
         highlights=context.main_menu_highlights,
-        aria_label="Menu links navigation",
         locale_suffix="English",
     )
 
@@ -276,7 +274,6 @@ def welsh_main_menu_displays_configured_content(context: Context) -> None:
     _assert_main_menu_content(
         page=context.page,
         highlights=context.welsh_main_menu_highlights,
-        aria_label="Menu links navigation",
         locale_suffix="Welsh",
     )
 
@@ -320,7 +317,7 @@ def welsh_footer_menu_displays_configured_content(context: Context) -> None:
 
 @then('the menu button has the button text "{button_text}"')
 def menu_button_has_correct_text(context: Context, button_text: str) -> None:
-    button = context.page.locator('button[aria-label="Toggle menu"]')
+    button = context.page.locator('button[aria-controls="nav-links-external"]')
     expect(button).to_be_visible()
     expect(button.locator(".ons-btn__text")).to_have_text(button_text)
 


### PR DESCRIPTION
### What is the context of this PR?

Add more translations. All but the cookies page content should now be translated.

### How to review

Ensure the translations match:

```
msgid ""
"These are accredited official statistics. They have been independently "
"reviewed by the Office for Statistics Regulation (OSR) and found to comply "
"with the standards of trustworthiness, quality and value in the <a "
"href=\"%(stats_authority_url)s\">Code of Practice for Statistics</a>. This "
"broadly means that the statistics:"
msgstr ""
"Mae'r rhain yn ystadegau swyddogol achrededig. Maent wedi cael eu "
"hadolygu'n annibynnol gan y Swyddfa Rheoleiddio Ystadegau (OSR) a chanfuwyd eu bod yn cydymffurfio "
"â safonau dibynadwyedd, ansawdd a gwerth yn y <a "
"href=\"%(stats_authority_url)s\">Cod Ymarfer ar gyfer Ystadegau</a>. Mae hyn "
"yn golygu'n fras bod yr ystadegau:"

#: cms/jinja2/templates/base.html:36
msgid "Menu links navigation"
msgstr "Llywio dolenni dewislen"

#: cms/jinja2/templates/base.html:37
msgid "Menu links"
msgstr "Dolenni dewislen"

#: cms/jinja2/templates/base.html:39
msgid "Toggle menu"
msgstr "Togl dewislen"
```

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
