### PR TITLE
Handle Pillow detecting a decompression bomb

### DIFF
--- a/cms/images/forms.py
+++ b/cms/images/forms.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django.forms import ValidationError
-from django.utils.translation import gettext_lazy as _
 from PIL.Image import DecompressionBombError
 from wagtail.images.forms import BaseImageForm
 
@@ -26,7 +25,7 @@ class CustomImageForm(BaseImageForm):
                 "file",
                 ValidationError(
                     self.fields["file"].error_messages["file_too_many_pixels"]
-                    % {"num_pixels": _("unknown number"), "max_pixels_count": self.fields["file"].max_image_pixels},
+                    % {"num_pixels": "unknown number", "max_pixels_count": self.fields["file"].max_image_pixels},
                     code="file_too_many_pixels",
                 ),
             )

--- a/cms/images/forms.py
+++ b/cms/images/forms.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+from django.forms import ValidationError
+from django.utils.translation import gettext_lazy as _
+from PIL.Image import DecompressionBombError
 from wagtail.images.forms import BaseImageForm
 
 
@@ -12,3 +15,18 @@ class CustomImageForm(BaseImageForm):
             self.fields[
                 "title"
             ].help_text = "The title field will be used as the file name when the image is downloaded."
+
+    def full_clean(self) -> None:
+        # HACK: Catch the decompression bomb error during clean, without modifying the field.
+        # Remove when https://github.com/wagtail/wagtail/pull/14225 is merged.
+        try:
+            super().full_clean()
+        except DecompressionBombError:
+            self.add_error(
+                "file",
+                ValidationError(
+                    self.fields["file"].error_messages["file_too_many_pixels"]
+                    % {"num_pixels": _("unknown number"), "max_pixels_count": self.fields["file"].max_image_pixels},
+                    code="file_too_many_pixels",
+                ),
+            )

--- a/cms/images/tests/test_forms.py
+++ b/cms/images/tests/test_forms.py
@@ -1,6 +1,11 @@
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from PIL import Image
 from wagtail.images import get_image_model
 from wagtail.images.forms import get_image_form
+from wagtail.images.tests.utils import get_test_image_file
 
 
 class CustomImageFormTests(TestCase):
@@ -19,3 +24,18 @@ class CustomImageFormTests(TestCase):
             form.fields["title"].help_text,
             "The title field will be used as the file name when the image is downloaded.",
         )
+
+    @patch.object(Image, "MAX_IMAGE_PIXELS", 1)
+    def test_decompression_bomb(self):
+        image = get_image_model()
+        form_class = get_image_form(image)
+
+        form = form_class(
+            data={
+                "title": "Test image",
+                "description": "test",
+            },
+            files={"file": SimpleUploadedFile("test.png", get_test_image_file().file.getvalue())},
+        )
+
+        self.assertFormError(form, "file", "This file has too many pixels (unknown number). Maximum pixels 10000000.")


### PR DESCRIPTION
### What is the context of this PR?

When fetching the size of an image, if Pillow thinks this is a decompression bomb it will raise an exception. This happens before the pixel sizes are returned, so Wagtail can't run its own validation.

This PR catches the exception and returns a modified error message, rather than receiving an unhandled exception.

### How to review

Try uploading an image (like the one linked to the ticket) and remove the 

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Also raised upstream as https://github.com/wagtail/wagtail/pull/14225. This can be reverted one upstream ships.
