### PR TITLE
Add workflow that checks for required approver when label applied

### DIFF
--- a/.github/workflows/required-approvers-label.yml
+++ b/.github/workflows/required-approvers-label.yml
@@ -1,0 +1,50 @@
+name: Require ONS Approval
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-label-and-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
+        with:
+          mode: minimum
+          count: 1
+          labels: 'Requires ONS Approval'
+          exit_type: success
+
+      - name: Check for required approvals
+        if: steps.check-label.outputs.status == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # List of required reviewers
+          REQUIRED_REVIEWERS=("sanjeevz3009", "MebinAbraham")
+
+          # Fetch reviews for the pr
+          REVIEWS=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews
+
+          APPROVED=false
+          for reviewer in "${REQUIRED_REVIEWERS[@]}"; do
+            STATE=$(echo "$REVIEWS" | jq -r --arg user "$reviewer" \
+              '[.[] | select(.user.login == $user and .state == "APPROVED")] | length')
+            if [ "$STATE" -gt 0 ]; then
+              APPROVED=true
+              echo "PR approved by $reviewer"
+              break
+            fi
+          done
+
+          if [ "$APPROVED" = "false" ]; then
+            echo "PR requires approval from at least one of the following reviewers: ${REQUIRED_REVIEWERS[*]}"
+            exit 1
+          fi


### PR DESCRIPTION
### What is the context of this PR?

Add a label that applies a check for review from a whitelist of approved reviewers.

We've been using the `do not merge` label for this purpose for a little while, but the name doesn't make it clear the reason why the pr is being blocked.

Using codeowners to add a hard requirement has been considered and deemed overly restrictive for small prs around typos or other minor changes.

This proposes a new label that makes the reasoning more obvious to contributors why their PR is blocked, and reduce manual label management.

### How to review

Decide if you think this is a good solution to the problem.

Check logic looks sound.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
