### PR TITLE
Merge fixes from v1.1.3 back into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [main]
+    branches: [main, 'release/v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
 
 concurrency:
   group: '${{ github.head_ref || github.ref }}-${{ github.workflow }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,10 +9,10 @@ name: CodeQL
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [main]
+    branches: [main, 'release/v*']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main]
+    branches: [main, 'release/v*']
 
   schedule:
     # Run on a daily interval at 12pm UTC

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -5,9 +5,9 @@ name: Lychee
 # Pull Requests to main
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [main]
+    branches: [main, 'release/v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
 
 concurrency:
   group: '${{ github.head_ref || github.ref }}-${{ github.workflow }}'

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -7,9 +7,9 @@ name: MegaLinter
 # Pull Requests to main
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [main]
+    branches: [main, 'release/v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
 
 # Comment env block if you do not want to apply fixes
 env:

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -111,7 +111,7 @@ class PublishBundlesCommandTestCase(TestCase):
 
         # Check that we have a log entry
         self.assertEqual(ModelLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 1)
-        self.assertEqual(PageLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 2)
+        self.assertEqual(PageLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 3)
 
     @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
     @patch("cms.bundles.notifications.slack.notify_slack_of_publication_start")
@@ -193,6 +193,67 @@ class PublishBundlesCommandTestCase(TestCase):
         self.assertEqual(release_page.datasets[0].value, bundle_dataset_a.dataset)
         self.assertEqual(release_page.datasets[1].value, bundle_dataset_b.dataset)
         self.assertEqual(release_page.datasets[2].value, bundle_dataset_c.dataset)
+
+    def test_publish_bundle_with_revisions_to_live_page(self):
+        """Test publishing a bundle containing a live page with unpublished revisions updates page."""
+        # Ensure the page is live
+        self.statistical_article.publish(self.statistical_article.get_latest_revision())
+        self.statistical_article.refresh_from_db()
+        self.assertTrue(self.statistical_article.live)
+
+        # Create a new revision (it will be in draft)
+        self.statistical_article.title = "Updated Title"
+        new_revision = self.statistical_article.save_revision()
+
+        # Assertions before call_command
+        self.statistical_article.refresh_from_db()
+        self.assertNotEqual(self.statistical_article.live_revision, new_revision)
+        self.assertEqual(self.statistical_article.get_latest_revision(), new_revision)
+        self.assertNotEqual(self.statistical_article.title, "Updated Title")
+
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+
+        self.call_command()
+
+        # Assertions after call_command
+        self.statistical_article.refresh_from_db()
+        self.assertEqual(self.statistical_article.live_revision, new_revision)
+        self.assertTrue(self.statistical_article.live)
+        self.assertEqual(self.statistical_article.title, "Updated Title")
+
+    @patch("cms.bundles.utils.logger")
+    def test_publish_bundle_with_no_successful_page_publishes(self, mock_utils_logger):
+        """Test that the bundle status is not updated if no pages were successfully published."""
+        # Create a page that will fail to publish (no revisions)
+        page_with_no_revisions = StatisticalArticlePageFactory(live=False)
+        page_with_no_revisions.revisions.all().delete()
+
+        BundlePageFactory(parent=self.bundle, page=page_with_no_revisions)
+
+        self.call_command()
+
+        # Check bundle status wasn't changed
+        self.bundle.refresh_from_db()
+        self.assertEqual(self.bundle.status, BundleStatus.APPROVED)
+
+        # Check error was logged in utils
+        mock_utils_logger.error.assert_any_call(
+            "No pages were successfully published",
+            extra={
+                "bundle_id": self.bundle.pk,
+                "event": "publish_failed_no_success",
+            },
+        )
+
+    def test_publish_bundle_with_zero_pages(self):
+        """Test that a bundle with zero pages is not marked as published."""
+        self.assertEqual(self.bundle.bundled_pages.count(), 0)
+
+        self.call_command()
+
+        # Check bundle status wasn't changed
+        self.bundle.refresh_from_db()
+        self.assertEqual(self.bundle.status, BundleStatus.APPROVED)
 
     def test_publish_bundle_with_welsh_release_calendar(self):
         """Test publishing a bundle with a Welsh release calendar page uses Welsh translations."""

--- a/cms/bundles/tests/test_signal_handlers.py
+++ b/cms/bundles/tests/test_signal_handlers.py
@@ -81,6 +81,9 @@ class TestNotifications(TestCase):
         # NB: Scheduled bundles are published using the management command.
 
         bundle = BundleFactory(approved=True, name="Approved Bundle")
+        page = StatisticalArticlePageFactory()
+        page.save_revision()
+        BundlePageFactory(parent=bundle, page=page)
         bundle.publication_date = timezone.now() - timedelta(days=1)
         bundle.save()
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -138,11 +138,21 @@ def _create_content_dict_for_pages(
     if article_pages:
         # NB: This string needs to match the one at the top of the file
         title = get_translated_string("Publications", language_code)
-        content.append({"type": "release_content", "value": {"title": title, "links": article_pages}})
+        content.append(
+            {
+                "type": "release_content",
+                "value": {"title": title, "links": article_pages},
+            }
+        )
     if methodology_pages:
         # NB: This string needs to match the one at the top of the file
         title = get_translated_string("Quality and methodology", language_code)
-        content.append({"type": "release_content", "value": {"title": title, "links": methodology_pages}})
+        content.append(
+            {
+                "type": "release_content",
+                "value": {"title": title, "links": methodology_pages},
+            }
+        )
     return content
 
 
@@ -168,7 +178,7 @@ def serialize_preview_page(page: Page, bundle_id: int, is_previewable: bool) -> 
             "page": None,
             "title": f"{specific_page.title} ({state})",
             "description": getattr(specific_page, "summary", ""),
-            "external_url": reverse("bundles:preview", args=[bundle_id, page.pk]) if is_previewable else "#",
+            "external_url": (reverse("bundles:preview", args=[bundle_id, page.pk]) if is_previewable else "#"),
         },
     }
 
@@ -223,7 +233,9 @@ def serialize_bundle_content_for_preview_release_calendar_page(
     return _create_content_dict_for_pages(all_pages, language_code)
 
 
-def serialize_datasets_for_release_calendar_page(bundle: Bundle) -> list[dict[str, Any]]:
+def serialize_datasets_for_release_calendar_page(
+    bundle: Bundle,
+) -> list[dict[str, Any]]:
     """Serializes the datasets of a bundle for a release calendar page."""
     return [
         {"type": "dataset_lookup", "id": uuid.uuid4(), "value": dataset["dataset"]}
@@ -381,7 +393,8 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
     """
     # using this rather than inline import to placate pyright complaining about cyclic imports
     notifications = __import__(
-        "cms.bundles.notifications.slack", fromlist=["notify_slack_of_publication_start", "notify_slack_of_publish_end"]
+        "cms.bundles.notifications.slack",
+        fromlist=["notify_slack_of_publication_start", "notify_slack_of_publish_end"],
     )
 
     logger.info(
@@ -395,8 +408,11 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
     notifications.notify_slack_of_publication_start(bundle, url=bundle.full_inspect_url)
 
     failed_page_publishes: list[int] = []
+    # This tracks if no pages are published to enable logging in the event we have
+    # another regression in publishing logic
+    successful_page_publishes = 0
 
-    for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision").not_live():
+    for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision"):
         try:
             # Durable ensures no other savepoint will roll back the publish
             with transaction.atomic(durable=True):
@@ -415,16 +431,30 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
                             "event": "publish_page_failed",
                         },
                     )
+                    continue
+                successful_page_publishes += 1
         except Exception:  # pylint: disable=broad-exception-caught
             # Log exception, but don't raise it so publishing can continue
-            logger.exception("Page publish failed", extra={"bundle_id": bundle.pk, "page_id": page.pk})
+            logger.exception(
+                "Page publish failed",
+                extra={"bundle_id": bundle.pk, "page_id": page.pk},
+            )
             failed_page_publishes.append(page.pk)
 
     # update and publish related release calendar
     if bundle.release_calendar_page_id:
         update_bundle_linked_release_calendar_page(bundle)
 
-    if not failed_page_publishes:
+    if successful_page_publishes == 0:
+        logger.error(
+            "No pages were successfully published",
+            extra={
+                "bundle_id": bundle.pk,
+                "event": "publish_failed_no_success",
+            },
+        )
+
+    if not failed_page_publishes and successful_page_publishes > 0:
         if update_status:
             bundle.status = BundleStatus.PUBLISHED
             bundle.save(update_fields=["status"])
@@ -453,7 +483,10 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         )
 
     notifications.notify_slack_of_publish_end(
-        bundle, publish_duration, url=bundle.full_inspect_url, successful=not failed_page_publishes
+        bundle,
+        publish_duration,
+        url=bundle.full_inspect_url,
+        successful=not failed_page_publishes,
     )
 
     return bool(failed_page_publishes)
@@ -505,7 +538,10 @@ def extract_content_id_from_bundle_response(response: dict[str, Any], dataset: A
 
 
 def get_data_admin_action_url(
-    action: Literal["edit", "preview"], dataset_id: str, edition_id: str, version_id: str
+    action: Literal["edit", "preview"],
+    dataset_id: str,
+    edition_id: str,
+    version_id: str,
 ) -> str:
     """Generate a relative URL for dataset actions in the ONS Data Admin interface.
 

--- a/cms/core/migrations/0016_backfill_alias_last_published_at.py
+++ b/cms/core/migrations/0016_backfill_alias_last_published_at.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def backfill_alias_last_published_at(apps, schema_editor):
+    Page = apps.get_model("wagtailcore.Page")
+    aliases = Page.objects.filter(alias_of__isnull=False, last_published_at__isnull=True).select_related("alias_of")
+    to_update = []
+    for alias in aliases:
+        if alias.alias_of.last_published_at:
+            alias.last_published_at = alias.alias_of.last_published_at
+            to_update.append(alias)
+    Page.objects.bulk_update(to_update, ["last_published_at"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0015_delete_existing_page_view_restrictions"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_alias_last_published_at, reverse_code=migrations.RunPython.noop),
+    ]

--- a/cms/core/signal_handlers.py
+++ b/cms/core/signal_handlers.py
@@ -6,7 +6,7 @@ from django.core.signals import setting_changed
 from django.db.models.signals import pre_save
 from django.utils.log import configure_logging
 from wagtail.models import DraftStateMixin, Locale, Page, Revision
-from wagtail.signals import page_slug_changed
+from wagtail.signals import page_published, page_slug_changed
 
 # Tree depth of the home page
 HOME_PAGE_DEPTH = 2
@@ -64,6 +64,22 @@ def sync_alias_translation_slugs(sender: Any, instance: Page, **kwargs: Any) -> 
         translation.save()
 
 
+def sync_alias_last_published_at(sender: Any, instance: Page, alias: bool = False, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    # Only handle alias publish events where last_published_at wasn't carried over from the revision
+    if not alias or instance.last_published_at is not None:
+        return
+
+    # Wagtail populates the alias via the stored revision content, which predates the publish and
+    # has last_published_at=None. Fetch the value directly from the source page and backfill it.
+    source_last_published_at = (
+        Page.objects.filter(pk=instance.alias_of_id).values_list("last_published_at", flat=True).first()
+    )
+
+    if source_last_published_at:
+        Page.objects.filter(pk=instance.pk).update(last_published_at=source_last_published_at)
+        instance.last_published_at = source_last_published_at
+
+
 def register_signal_handlers() -> None:
     for model in apps.get_models():
         if issubclass(model, DraftStateMixin):
@@ -72,5 +88,6 @@ def register_signal_handlers() -> None:
     pre_save.connect(remove_approved_go_live_seconds, sender=Revision)
 
     page_slug_changed.connect(sync_alias_translation_slugs)
+    page_published.connect(sync_alias_last_published_at)
 
     setting_changed.connect(reload_logging_config)

--- a/cms/standard_pages/tests/test_models.py
+++ b/cms/standard_pages/tests/test_models.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from wagtail.coreutils import get_dummy_request
+from wagtail.models import Locale
 from wagtail.rich_text import RichText
 from wagtail.test.utils import WagtailTestUtils
 
@@ -475,3 +476,26 @@ class InformationPageCSVDownloadTestCase(WagtailTestUtils, TestCase):
         response = self.client.get(f"{self.page.url}/download-table/nonexistent-id")
 
         self.assertEqual(response.status_code, 404)
+
+
+class InformationPageAliasLastPublishedAtTestCase(WagtailTestUtils, TestCase):
+    """Regression tests for alias last_published_at sync on publish."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cy_locale = Locale.objects.get(language_code="cy")
+
+    def test_alias_last_published_at_is_set_when_source_page_was_drafted_before_first_publish(self):
+        en_page = InformationPageFactory(live=False)
+        cy_alias = en_page.copy_for_translation(locale=self.cy_locale, copy_parents=True, alias=True)
+
+        self.assertIsNone(cy_alias.last_published_at)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            en_page.save_revision().publish()
+
+        en_page.refresh_from_db()
+        cy_alias.refresh_from_db()
+
+        self.assertIsNotNone(cy_alias.last_published_at)
+        self.assertEqual(cy_alias.last_published_at, en_page.last_published_at)


### PR DESCRIPTION
### What is the context of this PR?

Hotfix PRs https://github.com/ONSdigital/dis-wagtail/pull/614 and https://github.com/ONSdigital/dis-wagtail/pull/612 were deployed directly to release branches, this merges them back into main for development work.

#### Todo

- [x] Merge https://github.com/ONSdigital/dis-wagtail/pull/614

### How to review


### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy



### Follow-up Actions

