### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt --quiet --yes update \
     # Install the Postgres client (matching production version)
     && apt --quiet --yes install --no-install-recommends postgresql-client-${POSTGRES_VERSION} \
     && apt --quiet --yes autoremove \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 
 # Create an unprivileged user and virtual environment for the app
@@ -93,7 +93,8 @@ ARG POETRY_HOME=/opt/poetry
 #     $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION
 # EOF
 RUN python -m venv --upgrade-deps $POETRY_HOME \
-    && $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION
+    && $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION \
+    && rm -rf /root/.cache/pip
 
 # Set common environment variables
 ENV \
@@ -123,7 +124,7 @@ COPY pyproject.toml poetry.lock ./
 #     # Install the production dependencies
 #     poetry install --no-root --without dev
 # EOF
-RUN poetry install --no-root --without dev
+RUN poetry install --no-root --without dev && rm -rf /home/$USERNAME/.cache/
 
 
 ###################

--- a/scripts/load-design-system-templates.sh
+++ b/scripts/load-design-system-templates.sh
@@ -30,6 +30,7 @@ rm -rf ./cms/jinja2/components
 rm -rf ./cms/jinja2/layout
 mv -f templates/* ./cms/jinja2
 rm -rf templates
+rm -rf $TEMP_DIR
 echo "Saved Design System templates to 'cms/jinja2/components' and 'cms/jinja2/layout'"
 
 #

--- a/scripts/load-design-system-templates.sh
+++ b/scripts/load-design-system-templates.sh
@@ -30,7 +30,7 @@ rm -rf ./cms/jinja2/components
 rm -rf ./cms/jinja2/layout
 mv -f templates/* ./cms/jinja2
 rm -rf templates
-rm -rf $TEMP_DIR
+rm -rf "$TEMP_DIR"
 echo "Saved Design System templates to 'cms/jinja2/components' and 'cms/jinja2/layout'"
 
 #


### PR DESCRIPTION
### What is the context of this PR?

There were a few unnecessary caches left around in the built image.

Before: `web` target: 1.67GB
After: `web` target: 1.45GB (13% reduction)

### How to review

Build the image, and note that it's smaller on this branch than `main`.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

This should be all the low-hanging fruit. Anything larger will likely need some major refactoring.
