### PR TITLE
fix: preserve request method on slash redirects

### DIFF
--- a/cms/core/middleware.py
+++ b/cms/core/middleware.py
@@ -35,7 +35,7 @@ class NonTrailingSlashRedirectMiddleware(MiddlewareMixin):
                 if query:
                     path_without_slash = f"{path_without_slash}?{query}"
 
-                url: HttpResponsePermanentRedirect = redirect(path_without_slash, permanent=True)  # type:ignore
+                url: HttpResponsePermanentRedirect = redirect(path_without_slash, permanent=True)  # type: ignore
                 return url
         return None
 

--- a/cms/core/middleware.py
+++ b/cms/core/middleware.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponsePermanentRedirect
 from django.utils.deprecation import MiddlewareMixin
 
+from cms.core.utils import redirect
+
 NON_TRAILING_SLASH_METHODS = {"GET", "HEAD"}
 
 ALLOWED_REQUEST_PATHS = {
@@ -32,7 +34,7 @@ class NonTrailingSlashRedirectMiddleware(MiddlewareMixin):
                 query = request.META.get("QUERY_STRING", "")
                 if query:
                     path_without_slash = f"{path_without_slash}?{query}"
-                return HttpResponsePermanentRedirect(path_without_slash)
+                return redirect(path_without_slash, permanent=True)
         return None
 
     def is_request_path_allowed(self, path: str) -> bool:

--- a/cms/core/middleware.py
+++ b/cms/core/middleware.py
@@ -34,7 +34,9 @@ class NonTrailingSlashRedirectMiddleware(MiddlewareMixin):
                 query = request.META.get("QUERY_STRING", "")
                 if query:
                     path_without_slash = f"{path_without_slash}?{query}"
-                return redirect(path_without_slash, permanent=True)
+
+                url: HttpResponsePermanentRedirect = redirect(path_without_slash, permanent=True)  # type:ignore
+                return url
         return None
 
     def is_request_path_allowed(self, path: str) -> bool:

--- a/cms/core/tests/test_middleware.py
+++ b/cms/core/tests/test_middleware.py
@@ -12,21 +12,21 @@ class TestNonTrailingSlashRedirectMiddleware(TestCase):
         """Test that URLs with trailing slash are redirected to non-trailing slash."""
         request = self.factory.get("/some-page/")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/some-page")
 
     def test_preserves_query_string(self):
         """Test that query parameters are preserved during redirection."""
         request = self.factory.get("/some-page/?foo=bar")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/some-page?foo=bar")
 
     def test_preserves_complex_query_string(self):
         """Test that complex query strings with multiple parameters are preserved."""
         request = self.factory.get("/some-page/?foo=bar&baz=qux&test=value")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/some-page?foo=bar&baz=qux&test=value")
 
     def test_ignores_root(self):
@@ -62,14 +62,14 @@ class TestNonTrailingSlashRedirectMiddleware(TestCase):
         """Test that nested paths with trailing slash are redirected correctly."""
         request = self.factory.get("/section/subsection/page/")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/section/subsection/page")
 
     def test_nested_paths_with_query_string(self):
         """Test that nested paths with trailing slash and query string are handled correctly."""
         request = self.factory.get("/section/subsection/page/?param=value")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/section/subsection/page?param=value")
 
     def test_empty_query_string_not_added(self):
@@ -78,7 +78,7 @@ class TestNonTrailingSlashRedirectMiddleware(TestCase):
         request = self.factory.get("/some-page/")
         request.META["QUERY_STRING"] = ""
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/some-page")
 
     def test_file_extension_with_trailing_slash_not_redirected(self):
@@ -93,14 +93,14 @@ class TestNonTrailingSlashRedirectMiddleware(TestCase):
         """Test that paths with special characters are handled correctly."""
         request = self.factory.get("/special-chars_%C3%A9_%C3%A1/")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/special-chars_%C3%A9_%C3%A1")
 
     def test_multiple_trailing_slashes(self):
         """Test that multiple trailing slashes are handled correctly."""
         request = self.factory.get("/some-page///")
         response = self.middleware.process_request(request)
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 308)
         self.assertEqual(response.url, "/some-page")
 
     def test_different_http_methods(self):
@@ -112,7 +112,7 @@ class TestNonTrailingSlashRedirectMiddleware(TestCase):
             with self.subTest(method=method):
                 request = getattr(self.factory, method.lower())("/test-page/")
                 response = self.middleware.process_request(request)
-                self.assertEqual(response.status_code, 301)
+                self.assertEqual(response.status_code, 308)
                 self.assertEqual(response.url, "/test-page")
 
         for method in unaffected_methods:

--- a/cms/core/tests/test_pages.py
+++ b/cms/core/tests/test_pages.py
@@ -288,12 +288,12 @@ class ErrorPageTests(TranslationResetMixin, WagtailPageTestCase):
             response.content.decode("utf-8"),
         )
 
-    def test_301_before_404_page(self):
-        """Test that a 301 redirect is returned before the 404 page is served when necessary."""
-        # The lack of a trailing slash on the URL should result in a 301 redirect,
+    def test_308_before_404_page(self):
+        """Test that a 308 redirect is returned before the 404 page is served when necessary."""
+        # The lack of a trailing slash on the URL should result in a 308 redirect,
         # even if the page does not exist.
         response = self.client.get("/non-existent-page-with-trailing-slash/")
-        self.assertEqual(response.status_code, HTTPStatus.MOVED_PERMANENTLY)
+        self.assertEqual(response.status_code, HTTPStatus.PERMANENT_REDIRECT)
 
         # Follow the redirect
         response = self.client.get(response["Location"])


### PR DESCRIPTION
### What is the context of this PR?

Updates the non-trailing slash redirect middleware to use the shared CMS redirect helper for permanent redirects, returning `308` instead of `301`.

### How to review

Go to a route with a trailing slash and observe that you now are redirected using 308 not 301.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
