### PR TITLE
Wrap 500 fallback template content in a <main> tag

### DIFF
--- a/cms/jinja2/templates/pages/errors/500_fallback.html
+++ b/cms/jinja2/templates/pages/errors/500_fallback.html
@@ -29,9 +29,11 @@
     </head>
 
     <body>
-        <h1>Sorry, there’s a problem with the service</h1>
-        <p>Our scheduled publications can also be found on our <a href="https://backup.ons.gov.uk/">backup site</a>.</p>
-        <p>If you have any questions, <a href="/aboutus/contactus/generalandstatisticalenquiries">contact us</a>.</p>
+        <main>
+            <h1>Sorry, there’s a problem with the service</h1>
+            <p>Our scheduled publications can also be found on our <a href="https://backup.ons.gov.uk/">backup site</a>.</p>
+            <p>If you have any questions, <a href="/aboutus/contactus/generalandstatisticalenquiries">contact us</a>.</p>
+        </main>
     </body>
 
 </html>


### PR DESCRIPTION
### What is the context of this PR?

https://officefornationalstatistics.atlassian.net/browse/CMS-1208

The hard-coded fallback template for a 500 error was failing an automated a11y test due to a missing `<main>` tag around the main content.

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

In order to test the changes it's necessary to create a custom view in order to view the template.

In `cms/core/views.py` add the following temporary code:

```
def test_server_error_fallback(request: HttpRequest) -> HttpResponse:
    """Temporary view to render the 500 fallback error page for testing purposes."""
    return render(request, "templates/pages/errors/500_fallback.html", status=500)
```

In `cms/urls.py` add a new temporary path to test:

`path("test500-fallback", core_views.test_server_error_fallback, name="test_server_error_fallback"),`

Visit http://localhost:8000/test500-fallback in your browser.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
