### PR TITLE
Override translations for cookies page

### DIFF
--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-23 12:47+0100\n"
+"POT-Creation-Date: 2026-04-24 16:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,11 +368,11 @@ msgstr ""
 
 #: cms/jinja2/templates/pages/cookies.html:77
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 #: cms/jinja2/templates/pages/cookies.html:78
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: cms/jinja2/templates/pages/cookies.html:105
 msgid "Cookies that help with our communications and marketing"
@@ -791,11 +791,11 @@ msgstr "Cyhoeddiadau cysylltiedig"
 msgid "To be confirmed"
 msgstr "I’w gadarnhau"
 
-#: cms/settings/base.py:409
+#: cms/settings/base.py:411
 msgid "English"
 msgstr "Saesneg"
 
-#: cms/settings/base.py:410
+#: cms/settings/base.py:412
 msgid "Welsh"
 msgstr "Cymraeg"
 


### PR DESCRIPTION
### What is the context of this PR?

Adds a Welsh translation for Yes/No, using English so that when the language is toggled, it is not translated. Currently, it is still translated because those simple strings are still in the compiled Django package translations.

This approach was taken since those strings are not used elsewhere. The other option is to not mark them for translation in cookies.html.

Adding tests didn't seem worthwhile, given they will be fully translated in the near future.

### How to review

1. On `main` run `make compilemessages` then switch language on the cookies page and verify Yes/No is in Welsh
2. Switch to this branch, run `make compilemessages` and verify it is in English
3. Verify there are no other cases like this on the cookies page.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
