### PR TITLE
Clean up django tasks todos as we've updated to newer version of wagtail

### DIFF
--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -44,14 +44,6 @@ from cms.workflows.tests.utils import (
     progress_page_workflow,
 )
 
-# TODO: remove when Wagtail updates to django-tasks >= 0.11
-TASKS_ENQUEUE_ON_COMMIT = {
-    "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-        "ENQUEUE_ON_COMMIT": False,
-    }
-}
-
 
 class BundleViewSetTestCaseBase(WagtailTestUtils, TestCase):
     RELEASE_CALENDAR_PAGE_CASES: ClassVar[list[tuple[str, ReleaseStatus, str]]] = [
@@ -1386,7 +1378,6 @@ class BundleChooserViewsetTestCase(BundleViewSetTestCaseBase):
         self.assertNotContains(response, self.published_bundle.name)
         self.assertNotContains(response, self.approved_bundle.name)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_chooser_search(self):
         draft_bundle = BundleFactory(name="Draft")
         chooser_results_url = reverse(bundle_chooser_viewset.get_url_name("choose_results"))

--- a/cms/private_media/tests/test_documents.py
+++ b/cms/private_media/tests/test_documents.py
@@ -12,14 +12,6 @@ from cms.private_media.models import PrivateDocumentMixin
 
 from .utils import PURGED_URLS
 
-# TODO: remove when Wagtail updates to django-tasks >= 0.11
-TASKS_ENQUEUE_ON_COMMIT = {
-    "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-        "ENQUEUE_ON_COMMIT": False,
-    }
-}
-
 
 class TestModelConfiguration(SimpleTestCase):
     def test_document_model_using_private_document_mixin(self):
@@ -243,7 +235,6 @@ class TestPrivateDocumentManager(TestCase):
             self.public_documents.append(DocumentFactory(_privacy=Privacy.PUBLIC, collection=self.root_collection))
         PURGED_URLS.clear()
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_bulk_make_public(self):
         """Test the behaviour of PrivateDocumentManager.bulk_make_public()."""
         # Three documents are already public, so only three should be updated
@@ -269,7 +260,6 @@ class TestPrivateDocumentManager(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(self.model.objects.bulk_make_public(self.model.objects.all()), 0)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_bulk_make_private(self):
         """Test the behaviour of PrivateDocumentManager.bulk_make_private()."""
         # Three images are already private, so only three should be updated

--- a/cms/private_media/tests/test_images.py
+++ b/cms/private_media/tests/test_images.py
@@ -12,14 +12,6 @@ from cms.private_media.models import AbstractPrivateRendition, PrivateImageMixin
 
 from .utils import PURGED_URLS
 
-# TODO: remove when Wagtail updates to django-tasks >= 0.11
-TASKS_ENQUEUE_ON_COMMIT = {
-    "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-        "ENQUEUE_ON_COMMIT": False,
-    }
-}
-
 
 class TestModelConfiguration(SimpleTestCase):
     def test_image_model_using_private_image_mixin(self):
@@ -277,7 +269,6 @@ class TestPrivateImageManager(TestCase):
             self.public_images.append(public_image)
         PURGED_URLS.clear()
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_bulk_make_public(self):
         """Test the behaviour of PrivateImageManager.bulk_make_public()."""
         # Three image are already public, so only three should be updated
@@ -306,7 +297,6 @@ class TestPrivateImageManager(TestCase):
             # 1. to fetch the images
             self.assertEqual(self.model.objects.bulk_make_public(self.model.objects.all()), 0)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_bulk_make_private(self):
         """Test the behaviour of PrivateImageManager.bulk_make_private()."""
         # Three images are already private, so only three should be updated

--- a/cms/private_media/tests/test_signal_handlers.py
+++ b/cms/private_media/tests/test_signal_handlers.py
@@ -1,20 +1,12 @@
 import uuid
 from typing import Any
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from wagtail.models import Site
 from wagtail_factories import DocumentFactory, ImageFactory
 
 from cms.private_media.constants import Privacy
 from cms.standard_pages.models import InformationPage
-
-# TODO: remove when Wagtail updates to django-tasks >= 0.11
-TASKS_ENQUEUE_ON_COMMIT = {
-    "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-        "ENQUEUE_ON_COMMIT": False,
-    }
-}
 
 
 class SignalHandlersTestCase(TestCase):
@@ -107,7 +99,6 @@ class SignalHandlersTestCase(TestCase):
         self.public_document.refresh_from_db()
         self.assertEqual(self.public_document.privacy, expected_privacy)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_publishing_a_page_makes_referenced_media_public(self):
         """Tests the impact of publishing a media-referencing page has on the privacy of referenced media."""
         self.test_page.content = self.generate_media_referencing_content()
@@ -116,7 +107,6 @@ class SignalHandlersTestCase(TestCase):
         self.test_page.save_revision().publish()
         self.assertMediaPrivacy(Privacy.PUBLIC)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_unpublishing_a_page_makes_referenced_media_private(self):
         """Tests the impact of unpublishing a media-referencing page has on the privacy of referenced media."""
         self.test_page.content = self.generate_media_referencing_content()
@@ -136,7 +126,6 @@ class SignalHandlersTestCase(TestCase):
 
         self.test_page.unpublish()
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_unpublishing_a_page_when_media_is_referenced_by_a_draft_page(self):
         """Tests the impact of unpublishing a page that references media that is referenced by another draft page."""
         # Publish the first page, so that the reference index is populated, then unpublish it again
@@ -159,7 +148,6 @@ class SignalHandlersTestCase(TestCase):
         new_page.unpublish()
         self.assertMediaPrivacy(Privacy.PRIVATE)
 
-    @override_settings(TASKS=TASKS_ENQUEUE_ON_COMMIT)
     def test_unpublishing_a_page_when_media_is_referenced_by_a_live_page(self):
         """Tests the impact of unpublishing a page that references media that is referenced by another live page."""
         # Publish the first page, with references to media


### PR DESCRIPTION
### What is the context of this PR?

There were several places where we were overriding `django-tasks` default behaviour to enqueue tasks without a commit. As of our upgrade to Wagtail 7.3 we're using `django-tasks` version 0.11 which has this as the default behaviour.

### How to review

Ensure tests still run.
Double check we don't have any other places overriding the redundant setting.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

NA
