### PR TITLE
Show last publish date for aliases that where published from a draft on their `alias_of` page

### DIFF
--- a/cms/core/migrations/0016_backfill_alias_last_published_at.py
+++ b/cms/core/migrations/0016_backfill_alias_last_published_at.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def backfill_alias_last_published_at(apps, schema_editor):
+    Page = apps.get_model("wagtailcore.Page")
+    aliases = Page.objects.filter(alias_of__isnull=False, last_published_at__isnull=True).select_related("alias_of")
+    to_update = []
+    for alias in aliases:
+        if alias.alias_of.last_published_at:
+            alias.last_published_at = alias.alias_of.last_published_at
+            to_update.append(alias)
+    Page.objects.bulk_update(to_update, ["last_published_at"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0015_delete_existing_page_view_restrictions"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_alias_last_published_at, reverse_code=migrations.RunPython.noop),
+    ]

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -6,7 +6,7 @@ from django.core.signals import setting_changed
 from django.db.models.signals import pre_save
 from django.utils.log import configure_logging
 from wagtail.models import DraftStateMixin, Locale, Page, Revision
-from wagtail.signals import page_slug_changed
+from wagtail.signals import page_published, page_slug_changed
 
 # Tree depth of the home page
 HOME_PAGE_DEPTH = 2
@@ -64,6 +64,22 @@ def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> 
         translation.save()
 
 
+def sync_alias_last_published_at(sender: Any, instance: Page, alias: bool = False, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    # Only handle alias publish events where last_published_at wasn't carried over from the revision
+    if not alias or instance.last_published_at is not None:
+        return
+
+    # Wagtail populates the alias via the stored revision content, which predates the publish and
+    # has last_published_at=None. Fetch the value directly from the source page and backfill it.
+    source_last_published_at = (
+        Page.objects.filter(pk=instance.alias_of_id).values_list("last_published_at", flat=True).first()
+    )
+
+    if source_last_published_at:
+        Page.objects.filter(pk=instance.pk).update(last_published_at=source_last_published_at)
+        instance.last_published_at = source_last_published_at
+
+
 def register_signal_handlers() -> None:
     for model in apps.get_models():
         if issubclass(model, DraftStateMixin):
@@ -72,5 +88,6 @@ def register_signal_handlers() -> None:
     pre_save.connect(remove_approved_go_live_seconds, sender=Revision)
 
     page_slug_changed.connect(sync_alias_translation_slugs)
+    page_published.connect(sync_alias_last_published_at)
 
     setting_changed.connect(reload_logging_config)

--- a/cms/standard_pages/tests/test_models.py
+++ b/cms/standard_pages/tests/test_models.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from wagtail.coreutils import get_dummy_request
+from wagtail.models import Locale
 from wagtail.rich_text import RichText
 from wagtail.test.utils import WagtailTestUtils
 
@@ -475,3 +476,26 @@ class InformationPageCSVDownloadTestCase(WagtailTestUtils, TestCase):
         response = self.client.get(f"{self.page.url}/download-table/nonexistent-id")
 
         self.assertEqual(response.status_code, 404)
+
+
+class InformationPageAliasLastPublishedAtTestCase(WagtailTestUtils, TestCase):
+    """Regression tests for alias last_published_at sync on publish."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cy_locale = Locale.objects.get(language_code="cy")
+
+    def test_alias_last_published_at_is_set_when_source_page_was_drafted_before_first_publish(self):
+        en_page = InformationPageFactory(live=False)
+        cy_alias = en_page.copy_for_translation(locale=self.cy_locale, copy_parents=True, alias=True)
+
+        self.assertIsNone(cy_alias.last_published_at)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            en_page.save_revision().publish()
+
+        en_page.refresh_from_db()
+        cy_alias.refresh_from_db()
+
+        self.assertIsNotNone(cy_alias.last_published_at)
+        self.assertEqual(cy_alias.last_published_at, en_page.last_published_at)


### PR DESCRIPTION
### What is the context of this PR?

Ticket [CMS-1206](https://officefornationalstatistics.atlassian.net/browse/CMS-1206)

Fixes a bug where a Welsh alias of an InformationPage shows "Populated on publish" instead of  the actual publication date when the source English page was saved as a draft before its first publish.

#### Root cause

This looks like a limitation of default Wagtail behaviour. When a page is published, Wagtail calls update_aliases() to sync content to alias pages. It passes the stored revision content as the data source [ref](https://github.com/wagtail/wagtail/blob/136e2f65957314f26bd2632adec08fe5ef9a1e25/wagtail/actions/publish_page_revision.py#L62):

```python
  self.object.update_aliases(revision=self.revision, _content=self.revision.content)
```

That revision was created at save_revision() time (before the page was published) so `last_published_at` in the snapshot is None. Inside update_aliases(), Wagtail explicitly re-syncs `latest_revision_created_at` on the alias but never does the same for last_published_at see [wagtail code](https://github.com/wagtail/wagtail/blob/ccf5b8221b486faca71cb1eba81de130f9da98fe/wagtail/models/pages.py#L1183).

```python
  alias_updated.latest_revision_created_at = self.latest_revision_created_at
  # last_published_at is not synced — it comes from the revision snapshot (None)
  alias_updated.save(clean=False)
```
The alias is saved with last_published_at=None, causing the template to fall back to "Populated on publish".

#### Fix

I've added new page_published signal handler (sync_alias_last_published_at) that fires when alias=True and last_published_at is None on the alias. It fetches last_published_at directly from the source page and writes it back via a targeted UPDATE.

### How to review

  1. Create a new InformationPage under an IndexPage
  2. Save it as a draft (do not publish immediately)
  3. Publish the page
  4. Navigate to the Welsh alias of the page
  5. Verify the page shows the correct publication date rather than "Populated on publish"
  6. Repeat steps 1–5 but publish the page via a bundle to confirm the bundle flow is also covered

You should see the welsh page with the correct date:

<img width="486" height="184" alt="image" src="https://github.com/user-attachments/assets/c1b60080-76ba-404d-ad45-04790c3348d3" />


### Deployment Safety

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

From what I can tell, the underlying issue is in Wagtail core (update_aliases not syncing last_published_at). It might be worth raising as a bug so it can be fixed properly rather than worked around via this signal handler.
