### PR TITLE
Fix CSV data sanitisation for negative numbers

### DIFF
--- a/cms/data_downloads/tests/test_utils.py
+++ b/cms/data_downloads/tests/test_utils.py
@@ -410,15 +410,27 @@ class SanitizeDataForCsvTests(SimpleTestCase):
 
     def test_prepends_quote_to_string_starting_with_plus(self):
         """Test that strings starting with + are prefixed with a single quote."""
+        data = [["+1A2B3C4D", "normal"]]
+        result = sanitize_data_for_csv(data)
+        self.assertEqual(result, [["'+1A2B3C4D", "normal"]])
+
+    def test_not_prepends_quote_to_numbers_starting_with_plus(self):
+        """Test that safe expressions like +1234 are not modified, as they are valid numbers."""
         data = [["+1234", "normal"]]
         result = sanitize_data_for_csv(data)
-        self.assertEqual(result, [["'+1234", "normal"]])
+        self.assertEqual(result, [["+1234", "normal"]])
 
     def test_prepends_quote_to_string_starting_with_minus(self):
         """Test that strings starting with - are prefixed with a single quote."""
         data = [["-cmd|'/c calc'!A1", "normal"]]
         result = sanitize_data_for_csv(data)
         self.assertEqual(result, [["'-cmd|'/c calc'!A1", "normal"]])
+
+    def test_negative_numbers_as_strings_are_not_modified(self):
+        """Test that negative numbers represented as strings are not modified."""
+        data = [["-5", "-3.14"]]
+        result = sanitize_data_for_csv(data)
+        self.assertEqual(result, [["-5", "-3.14"]])
 
     def test_prepends_quote_to_string_starting_with_at(self):
         """Test that strings starting with @ are prefixed with a single quote."""

--- a/cms/data_downloads/utils.py
+++ b/cms/data_downloads/utils.py
@@ -95,15 +95,6 @@ def flatten_table_data(data: Mapping) -> list[list[str | int | float]]:
     return result
 
 
-def _is_number(val: str) -> bool:
-    """Check if a string represents a valid number."""
-    try:
-        float(val)
-        return True
-    except ValueError:
-        return False
-
-
 def sanitize_data_for_csv(data: list[list[str | int | float]]) -> list[list[str | int | float]]:
     """Sanitize data for CSV export by escaping formula triggers.
 
@@ -112,21 +103,22 @@ def sanitize_data_for_csv(data: list[list[str | int | float]]) -> list[list[str 
     """
     triggers = ("=", "+", "-", "@", "\t")
 
-    sanitized_row: list[list[str | int | float]] = []
+    sanitized_rows: list[list[str | int | float]] = []
     for row in data:
         new_row: list[str | int | float] = []
         for value in row:
             if isinstance(value, str) and value.startswith(triggers):
                 # If it's a number string (e.g. "-5"), do not prepend the quote
-                if _is_number(value):
+                try:
+                    float(value)  # Check if it can be converted to a number
                     new_row.append(value)
-                else:
+                except ValueError:
                     new_row.append(f"'{value}")
             else:
                 new_row.append(value)
-        sanitized_row.append(new_row)
+        sanitized_rows.append(new_row)
 
-    return sanitized_row
+    return sanitized_rows
 
 
 def create_data_csv_download_response_from_data(data: list[list[str | int | float]], *, title: str) -> HttpResponse:

--- a/cms/data_downloads/utils.py
+++ b/cms/data_downloads/utils.py
@@ -95,6 +95,15 @@ def flatten_table_data(data: Mapping) -> list[list[str | int | float]]:
     return result
 
 
+def _is_number(val: str) -> bool:
+    """Check if a string represents a valid number."""
+    try:
+        float(val)
+        return True
+    except ValueError:
+        return False
+
+
 def sanitize_data_for_csv(data: list[list[str | int | float]]) -> list[list[str | int | float]]:
     """Sanitize data for CSV export by escaping formula triggers.
 
@@ -103,10 +112,21 @@ def sanitize_data_for_csv(data: list[list[str | int | float]]) -> list[list[str 
     """
     triggers = ("=", "+", "-", "@", "\t")
 
-    return [
-        [f"'{value}" if isinstance(value, str) and value.startswith(triggers) else value for value in row]
-        for row in data
-    ]
+    sanitized_row = []
+    for row in data:
+        new_row = []
+        for value in row:
+            if isinstance(value, str) and value.startswith(triggers):
+                # If it's a number string (e.g. "-5"), do not prepend the quote
+                if _is_number(value):
+                    new_row.append(value)
+                else:
+                    new_row.append(f"'{value}")
+            else:
+                new_row.append(value)
+        sanitized_row.append(new_row)
+
+    return sanitized_row
 
 
 def create_data_csv_download_response_from_data(data: list[list[str | int | float]], *, title: str) -> HttpResponse:

--- a/cms/data_downloads/utils.py
+++ b/cms/data_downloads/utils.py
@@ -112,9 +112,9 @@ def sanitize_data_for_csv(data: list[list[str | int | float]]) -> list[list[str 
     """
     triggers = ("=", "+", "-", "@", "\t")
 
-    sanitized_row = []
+    sanitized_row: list[list[str | int | float]] = []
     for row in data:
-        new_row = []
+        new_row: list[str | int | float] = []
         for value in row:
             if isinstance(value, str) and value.startswith(triggers):
                 # If it's a number string (e.g. "-5"), do not prepend the quote


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses DPD-3743 and fixes the sanitisation process used for values included in generated CSVs.

Previously, negative numbers such as `-123` would be prepended with a quote, resulting in `'-123`.

The minus/dash symbol is escaped to avoid formula injection. However, the symbol does not need to be escaped if we deal with a real number.

This PR modifies the logic to check if the value is in fact a valid number, and skips sanitisation when this is the case.

### How to review

1. Create or edit a page in which you can embed a table, such as a statistical article page
2. Populate the table with data, including some negative numbers
3. Save and publish the page
4. Go to the live page
5. Download the CSV for that table
6. Inspect the CSV - confirm that negative numbers are represented correctly

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A