### PR TITLE
Use stream from openssl to generate randomness for feature split script

### DIFF
--- a/.github/split_functional_test_features.sh
+++ b/.github/split_functional_test_features.sh
@@ -31,11 +31,12 @@ shard_zero_based=$((SHARD_INDEX - 1))
 
 seedfile=""
 order_cmd=(sort)
-
 if [[ -n "$SHUFFLE_SEED" ]]; then
     echo "Using seed '$SHUFFLE_SEED' for shuffling" >&2
-    seedfile=$(mktemp)
-    printf '%s' "$SHUFFLE_SEED" >"$seedfile"
+    seedfile=$(mktemp -u)
+    mkfifo "$seedfile"
+    openssl enc -aes-256-ctr -nosalt -k "$SHUFFLE_SEED" -in /dev/zero 2>/dev/null >"$seedfile" &
+    openssl_pid=$!
     order_cmd=(shuf --random-source="$seedfile")
 fi
 
@@ -43,4 +44,7 @@ find functional_tests/features -name '*.feature' |
     "${order_cmd[@]}" |
     awk "NR % $TOTAL_SHARDS == $shard_zero_based"
 
-[[ -n "$seedfile" ]] && rm -f "$seedfile"
+if [[ -n "$SHUFFLE_SEED" ]]; then
+    kill "$openssl_pid" 2>/dev/null || true
+    rm -f "$seedfile"
+fi


### PR DESCRIPTION
### What is the context of this PR?

On PR #609, functional tests were failing to run due to an error when splitting the features.
This uses a stream from openssl to generate randomness for the `shuf` function, then kills the stream at the end of execution.

https://github.com/ONSdigital/dis-wagtail/actions/runs/25908707290/job/76148374282

### How to review

Ensure splits are generated randomly.
Ensure seeds correctly regenerate the same splits.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
