### PR TITLE
Ensure live pages with non published revisions are published by a bundle publish

### DIFF
--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -111,7 +111,7 @@ class PublishBundlesCommandTestCase(TestCase):
 
         # Check that we have a log entry
         self.assertEqual(ModelLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 1)
-        self.assertEqual(PageLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 2)
+        self.assertEqual(PageLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 3)
 
     @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
     @patch("cms.bundles.notifications.slack.notify_slack_of_publication_start")
@@ -193,6 +193,67 @@ class PublishBundlesCommandTestCase(TestCase):
         self.assertEqual(release_page.datasets[0].value, bundle_dataset_a.dataset)
         self.assertEqual(release_page.datasets[1].value, bundle_dataset_b.dataset)
         self.assertEqual(release_page.datasets[2].value, bundle_dataset_c.dataset)
+
+    def test_publish_bundle_with_revisions_to_live_page(self):
+        """Test publishing a bundle containing a live page with unpublished revisions updates page."""
+        # Ensure the page is live
+        self.statistical_article.publish(self.statistical_article.get_latest_revision())
+        self.statistical_article.refresh_from_db()
+        self.assertTrue(self.statistical_article.live)
+
+        # Create a new revision (it will be in draft)
+        self.statistical_article.title = "Updated Title"
+        new_revision = self.statistical_article.save_revision()
+
+        # Assertions before call_command
+        self.statistical_article.refresh_from_db()
+        self.assertNotEqual(self.statistical_article.live_revision, new_revision)
+        self.assertEqual(self.statistical_article.get_latest_revision(), new_revision)
+        self.assertNotEqual(self.statistical_article.title, "Updated Title")
+
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+
+        self.call_command()
+
+        # Assertions after call_command
+        self.statistical_article.refresh_from_db()
+        self.assertEqual(self.statistical_article.live_revision, new_revision)
+        self.assertTrue(self.statistical_article.live)
+        self.assertEqual(self.statistical_article.title, "Updated Title")
+
+    @patch("cms.bundles.utils.logger")
+    def test_publish_bundle_with_no_successful_page_publishes(self, mock_utils_logger):
+        """Test that the bundle status is not updated if no pages were successfully published."""
+        # Create a page that will fail to publish (no revisions)
+        page_with_no_revisions = StatisticalArticlePageFactory(live=False)
+        page_with_no_revisions.revisions.all().delete()
+
+        BundlePageFactory(parent=self.bundle, page=page_with_no_revisions)
+
+        self.call_command()
+
+        # Check bundle status wasn't changed
+        self.bundle.refresh_from_db()
+        self.assertEqual(self.bundle.status, BundleStatus.APPROVED)
+
+        # Check error was logged in utils
+        mock_utils_logger.error.assert_any_call(
+            "No pages were successfully published",
+            extra={
+                "bundle_id": self.bundle.pk,
+                "event": "publish_failed_no_success",
+            },
+        )
+
+    def test_publish_bundle_with_zero_pages(self):
+        """Test that a bundle with zero pages is not marked as published."""
+        self.assertEqual(self.bundle.bundled_pages.count(), 0)
+
+        self.call_command()
+
+        # Check bundle status wasn't changed
+        self.bundle.refresh_from_db()
+        self.assertEqual(self.bundle.status, BundleStatus.APPROVED)
 
     def test_publish_bundle_with_welsh_release_calendar(self):
         """Test publishing a bundle with a Welsh release calendar page uses Welsh translations."""

--- a/cms/bundles/tests/test_signal_handlers.py
+++ b/cms/bundles/tests/test_signal_handlers.py
@@ -81,6 +81,9 @@ class TestNotifications(TestCase):
         # NB: Scheduled bundles are published using the management command.
 
         bundle = BundleFactory(approved=True, name="Approved Bundle")
+        page = StatisticalArticlePageFactory()
+        page.save_revision()
+        BundlePageFactory(parent=bundle, page=page)
         bundle.publication_date = timezone.now() - timedelta(days=1)
         bundle.save()
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -408,6 +408,8 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
     notifications.notify_slack_of_publication_start(bundle, url=bundle.full_inspect_url)
 
     failed_page_publishes: list[int] = []
+    # This tracks if no pages are published to enable logging in the event we have
+    # another regression in publishing logic
     successful_page_publishes = 0
 
     for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision"):

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -138,11 +138,21 @@ def _create_content_dict_for_pages(
     if article_pages:
         # NB: This string needs to match the one at the top of the file
         title = get_translated_string("Publications", language_code)
-        content.append({"type": "release_content", "value": {"title": title, "links": article_pages}})
+        content.append(
+            {
+                "type": "release_content",
+                "value": {"title": title, "links": article_pages},
+            }
+        )
     if methodology_pages:
         # NB: This string needs to match the one at the top of the file
         title = get_translated_string("Quality and methodology", language_code)
-        content.append({"type": "release_content", "value": {"title": title, "links": methodology_pages}})
+        content.append(
+            {
+                "type": "release_content",
+                "value": {"title": title, "links": methodology_pages},
+            }
+        )
     return content
 
 
@@ -168,7 +178,7 @@ def serialize_preview_page(page: Page, bundle_id: int, is_previewable: bool) -> 
             "page": None,
             "title": f"{specific_page.title} ({state})",
             "description": getattr(specific_page, "summary", ""),
-            "external_url": reverse("bundles:preview", args=[bundle_id, page.pk]) if is_previewable else "#",
+            "external_url": (reverse("bundles:preview", args=[bundle_id, page.pk]) if is_previewable else "#"),
         },
     }
 
@@ -223,7 +233,9 @@ def serialize_bundle_content_for_preview_release_calendar_page(
     return _create_content_dict_for_pages(all_pages, language_code)
 
 
-def serialize_datasets_for_release_calendar_page(bundle: Bundle) -> list[dict[str, Any]]:
+def serialize_datasets_for_release_calendar_page(
+    bundle: Bundle,
+) -> list[dict[str, Any]]:
     """Serializes the datasets of a bundle for a release calendar page."""
     return [
         {"type": "dataset_lookup", "id": uuid.uuid4(), "value": dataset["dataset"]}
@@ -381,7 +393,8 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
     """
     # using this rather than inline import to placate pyright complaining about cyclic imports
     notifications = __import__(
-        "cms.bundles.notifications.slack", fromlist=["notify_slack_of_publication_start", "notify_slack_of_publish_end"]
+        "cms.bundles.notifications.slack",
+        fromlist=["notify_slack_of_publication_start", "notify_slack_of_publish_end"],
     )
 
     logger.info(
@@ -395,8 +408,9 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
     notifications.notify_slack_of_publication_start(bundle, url=bundle.full_inspect_url)
 
     failed_page_publishes: list[int] = []
+    successful_page_publishes = 0
 
-    for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision").not_live():
+    for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision"):
         try:
             # Durable ensures no other savepoint will roll back the publish
             with transaction.atomic(durable=True):
@@ -415,16 +429,30 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
                             "event": "publish_page_failed",
                         },
                     )
+                    continue
+                successful_page_publishes += 1
         except Exception:  # pylint: disable=broad-exception-caught
             # Log exception, but don't raise it so publishing can continue
-            logger.exception("Page publish failed", extra={"bundle_id": bundle.pk, "page_id": page.pk})
+            logger.exception(
+                "Page publish failed",
+                extra={"bundle_id": bundle.pk, "page_id": page.pk},
+            )
             failed_page_publishes.append(page.pk)
 
     # update and publish related release calendar
     if bundle.release_calendar_page_id:
         update_bundle_linked_release_calendar_page(bundle)
 
-    if not failed_page_publishes:
+    if successful_page_publishes == 0:
+        logger.error(
+            "No pages were successfully published",
+            extra={
+                "bundle_id": bundle.pk,
+                "event": "publish_failed_no_success",
+            },
+        )
+
+    if not failed_page_publishes and successful_page_publishes > 0:
         if update_status:
             bundle.status = BundleStatus.PUBLISHED
             bundle.save(update_fields=["status"])
@@ -453,7 +481,10 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         )
 
     notifications.notify_slack_of_publish_end(
-        bundle, publish_duration, url=bundle.full_inspect_url, successful=not failed_page_publishes
+        bundle,
+        publish_duration,
+        url=bundle.full_inspect_url,
+        successful=not failed_page_publishes,
     )
 
     return bool(failed_page_publishes)
@@ -505,7 +536,10 @@ def extract_content_id_from_bundle_response(response: dict[str, Any], dataset: A
 
 
 def get_data_admin_action_url(
-    action: Literal["edit", "preview"], dataset_id: str, edition_id: str, version_id: str
+    action: Literal["edit", "preview"],
+    dataset_id: str,
+    edition_id: str,
+    version_id: str,
 ) -> str:
     """Generate a relative URL for dataset actions in the ONS Data Admin interface.
 


### PR DESCRIPTION
### What is the context of this PR?

Addresses CMS-1209

Logic around bundle publishing changed at some point that prevented pages that were live but with new revisions being published when a bundle was published.

This PR ensures that revisions to already live pages are published as part of a bundle, and adds a regression test for the cases where they are not. It also adds logging for cases where zero pages are published as part of a bundle with tests.

### How to review

1. Publish a page
2. Create a draft revision of the page
3. Add to a bundle
4. Publish the bundle
5. Ensure the new changes were published, and not ignored

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions


