### PR TITLE
chore(i18n): localise Back to top link

### DIFF
--- a/cms/jinja2/templates/base_page.html
+++ b/cms/jinja2/templates/base_page.html
@@ -1,6 +1,8 @@
 {% extends "templates/base.html" %}
 {% from "components/back-to-top/_macro.njk" import onsBackToTop %}
 
+{%- set back_to_top = _('Back to top') -%}
+
 {% block meta %}
     {{ super() }}
     {% if page %}
@@ -108,7 +110,12 @@
                             </h1>
                         {% endif %}
                         {% block main %}{% endblock %}
-                        {{ onsBackToTop() }}{# used in small viewports #}
+                        {# used in small viewports #}
+                        {# fmt:off #}
+                        {{ onsBackToTop({
+                            "description": back_to_top,
+                        }) }}
+                        {# fmt:on #}
                     </div>
                 </div>
             </div>

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -176,7 +176,7 @@ msgstr ", ac eithrio lle y nodir fel arall"
 
 #: cms/jinja2/templates/base_page.html:4
 msgid "Back to top"
-msgstr "Yn ôl i'r brig"
+msgstr "Nôl i’r brig"
 
 #: cms/jinja2/templates/base_page.html:63
 msgid "in English"

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 16:26+0100\n"
+"POT-Creation-Date: 2026-05-01 07:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -174,15 +174,19 @@ msgstr "Mae’r holl gynnwys ar gael o dan y"
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
 
-#: cms/jinja2/templates/base_page.html:61
+#: cms/jinja2/templates/base_page.html:4
+msgid "Back to top"
+msgstr "Yn ôl i'r brig"
+
+#: cms/jinja2/templates/base_page.html:63
 msgid "in English"
 msgstr "yn Saesneg"
 
-#: cms/jinja2/templates/base_page.html:62
+#: cms/jinja2/templates/base_page.html:64
 msgid "in Welsh"
 msgstr "yn y Gymraeg"
 
-#: cms/jinja2/templates/base_page.html:69
+#: cms/jinja2/templates/base_page.html:71
 #, python-format
 msgid ""
 "This page is currently not available %(in_language)s. It is displayed in its "


### PR DESCRIPTION
### What is the context of this PR?

Adds the translated description for the back-to-top component in `base_page.html` so it uses the locale catalogue rather than the default English text.

### How to review

Verify the Welsh locale shows the translated Back to top link (Scroll to bottom on small viewport)

No tests since we don't validate translations.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
