### PR TITLE
Update django and wagtail for security patches

### DIFF
--- a/cms/core/tests/test_permission_testers.py
+++ b/cms/core/tests/test_permission_testers.py
@@ -250,7 +250,7 @@ class TestCustomPagePermissions(WagtailTestUtils, TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "You do not have permission")
+        self.assertContains(response, "you do not have permission")
         with self.assertRaises(InformationPage.DoesNotExist):
             InformationPage.objects.get(slug=new_slug)
 

--- a/cms/core/tests/test_views.py
+++ b/cms/core/tests/test_views.py
@@ -12,6 +12,7 @@ from fakeredis import FakeConnection
 from wagtail.test.utils import WagtailTestUtils
 
 from cms.home.models import HomePage
+from cms.standard_pages.tests.factories import IndexPageFactory
 
 
 class CSRFTestCase(TestCase):
@@ -283,6 +284,7 @@ class AdminPageTreeTestCase(WagtailTestUtils, TestCase):
     def setUpTestData(cls):
         cls.superuser = cls.create_superuser(username="admin")
         cls.homepage = HomePage.objects.first()
+        cls.index_page = IndexPageFactory(parent=cls.homepage)
 
     def setUp(self):
         self.client.force_login(self.superuser)
@@ -294,9 +296,15 @@ class AdminPageTreeTestCase(WagtailTestUtils, TestCase):
 
         self.assertInHTML('<span class="w-status w-status--label w-m-0">English</span>', content)
 
+    def test_root_page_redirects_from_copy_page(self):
+        """Test that the copy root page path redirects to admin home."""
+        response = self.client.get(reverse("wagtailadmin_pages:copy", args=[self.homepage.id]))
+
+        self.assertRedirects(response, f"/{settings.WAGTAILADMIN_HOME_PATH}")
+
     def test_copy_page_does_not_have_publish_or_alias_options(self):
         """Test that the options to publish or copy as alias are removed via cms.core.forms.ONSCopyForm."""
-        response = self.client.get(reverse("wagtailadmin_pages:copy", args=[self.homepage.id]))
+        response = self.client.get(reverse("wagtailadmin_pages:copy", args=[self.index_page.id]))
 
         self.assertNotContains(response, "id_publish_copies")
         self.assertNotContains(response, "id_alias")

--- a/poetry.lock
+++ b/poetry.lock
@@ -853,14 +853,14 @@ django = ">=4.2"
 
 [[package]]
 name = "django"
-version = "6.0.4"
+version = "6.0.5"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da"},
-    {file = "django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac"},
+    {file = "django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0"},
+    {file = "django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269"},
 ]
 
 [package.dependencies]
@@ -3667,14 +3667,14 @@ dev = ["black", "pytest"]
 
 [[package]]
 name = "wagtail"
-version = "7.3.1"
+version = "7.3.2"
 description = "A Django content management system."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "wagtail-7.3.1-py3-none-any.whl", hash = "sha256:eab131e15ab9edc7ed24143d44271e92af79239e105bc3e173d26c95d2b489b3"},
-    {file = "wagtail-7.3.1.tar.gz", hash = "sha256:2ce131d9a4e7d55fdb5b592d320a758a189174b2cc3966b70a34a1b3dc56f449"},
+    {file = "wagtail-7.3.2-py3-none-any.whl", hash = "sha256:cf19b5c6df2f36781f73b311b6f690250da7da1e2f8bc6bf8dff83483980b91a"},
+    {file = "wagtail-7.3.2.tar.gz", hash = "sha256:d7114887402d878860b5427697e8ab47832198bc1aaf1467e2ac1f182cb13860"},
 ]
 
 [package.dependencies]
@@ -3897,4 +3897,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14"
-content-hash = "a1683b19df58218c624f75cdc5f1618d9ca6b6d2a0222381d95e207d3b990b36"
+content-hash = "dc75e0ecb1154cab02f3807f8f670bffcdbecc7777cacf552c3b6d2777a7f230"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires-poetry = ">=2.2"
 
 [tool.poetry.dependencies]
 python = "^3.14"
-django = "~6.0.4"
-wagtail = "~7.3.1"
+django = "~6.0.5"
+wagtail = "~7.3.2"
 dj-database-url = "~3.1.0"
 django-csp = "~4.0"
 django-defender = "~0.9.8"


### PR DESCRIPTION
### What is the context of this PR?

Addresses CMS-1222

Upgrades django and wagtail to the latest patch security releases.

### How to review

- Ensure all tests still pass
- Review Django release notes [here](https://docs.djangoproject.com/en/6.0/releases/6.0.5/)
- Review Wagtail release notes [here](https://docs.wagtail.org/en/stable/releases/7.3.2.html)
- Verify there are code changes needed to be compatible with new versions

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy


### Follow-up Actions

NA
