### PR TITLE
Replace `django.shortcuts.redirect` with `cms.core.utils.redirect`

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
@@ -31,7 +31,7 @@ from cms.core.custom_date_format import ons_date_format
 from cms.core.fields import StreamField
 from cms.core.models import BasePage
 from cms.core.models.mixins import NoTrailingSlashRoutablePageMixin
-from cms.core.utils import redirect_to_parent_listing
+from cms.core.utils import redirect, redirect_to_parent_listing
 from cms.core.widgets import date_widget
 from cms.data_downloads.mixins import DataDownloadMixin
 from cms.datasets.blocks import DatasetStoryBlock

--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -127,6 +127,12 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
     def test_default_route_rendering(self):
         self.assertPageIsRenderable(self.page)
 
+    def test_serve_redirects_non_editions_path_to_editions_url_with_correct_code(self):
+        raw_url = f"{self.page.get_parent().url}/{self.page.slug}"
+        response = self.client.get(raw_url)
+        _, _, editions_path = self.page.get_url_parts()
+        self.assertRedirects(response, editions_path, status_code=307, fetch_redirect_response=False)
+
     def test_page_content(self):
         response = self.client.get(self.page.url)
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/cms/articles/wagtail_hooks.py
+++ b/cms/articles/wagtail_hooks.py
@@ -1,14 +1,13 @@
 from typing import TYPE_CHECKING
 
-from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
 from wagtail import hooks
 from wagtail.admin import messages
 
 from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
+from cms.core.utils import redirect
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest
+    from django.http import HttpRequest, HttpResponsePermanentRedirect, HttpResponseRedirect
     from wagtail.models import Page
 
 
@@ -27,7 +26,7 @@ def before_create_page(
 
 
 @hooks.register("before_delete_page")
-def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | None:
+def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | HttpResponsePermanentRedirect | None:
     if request.method == "POST":
         if page.specific_class is StatisticalArticlePage and page.specific.figures_used_by_ancestor_with_no_fallback:
             messages.warning(
@@ -36,7 +35,7 @@ def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect
             )
             # Redirect to the delete page (the same page) to prevent delete action
             # See: https://docs.wagtail.org/en/latest/reference/hooks.html#before-delete-page
-            return redirect("wagtailadmin_pages:delete", page.pk)
+            return redirect("wagtailadmin_pages:delete", page.pk, preserve_request=False)
         if (
             page.specific_class is ArticleSeriesPage
             and (latest := page.get_latest())
@@ -47,13 +46,15 @@ def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect
                 " that are referenced elsewhere."
             )
             messages.warning(request, message)
-            return redirect("wagtailadmin_pages:delete", page.pk)
+            return redirect("wagtailadmin_pages:delete", page.pk, preserve_request=False)
 
     return None
 
 
 @hooks.register("before_unpublish_page")
-def before_unpublish_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | None:
+def before_unpublish_page(
+    request: HttpRequest, page: Page
+) -> HttpResponseRedirect | HttpResponsePermanentRedirect | None:
     if request.method == "POST":
         if page.specific_class is StatisticalArticlePage and page.specific.figures_used_by_ancestor_with_no_fallback:
             messages.warning(
@@ -62,7 +63,7 @@ def before_unpublish_page(request: HttpRequest, page: Page) -> HttpResponseRedir
             )
             # Redirect to the unpublish page (the same page) to prevent unpublish action
             # See: https://docs.wagtail.org/en/latest/reference/hooks.html#before-delete-page
-            return redirect("wagtailadmin_pages:unpublish", page.pk)
+            return redirect("wagtailadmin_pages:unpublish", page.pk, preserve_request=False)
         if (
             page.specific_class is ArticleSeriesPage
             and (latest := page.get_latest())
@@ -73,6 +74,6 @@ def before_unpublish_page(request: HttpRequest, page: Page) -> HttpResponseRedir
                 " that are referenced elsewhere."
             )
             messages.warning(request, message)
-            return redirect("wagtailadmin_pages:unpublish", page.pk)
+            return redirect("wagtailadmin_pages:unpublish", page.pk, preserve_request=False)
 
     return None

--- a/cms/bundles/views/add_to_bundle.py
+++ b/cms/bundles/views/add_to_bundle.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import get_text_list
@@ -16,9 +16,10 @@ from cms.bundles.admin_forms import AddToBundleForm
 from cms.bundles.mixins import BundledPageMixin
 from cms.bundles.models import Bundle, BundlePage
 from cms.bundles.permissions import user_can_manage_bundles
+from cms.core.utils import redirect
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest, HttpResponseBase, HttpResponseRedirect
+    from django.http import HttpRequest, HttpResponseBase, HttpResponsePermanentRedirect, HttpResponseRedirect
 
 
 class AddToBundleView(FormView):
@@ -62,9 +63,9 @@ class AddToBundleView(FormView):
             )
 
             if self.goto_next:
-                return redirect(self.goto_next)
+                return redirect(self.goto_next, preserve_request=False)
 
-            return redirect("wagtailadmin_home")
+            return redirect("wagtailadmin_home", preserve_request=False)
 
         if self.page_to_add.in_active_bundle:
             text_list = get_text_list(
@@ -76,9 +77,9 @@ class AddToBundleView(FormView):
             messages.warning(request, f"Page '{admin_display_title}' is already in a bundle ('{text_list}')")
 
             if self.goto_next:
-                return redirect(self.goto_next)
+                return redirect(self.goto_next, preserve_request=False)
 
-            return redirect("wagtailadmin_home")
+            return redirect("wagtailadmin_home", preserve_request=False)
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -97,7 +98,7 @@ class AddToBundleView(FormView):
         )
         return context_data
 
-    def form_valid(self, form: AddToBundleForm) -> HttpResponseRedirect:
+    def form_valid(self, form: AddToBundleForm) -> HttpResponseRedirect | HttpResponsePermanentRedirect:
         bundle: Bundle = form.cleaned_data["bundle"]  # the 'bundle' field is required in the form.
         bundle.bundled_pages.add(BundlePage(page=self.page_to_add))
         bundle.save()
@@ -114,6 +115,6 @@ class AddToBundleView(FormView):
         )
         redirect_to = self.request.POST.get("next", "")
         if url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={self.request.get_host()}):
-            return redirect(redirect_to)
+            return redirect(redirect_to, preserve_request=False)
 
-        return redirect("wagtailadmin_explore", self.page_to_add.get_parent().id)
+        return redirect("wagtailadmin_explore", self.page_to_add.get_parent().id, preserve_request=False)

--- a/cms/bundles/views/preview.py
+++ b/cms/bundles/views/preview.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.generic import TemplateView
@@ -25,10 +25,11 @@ from cms.bundles.utils import (
     serialize_datasets_for_release_calendar_page,
 )
 from cms.core.fields import StreamField
+from cms.core.utils import redirect
 from cms.release_calendar.enums import ReleaseStatus
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest, HttpResponseRedirect
+    from django.http import HttpRequest, HttpResponsePermanentRedirect, HttpResponseRedirect
 
 
 class BundleContentsMixin:
@@ -251,7 +252,9 @@ class PreviewBundleDatasetView(BundleContentsMixin, TemplateView):
 
         return None
 
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> TemplateResponse | HttpResponseRedirect:
+    def get(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> TemplateResponse | HttpResponseRedirect | HttpResponsePermanentRedirect:
         bundle_id = kwargs["bundle_id"]
 
         if settings.DIS_DATASETS_BUNDLE_API_ENABLED is False:
@@ -259,7 +262,7 @@ class PreviewBundleDatasetView(BundleContentsMixin, TemplateView):
                 request,
                 "The Datasets Bundle API is not enabled. Cannot preview dataset.",
             )
-            return redirect("bundle:inspect", bundle_id)
+            return redirect("bundle:inspect", bundle_id, preserve_request=False)
 
         bundle = get_object_or_404(Bundle, pk=bundle_id)
 
@@ -282,7 +285,7 @@ class PreviewBundleDatasetView(BundleContentsMixin, TemplateView):
                 "could not be found in this bundle or does not have a preview available.",
             )
             # Return to the bundle inspect page if we cannot show a preview of the dataset
-            return redirect("bundle:inspect", bundle_id)
+            return redirect("bundle:inspect", bundle_id, preserve_request=False)
 
         # Build preview items for all pages and datasets in the bundle.
         # While the view is for previewing a dataset, we still want to show all

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -10,7 +10,6 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import F
 from django.http import HttpRequest
-from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -33,6 +32,7 @@ from cms.bundles.notifications.slack import (
 from cms.bundles.permissions import user_can_manage_bundles, user_can_preview_bundle
 from cms.bundles.utils import get_data_admin_action_url, publish_bundle
 from cms.core.custom_date_format import ons_date_format
+from cms.core.utils import redirect
 
 if TYPE_CHECKING:
     from django.db.models.fields import Field
@@ -136,7 +136,7 @@ class BundleEditView(EditView):
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
         if (instance := self.get_object()) and instance.status == BundleStatus.PUBLISHED:
-            return redirect(self.index_url_name)
+            return redirect(self.index_url_name, preserve_request=False)
 
         if request.method == "POST" and self.get_action(request) not in self.get_available_actions():
             # someone's trying to POST with an action that is not available, so bail out early
@@ -721,7 +721,7 @@ class BundleDeleteView(DeleteView):
             error = getattr(e, "message", str(e))
             error_message = f"The bundle could not be deleted due to errors. {error}."
             messages.error(self.request, error_message)
-            return redirect(reverse(self.index_url_name))
+            return redirect(reverse(self.index_url_name), preserve_request=False)
 
 
 class BundleIndexView(IndexView):

--- a/cms/private_media/views.py
+++ b/cms/private_media/views.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import FileResponse, Http404, HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.views.generic import View
 from wagtail.documents import get_document_model
@@ -15,10 +15,11 @@ from wagtail.images.models import SourceImageIOError
 from wagtail.images.permissions import permission_policy as image_permission_policy
 from wagtail.images.utils import verify_signature
 
+from cms.core.utils import redirect
 from cms.private_media.utils import user_can_access_asset
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest, HttpResponseBase, HttpResponseRedirect
+    from django.http import HttpRequest, HttpResponseBase, HttpResponsePermanentRedirect, HttpResponseRedirect
     from wagtail.documents.models import AbstractDocument
     from wagtail.images.models import AbstractImage, AbstractRendition
 
@@ -90,7 +91,7 @@ class ImageServeView(View):
         """
         return get_object_or_404(get_image_model(), id=image_id)
 
-    def redirect_to_file(self, url: str) -> HttpResponseRedirect:
+    def redirect_to_file(self, url: str) -> HttpResponseRedirect | HttpResponsePermanentRedirect:
         """Return a cachable temporary redirect to the requested file URL.
 
         The response is cached for 1 hour to reduce load on the web server.
@@ -98,7 +99,7 @@ class ImageServeView(View):
         URL (and other rendition URLs) will be submitted to the active
         edge-cache provider.
         """
-        response = redirect(url)
+        response = redirect(url, preserve_request=False)
         patch_cache_control(response, max_age=3600, public=True)
         return response
 
@@ -192,7 +193,7 @@ class DocumentServeView(View):
             raise Http404
         return obj
 
-    def redirect_to_file(self, url: str) -> HttpResponseRedirect:
+    def redirect_to_file(self, url: str) -> HttpResponseRedirect | HttpResponsePermanentRedirect:
         """Return a cachable temporary redirect to the file URL.
 
         The redirect response is cached for 1 hour to alleviate load on the
@@ -200,7 +201,7 @@ class DocumentServeView(View):
         purge request for this URL will be submitted to the active edge-cache
         provider.
         """
-        response = redirect(url, permanent=False)
+        response = redirect(url, preserve_request=False)
         patch_cache_control(response, max_age=3600, public=True)
         return response
 

--- a/cms/release_calendar/wagtail_hooks.py
+++ b/cms/release_calendar/wagtail_hooks.py
@@ -1,38 +1,38 @@
 from typing import TYPE_CHECKING
 
-from django.shortcuts import redirect
 from django.templatetags.static import static
 from django.utils.html import format_html
 from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.utils import get_valid_next_url_from_request
 
+from cms.core.utils import redirect
 from cms.release_calendar.models import ReleaseCalendarIndex, ReleaseCalendarPage
 from cms.release_calendar.viewsets import release_calendar_chooser_viewset
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest, HttpResponseRedirect
+    from django.http import HttpRequest, HttpResponsePermanentRedirect, HttpResponseRedirect
     from wagtail.models import Page
 
     from .viewsets import FutureReleaseCalendarPageChooserViewSet
 
 
 @hooks.register("before_delete_page")
-def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | None:
+def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | HttpResponsePermanentRedirect | None:
     """Block release calendar page deletion and show a message."""
     if page.specific_class == ReleaseCalendarPage:
         messages.warning(request, "Release Calendar pages cannot be deleted. You can mark them as cancelled instead.")
-        return redirect("wagtailadmin_pages:edit", page.pk)
+        return redirect("wagtailadmin_pages:edit", page.pk, preserve_request=False)
 
     if page.specific_class == ReleaseCalendarIndex:
         messages.warning(request, "The Release Calendar index cannot be deleted.")
 
         # redirect to a valid next url (passed via the 'next' query parameter)
         if next_url := get_valid_next_url_from_request(request):
-            return redirect(next_url)
+            return redirect(next_url, preserve_request=False)
 
         # default to the Wagtail dashboard.
-        return redirect("wagtailadmin_home")
+        return redirect("wagtailadmin_home", preserve_request=False)
 
     return None
 

--- a/cms/topics/wagtail_hooks.py
+++ b/cms/topics/wagtail_hooks.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.shortcuts import redirect
 from wagtail import hooks
 from wagtail.admin import messages
 
+from cms.core.utils import redirect
 from cms.themes.models import ThemePage
 
 from .models import TopicPage
@@ -54,5 +54,5 @@ def before_create_page(request: HttpRequest, page: Page) -> HttpResponse | None:
             request,
             "Topic and theme pages cannot be duplicated as selected taxonomy needs to be unique for each page.",
         )
-        return redirect("wagtailadmin_explore", page.get_parent().id)
+        return redirect("wagtailadmin_explore", page.get_parent().id, preserve_request=False)
     return None

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -52,6 +52,7 @@ if not settings.IS_EXTERNAL_ENV:
     ]
     if not settings.WAGTAIL_CORE_ADMIN_LOGIN_ENABLED:
         # Filter wagtail admin patterns to exclude /login and /password_reset
+        # These use a 301 as django RedirectView doesn't currently provide a preserve request option
         wagtail_admin_patterns += [
             path(
                 "login/",
@@ -67,6 +68,7 @@ if not settings.IS_EXTERNAL_ENV:
 
     if not settings.ALLOW_TEAM_MANAGEMENT and settings.AWS_COGNITO_TEAM_SYNC_ENABLED:
         # Redirect all preview teams pages to Florence groups when team sync is enabled
+        # These use a 301 as django RedirectView doesn't currently provide a preserve request option
         wagtail_admin_patterns += [
             re_path(
                 r"^teams/",

--- a/cms/workflows/views.py
+++ b/cms/workflows/views.py
@@ -2,21 +2,24 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from wagtail.admin import messages
 from wagtail.models import Page
 
+from cms.core.utils import redirect
 from cms.users.models import User
 from cms.workflows.models import ReadyToPublishGroupTask
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
-    from django.http.response import HttpResponseRedirect
+    from django.http.response import HttpResponsePermanentRedirect, HttpResponseRedirect
 
 
-def unlock(request: HttpRequest, page_id: int) -> TemplateResponse | HttpResponseRedirect:
+def unlock(
+    request: HttpRequest, page_id: int
+) -> TemplateResponse | HttpResponseRedirect | HttpResponsePermanentRedirect:
     page = get_object_or_404(Page, id=page_id)
     if not page.permissions_for_user(request.user).can_edit():
         raise PermissionDenied
@@ -39,7 +42,7 @@ def unlock(request: HttpRequest, page_id: int) -> TemplateResponse | HttpRespons
             page.current_workflow_task.on_action(page.current_workflow_task_state, user, "unlock")
             messages.success(request, "Page editing unlocked.")
 
-            return redirect(next_url)
+            return redirect(next_url, preserve_request=False)
 
     return TemplateResponse(
         request,

--- a/cms/workflows/wagtail_hooks.py
+++ b/cms/workflows/wagtail_hooks.py
@@ -2,7 +2,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.models import Permission
-from django.shortcuts import redirect
 from django.templatetags.static import static
 from django.urls import include, reverse
 from django.utils import timezone
@@ -12,6 +11,7 @@ from wagtail.admin import messages
 from wagtail.admin.action_menu import PageLockedMenuItem, WorkflowMenuItem
 
 from cms.bundles.utils import in_active_bundle, in_bundle_ready_to_be_published
+from cms.core.utils import redirect
 
 from . import admin_urls
 from .action_menu import SubmitForModerationMenuItem, UnlockWorkflowMenuItem
@@ -104,7 +104,7 @@ def before_edit_page_post_workflow_action_without_workflow(request: HttpRequest,
         and not page.current_workflow_task
     ):
         messages.error(request, "Could not perform the action as the page is no longer in a workflow.")
-        return redirect("wagtailadmin_pages:edit", page.pk)
+        return redirect("wagtailadmin_pages:edit", page.pk, preserve_request=False)
     return None
 
 
@@ -118,7 +118,7 @@ def before_edit_page(request: HttpRequest, page: Page) -> HttpResponse | None:
         or (request.POST.get("expire_at") and not page.expire_at)
     ):
         messages.error(request, "Cannot set page-level schedule while the page is in a bundle.")
-        return redirect("wagtailadmin_pages:edit", page.pk)
+        return redirect("wagtailadmin_pages:edit", page.pk, preserve_request=False)
 
     if request.POST.get("action-workflow-action") == "true":
         action_name = request.POST.get("workflow-action-name", "")
@@ -127,7 +127,7 @@ def before_edit_page(request: HttpRequest, page: Page) -> HttpResponse | None:
             messages.error(
                 request, "Cannot self-approve your changes. Please ask another Publishing team member to do so."
             )
-            return redirect("wagtailadmin_pages:edit", page.pk)
+            return redirect("wagtailadmin_pages:edit", page.pk, preserve_request=False)
 
         if action_name == "locked-approve" and is_page_ready_to_publish(page) and not in_active_bundle(page):
             # The page is "Ready to publish" and the edit form was POSTed with the ReadyToPublishGroupTask
@@ -154,7 +154,7 @@ def before_edit_page(request: HttpRequest, page: Page) -> HttpResponse | None:
             buttons.append(messages.button(reverse("wagtailadmin_pages:edit", args=(page.pk,)), "Edit"))
             messages.success(request, message, buttons=buttons)
 
-            return redirect("wagtailadmin_explore", page.get_parent().pk)
+            return redirect("wagtailadmin_explore", page.get_parent().pk, preserve_request=False)
 
     return None
 


### PR DESCRIPTION
### What is the context of this PR?

Replaces uses of django's redirect util with our own.

Sets `preserve_request=False` for cases where post requests redirect to get.

Adds a test for the case where a `StatisticalArticlePage` redirects to edition url, asserting the correct status code.

### How to review

Run tests to ensure they pass.

Run the app and check behaviour is correct for code paths affected by changes.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

NA
