### PR TITLE
Order bundle listings by most recently updated first

### DIFF
--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -1286,14 +1286,14 @@ class BundleIndexViewTestCase(BundleViewSetTestCaseBase):
     def test_ordering(self):
         """Checks that the correct ordering is applied."""
         cases = {
-            "": ("name",),
+            "": ("-updated_at",),
             "name": ("name",),
             "-name": ("-name",),
             "scheduled_publication_date": (OrderBy(F("release_date"), descending=False, nulls_last=True),),
             "-scheduled_publication_date": (OrderBy(F("release_date"), descending=True, nulls_last=True),),
             "status": (OrderBy(F("status_label"), descending=False),),
             "-status": (OrderBy(F("status_label"), descending=True),),
-            "invalid_ordering": ("name",),
+            "invalid_ordering": ("-updated_at",),
         }
         for param, order_by in cases.items():
             with self.subTest(param=param):
@@ -1302,6 +1302,22 @@ class BundleIndexViewTestCase(BundleViewSetTestCaseBase):
                     response.context_data["object_list"].query.order_by,
                     order_by,
                 )
+
+    def test_index_view_default_bundle_ordering_is_most_recently_updated(self):
+        old_bundle = BundleFactory(updated_at=timezone.now() - timedelta(days=1))
+        new_bundle = BundleFactory(updated_at=timezone.now())
+        response = self.client.get(self.bundle_index_url)
+
+        self.assertEqual(response.context_data["object_list"][0].id, new_bundle.id)
+        self.assertEqual(response.context_data["object_list"][1].id, old_bundle.id)
+
+        # Ensure the old bundle moves to the top of the list when updated
+        old_bundle.updated_at = timezone.now() + timedelta(days=1)
+        old_bundle.save(update_fields=["updated_at"])
+        response = self.client.get(self.bundle_index_url)
+
+        self.assertEqual(response.context_data["object_list"][0].id, old_bundle.id)
+        self.assertEqual(response.context_data["object_list"][1].id, new_bundle.id)
 
 
 class BundleDeleteTestCase(WagtailTestUtils, TestCase):

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -1304,7 +1304,7 @@ class BundleIndexViewTestCase(BundleViewSetTestCaseBase):
                 )
 
     def test_index_view_default_bundle_ordering_is_most_recently_updated(self):
-        old_bundle = BundleFactory(updated_at=timezone.now() - timedelta(days=1))
+        old_bundle = BundleFactory(name="1 Day Old Bundle", updated_at=timezone.now() - timedelta(days=1))
         new_bundle = BundleFactory(updated_at=timezone.now())
         response = self.client.get(self.bundle_index_url)
 

--- a/cms/bundles/tests/test_wagtail_hooks.py
+++ b/cms/bundles/tests/test_wagtail_hooks.py
@@ -81,7 +81,7 @@ class WagtailHooksTestCase(WagtailTestUtils, TestCase):
     def test_latest_bundles_panel_ordering(self):
         """Checks that the latest bundles dashboard panel orders bundles by updated_at descending."""
         old_bundle = BundleFactory(
-            name="Old Bundle", created_by=self.superuser, updated_at=timezone.now() - timedelta(days=3)
+            name="3 Day Old Bundle", created_by=self.superuser, updated_at=timezone.now() - timedelta(days=3)
         )
         new_bundle = BundleFactory(name="New Bundle", created_by=self.superuser, updated_at=timezone.now())
 
@@ -142,7 +142,10 @@ class WagtailHooksTestCase(WagtailTestUtils, TestCase):
     def test_bundles_to_preview_panel_ordering(self):
         """Checks that the bundles preview dashboard panel orders bundles by updated_at descending."""
         old_bundle = BundleFactory(
-            in_review=True, name="Old Bundle", created_by=self.superuser, updated_at=timezone.now() - timedelta(days=3)
+            in_review=True,
+            name="3 Day Old Bundle",
+            created_by=self.superuser,
+            updated_at=timezone.now() - timedelta(days=3),
         )
         new_bundle = BundleFactory(
             in_review=True, name="New Bundle", created_by=self.superuser, updated_at=timezone.now()

--- a/cms/bundles/tests/test_wagtail_hooks.py
+++ b/cms/bundles/tests/test_wagtail_hooks.py
@@ -1,5 +1,8 @@
+from datetime import timedelta
+
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
 
 from cms.articles.tests.factories import ArticlesIndexPageFactory, StatisticalArticlePageFactory
@@ -75,6 +78,22 @@ class WagtailHooksTestCase(WagtailTestUtils, TestCase):
             self.assertContains(response, bundle.status.label)
         self.assertNotContains(response, self.published_bundle.status.label)
 
+    def test_latest_bundles_panel_ordering(self):
+        """Checks that the latest bundles dashboard panel orders bundles by updated_at descending."""
+        old_bundle = BundleFactory(
+            name="Old Bundle", created_by=self.superuser, updated_at=timezone.now() - timedelta(days=3)
+        )
+        new_bundle = BundleFactory(name="New Bundle", created_by=self.superuser, updated_at=timezone.now())
+
+        self.client.force_login(self.publishing_officer)
+        response = self.client.get(self.dashboard_url)
+
+        panels = response.context["panels"]
+        self.assertIsInstance(panels[0], LatestBundlesPanel)
+        bundles = panels[0].get_context_data()["bundles"]
+        self.assertEqual(bundles[0], new_bundle)
+        self.assertEqual(bundles[1], old_bundle)
+
     def test_bundle_to_preview_panel_is_shown(self):
         cases = [
             (self.generic_user, 0),
@@ -119,6 +138,24 @@ class WagtailHooksTestCase(WagtailTestUtils, TestCase):
 
         self.assertNotContains(response, self.draft_bundle.name)
         self.assertNotContains(response, self.published_bundle.name)
+
+    def test_bundles_to_preview_panel_ordering(self):
+        """Checks that the bundles preview dashboard panel orders bundles by updated_at descending."""
+        old_bundle = BundleFactory(
+            in_review=True, name="Old Bundle", created_by=self.superuser, updated_at=timezone.now() - timedelta(days=3)
+        )
+        new_bundle = BundleFactory(
+            in_review=True, name="New Bundle", created_by=self.superuser, updated_at=timezone.now()
+        )
+
+        self.client.force_login(self.publishing_officer)
+        response = self.client.get(self.dashboard_url)
+
+        panels = response.context["panels"]
+        self.assertIsInstance(panels[1], BundlesInReviewPanel)
+        bundles = panels[1].get_context_data()["bundles"]
+        self.assertEqual(bundles[0], new_bundle)
+        self.assertEqual(bundles[1], old_bundle)
 
     def test_bundles_in_preview_more_link_rendered(self):
         BundleFactory.create_batch(10, approved=True)  # + self.in_review_bundle

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -852,6 +852,7 @@ class BundleViewSet(ModelViewSet):
     add_to_admin_menu = True
     inspect_view_enabled = True
     menu_order = 150
+    ordering = "-updated_at"
 
 
 bundle_viewset = BundleViewSet("bundle")

--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -139,7 +139,7 @@ class LatestBundlesPanel(Component):
         """Adds the request, the latest bundles and whether the panel is shown to the panel context."""
         context = super().get_context_data(parent_context)
         context["request"] = self.request
-        context["bundles"] = sorted(self.get_latest_bundles(), key=lambda b: b.updated_at, reverse=True)
+        context["bundles"] = self.get_latest_bundles()
         context["is_shown"] = self.is_shown
         context["num_bundles"] = self.num_bundles
         return context
@@ -186,7 +186,7 @@ class BundlesInReviewPanel(Component):
         """Adds the request, the latest bundles and whether the panel is shown to the panel context."""
         context = super().get_context_data(parent_context)
         context["request"] = self.request
-        context["bundles"] = sorted(self.bundles[: self.num_bundles], key=lambda b: b.updated_at, reverse=True)
+        context["bundles"] = self.bundles[: self.num_bundles]
         context["is_shown"] = self.is_shown
         context["more_link"] = len(self.bundles) > self.num_bundles
         return context

--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -131,7 +131,7 @@ class LatestBundlesPanel(Component):
         """Returns the latest 10 bundles if the panel is shown."""
         queryset: QuerySet[Bundle] = Bundle.objects.none()
         if self.is_shown:
-            queryset = Bundle.objects.active()[: self.num_bundles]
+            queryset = Bundle.objects.active().order_by("-updated_at")[: self.num_bundles]
 
         return queryset
 
@@ -174,7 +174,7 @@ class BundlesInReviewPanel(Component):
         if not self.is_shown:
             return cast(QuerySet[Bundle], Bundle.objects.none())
 
-        queryset: QuerySet[Bundle] = Bundle.objects.previewable().order_by("approved_at")
+        queryset: QuerySet[Bundle] = Bundle.objects.previewable().order_by("-updated_at")
         if self._can_manage:
             # show all "in preview" for users that can manage.
             return queryset

--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -139,7 +139,7 @@ class LatestBundlesPanel(Component):
         """Adds the request, the latest bundles and whether the panel is shown to the panel context."""
         context = super().get_context_data(parent_context)
         context["request"] = self.request
-        context["bundles"] = sorted(self.get_latest_bundles(), key=lambda b: b.name)
+        context["bundles"] = sorted(self.get_latest_bundles(), key=lambda b: b.updated_at, reverse=True)
         context["is_shown"] = self.is_shown
         context["num_bundles"] = self.num_bundles
         return context
@@ -186,7 +186,7 @@ class BundlesInReviewPanel(Component):
         """Adds the request, the latest bundles and whether the panel is shown to the panel context."""
         context = super().get_context_data(parent_context)
         context["request"] = self.request
-        context["bundles"] = sorted(self.bundles[: self.num_bundles], key=lambda b: b.name)
+        context["bundles"] = sorted(self.bundles[: self.num_bundles], key=lambda b: b.updated_at, reverse=True)
         context["is_shown"] = self.is_shown
         context["more_link"] = len(self.bundles) > self.num_bundles
         return context


### PR DESCRIPTION
### What is the context of this PR?

Addresses [CMS-1215](https://officefornationalstatistics.atlassian.net/browse/CMS-1215?atlOrigin=eyJpIjoiNzc4MzEyMTM5YTllNDc5MGE1YjU3MTgwN2I2ZmFmYTAiLCJwIjoiaiJ9). 

We want the bundle listing page in Wagtail admin to open with the most recently changed bundles at the top rather than alphabetically, in the same way editors are used to seeing recently changed pages surfaced in Wagtail.

Additionally, this PR updates the ordering of the LatestBundlesPanel and BundlesInReviewPanel on the admin index page for consistency, as these were also previously ordered by name. 

### How to review

1. Create a bundle, e.g. "Bundle1". 
2. Create a second bundle, e.g. "Bundle2". 
3. Submit both bundles for preview.
4. Verify that the second bundle appears first in the Bundles list on the 'Latest Active Bundles' Panel.
5. ... and on the 'Bundles Ready for Preview' Panel.
6. ... and on the Bundles manager page (via the sidebar). 

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
