### PR TITLE
Fixes manually published bundle setting unknown approval data

### DIFF
--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -331,6 +331,10 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
             if submitted_status == BundleStatus.APPROVED:
                 cleaned_data["approved_at"] = timezone.now()
                 cleaned_data["approved_by"] = self.for_user
+            elif submitted_status == BundleStatus.PUBLISHED:
+                if not self.instance.approved_by_id:
+                    cleaned_data["approved_at"] = timezone.now()
+                    cleaned_data["approved_by"] = self.for_user
             elif self.instance.status == BundleStatus.APPROVED:
                 # the bundle was approved, and is now unapproved.
                 cleaned_data["approved_at"] = None

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -375,12 +375,7 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseBase):
         self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
 
     def test_bundle_edit_view__manual_publish__sets_approved_by_and_approved_at(self):
-        """Publishing directly should populate approved_by and approved_at.
-
-        When a Publishing Admin publishes a bundle directly (without a separate approval step),
-        the approved_by and approved_at fields are not set, causing the inspect view to show
-        'Unknown approval data' instead of the publisher's name and timestamp.
-        """
+        """Publishing directly should populate approved_by and approved_at."""
         self.bundle.status = BundleStatus.APPROVED
         self.bundle.save(update_fields=["status"])
         self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
@@ -847,22 +842,6 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
         self.assertContains(response, "1 July 2025 1:37pm")
         self.assertContains(response, "1 July 2025 1:45pm")
         self.assertContains(response, "1 July 2025 2:00pm")
-
-    def test_inspect_view__approval_status__shows_unknown_when_published_directly(self):
-        """Inspect view shows 'Unknown approval data' when a bundle is published directly.
-
-        When a Publishing Admin publishes without a separate approval step, approved_by
-        and approved_at are never set, causing the inspect view to display
-        'Unknown approval data' rather than the publisher's details.
-        """
-        self.bundle.status = BundleStatus.PUBLISHED
-        self.bundle.approved_by = None
-        self.bundle.approved_at = None
-        self.bundle.save(update_fields=["status", "approved_by", "approved_at"])
-
-        response = self.client.get(reverse("bundle:inspect", args=[self.bundle.pk]))
-
-        self.assertNotContains(response, "Unknown approval data")
 
     def test_inspect_view__shows_bundle_api_bundle_id_when_exists(self):
         # Ensure the bundle has "bundle_api_bundle_id" set

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -374,6 +374,21 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseBase):
         self.bundle.save(update_fields=["status"])
         self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
 
+    def test_bundle_edit_view__manual_publish__sets_approved_by_and_approved_at(self):
+        """Publishing directly should populate approved_by and approved_at.
+
+        When a Publishing Admin publishes a bundle directly (without a separate approval step),
+        the approved_by and approved_at fields are not set, causing the inspect view to show
+        'Unknown approval data' instead of the publisher's name and timestamp.
+        """
+        self.bundle.status = BundleStatus.APPROVED
+        self.bundle.save(update_fields=["status"])
+        self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
+
+        self.bundle.refresh_from_db()
+        self.assertIsNotNone(self.bundle.approved_at)
+        self.assertIsNotNone(self.bundle.approved_by)
+
     def test_bundle_edit_view__shows_release_calendar_page_details(self):
         """Release calendar page's title, status and release date are displayed when selected in bundles."""
         for title, status, expected_text in self.RELEASE_CALENDAR_PAGE_CASES:
@@ -832,6 +847,22 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
         self.assertContains(response, "1 July 2025 1:37pm")
         self.assertContains(response, "1 July 2025 1:45pm")
         self.assertContains(response, "1 July 2025 2:00pm")
+
+    def test_inspect_view__approval_status__shows_unknown_when_published_directly(self):
+        """Inspect view shows 'Unknown approval data' when a bundle is published directly.
+
+        When a Publishing Admin publishes without a separate approval step, approved_by
+        and approved_at are never set, causing the inspect view to display
+        'Unknown approval data' rather than the publisher's details.
+        """
+        self.bundle.status = BundleStatus.PUBLISHED
+        self.bundle.approved_by = None
+        self.bundle.approved_at = None
+        self.bundle.save(update_fields=["status", "approved_by", "approved_at"])
+
+        response = self.client.get(reverse("bundle:inspect", args=[self.bundle.pk]))
+
+        self.assertNotContains(response, "Unknown approval data")
 
     def test_inspect_view__shows_bundle_api_bundle_id_when_exists(self):
         # Ensure the bundle has "bundle_api_bundle_id" set


### PR DESCRIPTION
 ### What is the context of this PR?

Addresses [CMS-929](https://officefornationalstatistics.atlassian.net/browse/CMS-929?atlOrigin=eyJpIjoiYjMxZmFmYmQxODgyNDQ5NTlmOGUwNDQ1ZTM0ZjFhNDgiLCJwIjoiaiJ9)

When a Publishing Admin published a bundle directly (without a separate approval step), the `approved_by` and `approved_at` fields were never populated. Additionally, when publishing from `APPROVED` status, the form's `clean()` method was actively clearing those fields. The inspect view then had no approval data to display and fell through to "Unknown approval data".

<img width="1323" height="644" alt="Screenshot(1)" src="https://github.com/user-attachments/assets/841c2c0f-7cfb-4bdf-9ac9-6e76e0701f22" />

#### Here are the exact conditions required to reproduce the bug as a PA user:

1. Create a bundle with no publication date and no linked release calendar page
2. Add a page that is ready to publish
3. Move the bundle to "In Preview" via Save to Preview
4. Approve the bundle
5. Manually click Publish in the UI (only visible because there is no publication date, normally publishing is handled by the management command on a schedule)
6. Navigate to the bundle inspect view via the Published status filter (published bundles are
hidden from the default listing)
7. Check the Approval status field shows "Unknown approval data" (like the screenshot above)

####  Why this is extremely unlikely in practice:

- Bundles almost always have either a publication date or a linked release calendar page, without one the bundle has no scheduled go-live time
- The management command handles publishing in production, meaning the manual publish button in the UI is rarely if ever used in a real workflow (although I can't be sure of that)

In short: it requires a deliberately incomplete bundle setup, a manual publish action that bypasses the normal scheduled workflow.

### How to review

1. Log in as a Publishing Admin
2. Create a bundle with valid mandatory data and no publication date (so you can publish the bundle)
3. Approve and publish the bundle directly
4. Go to the bundles listing, use the filter to show published bundles and find the one you published
5. Open your publlshed bundle in the Inspect view
6. Confirm the Approval status shows the publisher's name and timestamp, not "Unknown approval
  data"

  ### Deployment Safety

  Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

  Please select one:

  - [x] Safe to auto-deploy
  - [ ] Not safe to auto-deploy

  ### Follow-up Actions

  None.