### PR TITLE
Hide non editable fields in bundle minimap

### DIFF
--- a/cms/bundles/models.py
+++ b/cms/bundles/models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
-from wagtail.admin.panels import FieldPanel, FieldRowPanel
+from wagtail.admin.panels import FieldRowPanel
 from wagtail.models import Orderable, Page
 from wagtail.search import index
 
@@ -25,6 +25,7 @@ from .panels import (
     BundleFieldPanel,
     BundleMultipleChooserPanel,
     BundleStatusPanel,
+    HiddenFieldPanel,
     PageChooserWithStatusPanel,
     ReleaseChooserWithDetailsPanel,
 )
@@ -191,9 +192,9 @@ class Bundle(index.Indexed, ClusterableModel, models.Model):  # type: ignore[dja
             chooser_field_name="team",
         ),
         # these are handled by the form
-        FieldPanel("status", classname="hidden w-hidden"),
-        FieldPanel("approved_by", classname="hidden w-hidden"),
-        FieldPanel("approved_at", classname="hidden w-hidden"),
+        HiddenFieldPanel("status"),
+        HiddenFieldPanel("approved_by"),
+        HiddenFieldPanel("approved_at"),
     ]
 
     search_fields: ClassVar[list[index.BaseField]] = [

--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -213,7 +213,7 @@ class ReleaseChooserWithDetailsPanel(BundleFieldPanel):
 class HiddenFieldPanel(FieldPanel):
     """A FieldPanel that renders no output.
 
-    Used for fields managed purely via form logic that need to be excluded from all UI including minimap.
+    Used for fields managed purely via form logic that need to be excluded from all UI, including minimap.
     """
 
     def __init__(self, field_name: str, **kwargs: Any) -> None:

--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -221,6 +221,6 @@ class HiddenFieldPanel(FieldPanel):
         super().__init__(field_name, **kwargs)
 
     class BoundPanel(FieldPanel.BoundPanel):
-        def is_shown(self) -> bool:
-            # Exclude from the minimap and panel tree
-            return False
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.heading = ""

--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -223,4 +223,6 @@ class HiddenFieldPanel(FieldPanel):
     class BoundPanel(FieldPanel.BoundPanel):
         def __init__(self, **kwargs: Any) -> None:
             super().__init__(**kwargs)
+            # Override heading to empty string. This prevents the header section html from being rendered
+            # in the form and stops it being displayed in the minimap
             self.heading = ""

--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -208,3 +208,19 @@ class ReleaseChooserWithDetailsPanel(BundleFieldPanel):
         if value is None:
             return ""
         return get_release_calendar_page_details(value)
+
+
+class HiddenFieldPanel(FieldPanel):
+    """A FieldPanel that renders no output.
+
+    Used for fields managed purely via form logic that need to be excluded from all UI including minimap.
+    """
+
+    def __init__(self, field_name: str, **kwargs: Any) -> None:
+        kwargs.setdefault("classname", "hidden w-hidden")
+        super().__init__(field_name, **kwargs)
+
+    class BoundPanel(FieldPanel.BoundPanel):
+        def is_shown(self) -> bool:
+            # Exclude from the minimap and panel tree
+            return False

--- a/cms/bundles/tests/test_panels.py
+++ b/cms/bundles/tests/test_panels.py
@@ -205,8 +205,8 @@ class HiddenFieldPanelTestCase(TestCase):
         panel = HiddenFieldPanel("status", classname="custom-class")
         self.assertEqual(panel.classname, "custom-class")
 
-    def test_is_shown_returns_false(self):
-        """Bound panel should not be shown, hiding it from the form and minimap."""
+    def test_heading_is_empty(self):
+        """Bound panel heading should be empty, hiding it from the minimap."""
         panel = HiddenFieldPanel("status")
         bound_panel = panel.bind_to_model(Bundle).get_bound_panel(instance=Bundle())
-        self.assertFalse(bound_panel.is_shown())
+        self.assertEqual(bound_panel.heading, "")

--- a/cms/bundles/tests/test_panels.py
+++ b/cms/bundles/tests/test_panels.py
@@ -16,6 +16,7 @@ from cms.bundles.panels import (
     BundleDatasetChooserWidget,
     BundleMultipleChooserPanel,
     BundleNotePanel,
+    HiddenFieldPanel,
 )
 from cms.bundles.tests.factories import BundleFactory, BundlePageFactory
 
@@ -189,3 +190,23 @@ class BundleDatasetChooserPanelTestCase(TestCase):
 
         # Verify that for_bundle=true is in the URL
         self.assertIn("for_bundle=true", chooser_url)
+
+
+class HiddenFieldPanelTestCase(TestCase):
+    """Test HiddenFieldPanel functionality."""
+
+    def test_default_classname(self):
+        """Panel should default to hidden classnames without needing them passed explicitly."""
+        panel = HiddenFieldPanel("status")
+        self.assertEqual(panel.classname, "hidden w-hidden")
+
+    def test_classname_can_be_overridden(self):
+        """Custom classname should override the default."""
+        panel = HiddenFieldPanel("status", classname="custom-class")
+        self.assertEqual(panel.classname, "custom-class")
+
+    def test_is_shown_returns_false(self):
+        """Bound panel should not be shown, hiding it from the form and minimap."""
+        panel = HiddenFieldPanel("status")
+        bound_panel = panel.bind_to_model(Bundle).get_bound_panel(instance=Bundle())
+        self.assertFalse(bound_panel.is_shown())


### PR DESCRIPTION
### What is the context of this PR?

Addresses CMS-1214

Currently we need to keep status, approved_by and approved_at fields as hidden fields in the wagtail admin bundle UI, but they are handled exclusively by the form. The existing logic was not sufficient to hide them from the editor minimap.

This PR adds a new HiddenFieldPanel class that force overrides the heading to an empty string, so header templating isn't displayed and it's not picked up by the minimap js. We need to keep the non editable fields present in the form to be submitted at the moment given the current logic.

### How to review

Check in the UI that the fields don't get shown in the form or minimap.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
