### PR TITLE
chore(bundles): rename approval status label to approved by

### DIFF
--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -623,7 +623,7 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
         self.assertContains(response, "Created by")
         self.assertContains(response, "Scheduled publication")
         self.assertContains(response, "Associated release calendar")
-        self.assertContains(response, "Approval status")
+        self.assertContains(response, "Approved by")
         self.assertContains(response, "Status")
 
     def test_inspect_view__previewers__contains_only_relevant_fields(self):
@@ -636,7 +636,7 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
         self.assertContains(response, "Created by")
         self.assertContains(response, "Scheduled publication")
         self.assertContains(response, "Associated release calendar")
-        self.assertNotContains(response, "Approval status")
+        self.assertNotContains(response, "Approved by")
         self.assertNotContains(response, "Status")
 
     def test_inspect_view__previewers__contains_only_relevant_pages(self):

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -360,7 +360,7 @@ class BundleInspectView(InspectView):
     def get_field_label(self, field_name: str, field: Field) -> str:
         match field_name:
             case "approved":
-                label = "Approval status"
+                label = "Approved by"
             case "scheduled_publication":
                 label = "Scheduled publication"
             case "pages":
@@ -384,7 +384,7 @@ class BundleInspectView(InspectView):
         return ons_date_format(self.object.approved_at, settings.DATETIME_FORMAT) if self.object.approved_at else ""
 
     def get_approved_display_value(self) -> str:
-        """Custom approved by formatting. Varies based on status, and approver/time of approval."""
+        """Custom approved by formatting. Varies based on status and approver/time of approval."""
         if self.object.status in [BundleStatus.APPROVED, BundleStatus.PUBLISHED]:
             if self.object.approved_by_id and self.object.approved_at:
                 return (


### PR DESCRIPTION
### What is the context of this PR?

Updates the bundle inspect view approval field label from “Approval status” to “Approved by” so the UI better reflects the displayed value.

### How to review

Ensure the change makes sense

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
