### PR TITLE
Change previous releases heading to sentence case

### DIFF
--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -1211,7 +1211,7 @@ class PreviousReleasesWithoutPaginationTestCase(TestCase):
         self.assertInHTML(str(RichText(first_child.summary)), response.content.decode(encoding="utf-8"))
         self.assertContains(response, 'class="ons-document-list__item"', count=self.total_batch)
         self.assertContains(response, "Latest release", count=1)
-        self.assertContains(response, "Previous releases", count=1)
+        self.assertContains(response, "Previous releases", count=2)
 
     def test_pagination_is_not_shown(self):
         response = self.client.get(self.previous_releases_url)

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -1211,7 +1211,7 @@ class PreviousReleasesWithoutPaginationTestCase(TestCase):
         self.assertInHTML(str(RichText(first_child.summary)), response.content.decode(encoding="utf-8"))
         self.assertContains(response, 'class="ons-document-list__item"', count=self.total_batch)
         self.assertContains(response, "Latest release", count=1)
-        self.assertContains(response, "Previous releases", count=2)
+        self.assertContains(response, '<h2 class="ons-hero--topic">Previous releases</h2>', count=1)
 
     def test_pagination_is_not_shown(self):
         response = self.client.get(self.previous_releases_url)

--- a/cms/jinja2/templates/pages/statistical_article_page--previous-releases.html
+++ b/cms/jinja2/templates/pages/statistical_article_page--previous-releases.html
@@ -10,7 +10,7 @@
 {%- endset -%}
 
 {%- block header_area %}
-    {%- set hero_topic = _("Previous Releases") -%}
+    {%- set hero_topic = _("Previous releases") -%}
     {%- set hero_title = page.title ~ " " ~ _("Statistical articles") -%}
     {# fmt:off #}
     {{

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -639,7 +639,7 @@ msgid "Previous releases for %(title)s"
 msgstr "Datganiadau blaenorol am %(title)s"
 
 #: cms/jinja2/templates/pages/statistical_article_page--previous-releases.html:13
-msgid "Previous Releases"
+msgid "Previous releases"
 msgstr "Datganiadau Blaenorol"
 
 #: cms/jinja2/templates/pages/statistical_article_page--previous-releases.html:14

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -640,7 +640,7 @@ msgstr "Datganiadau blaenorol am %(title)s"
 
 #: cms/jinja2/templates/pages/statistical_article_page--previous-releases.html:13
 msgid "Previous releases"
-msgstr "Datganiadau Blaenorol"
+msgstr "Datganiadau blaenorol"
 
 #: cms/jinja2/templates/pages/statistical_article_page--previous-releases.html:14
 msgid "Statistical articles"


### PR DESCRIPTION
### What is the context of this PR?

Addresses [DPD-4741](https://officefornationalstatistics.atlassian.net/browse/DPD-4741?atlOrigin=eyJpIjoiYjVlYzk1ZTQ5NmVmNDM4MTk2MTEyOGE1MWEzNmMxMjciLCJwIjoiaiJ9).

This PR updates the content label on the previous releases page to be sentence case for consistency across the site (“Previous releases” instead of “Previous Releases”). 

### How to review

1. Go to a live statistical article page

2. Click the “View previous releases” link

3. View the content label on the page and confirm it contains "Previous releases" (sentence case) rather than "Previous Releases" (title case).

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
