### PR TITLE
Ignore vuln in js uuid package for now

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,8 @@
 [[IgnoredVulns]]
 id = "PYSEC-2025-183"
 reason = "Disputed CVE - key length is application responsibility, no fix available upstream"
+
+[[IgnoredVulns]]
+id = "CVE-2026-41907"
+reason = "Dependency of webpack-dev-server, only a local development tool. No fix available upstream and extemely low risk of any exploit. Can remove when webpack-dev-server is updated to a version that doesn't depend on this vulnerable version of uuid"
+


### PR DESCRIPTION
### What is the context of this PR?

Ignore CVE-2026-41907 affecting uuid dependency of webpack-dev-server.

Currently extremely unlikely to be exploited in our local development and no good upstream fix. Can remove when webpack-dev-server is updated.

### How to review

Check file looks good

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
