### PR TITLE
Spike to investigate the switch to the wide container, and where we might need to restrict content width

### DIFF
--- a/cms/jinja2/templates/base.html
+++ b/cms/jinja2/templates/base.html
@@ -47,6 +47,7 @@
 {% set pageConfig = {
     "bodyClasses": body_class,
     "title": page_title,
+    "wide": true,
     "header": {
         "variants": "basic",
         "phase": {

--- a/cms/jinja2/templates/components/streamfield/information_panel.html
+++ b/cms/jinja2/templates/components/streamfield/information_panel.html
@@ -1,7 +1,8 @@
 {% from "components/panel/_macro.njk" import onsPanel %}
 
+{# For the information panel we might want the background colour to span the full width, but for the text width to be restricted - therefore we might want to impose the width restriction in the DS component #}
 {# fmt:off #}
-{{- 
+{{-
     onsPanel({
         "variant": "info",
         "body": value.body,

--- a/cms/jinja2/templates/components/streamfield/quote_block.html
+++ b/cms/jinja2/templates/components/streamfield/quote_block.html
@@ -1,5 +1,6 @@
 {% from "components/quote/_macro.njk" import onsQuote %}
 {% if value.attribution %}
+    {# For certain blocks like the quote we might want to impose the reading width at the DS component level, rather than in the cms - it would make sense for the DS to own it where there is a DS component that can be updated - unlike the case of the rich text block or the heading block #}
     {{- onsQuote({ "text": value.quote, "ref": value.attribution }) -}}
 {% else %}
     {{- onsQuote({ "text": value.quote }) -}}

--- a/cms/jinja2/templates/components/streamfield/section_block.html
+++ b/cms/jinja2/templates/components/streamfield/section_block.html
@@ -1,5 +1,6 @@
 <section id="{{ value.title|slugify() }}">
-    <h2 class="ons-u-fs-l">{{ value.title }}</h2>
+    {# Example of placing the ons-reading-width class on an individual element rather than in a wrapper surrounding it - in this case that is more semantic #}
+    <h2 class="ons-u-fs-l ons-reading-width">{{ value.title }}</h2>
 
     {% include_block value.content %}
 </section>

--- a/cms/jinja2/templates/components/streamfield/stream_block.html
+++ b/cms/jinja2/templates/components/streamfield/stream_block.html
@@ -1,6 +1,9 @@
+{% set restricted_width_block_types = ["heading", "rich_text", "accordion"] %}
+
 {% for content_block in value %}
     {% with block_id = content_block.id %}
-        <div class="{% if content_block.block_type !='heading' %}spacing{% endif %}">
+        {# Using stream_block.html to restrict certain blocks at the top level #}
+        <div class="{% if content_block.block_type !='heading' %}spacing{% endif %} {% if content_block.block_type in restricted_width_block_types %}ons-reading-width{% endif %}">
             {% include_block content_block %}
         </div>
     {% endwith %}

--- a/cms/jinja2/templates/pages/errors/403.html
+++ b/cms/jinja2/templates/pages/errors/403.html
@@ -5,6 +5,7 @@
 {% block main %}
     <h1>Access Denied</h1>
 
+    {# As part of the update we'd need to check all page templates, including errors, for any that need the restricted reading width. #}
     <p>
         We cannot process your request.<br>
         You can try to go back and try again. If the problem persists, please contact us.

--- a/cms/jinja2/templates/pages/home_page.html
+++ b/cms/jinja2/templates/pages/home_page.html
@@ -8,7 +8,8 @@
     {{
         onsHero({
             "title": 'Home',
-            "variants": 'navy-blue'
+            "variants": 'navy-blue',
+            "wide": true,
         })
     }}
     {# fmt:on #}

--- a/cms/jinja2/templates/pages/index_page.html
+++ b/cms/jinja2/templates/pages/index_page.html
@@ -18,6 +18,7 @@
             "title": page.title,
             "richText": page.summary|richtext(),
             "variants": 'grey',
+            "wide": true,
         })
     }}
     {# fmt:on #}

--- a/cms/jinja2/templates/pages/information_page.html
+++ b/cms/jinja2/templates/pages/information_page.html
@@ -25,6 +25,7 @@
 {# fmt:on #}
 
 {% block header_area %}
+    {# There is a fix on the way from the DS that sorts the width of the breadcrumbs component based on the pageConfig.wide setting #}
     {# fmt:off #}
     {{
         onsBreadcrumbs({
@@ -33,10 +34,12 @@
             "variant": 'grey'
         })
     }}
+    {# when we update the content width, the hero will need the 'wide' option applying manually, as it isn't in the base template. I've done this for a few page templates in this spike but not across the board. The title and paragraph text inside it already have a restricted width, but we might want to consider changing that to match the reading width. #}
     {{
         onsHero({
             "title": page.title,
             "variants": 'grey',
+            "wide": true,
             "richText": page.summary|richtext(),
             "detailsColumns": 12,
             "descriptionList": {

--- a/cms/jinja2/templates/pages/statistical_article_page.html
+++ b/cms/jinja2/templates/pages/statistical_article_page.html
@@ -228,7 +228,8 @@
                         {% include_block page.content %}
 
                         {% if page.show_cite_this_page %}
-                            <section id="cite-this-page" class="spacing">
+                            {# Another example of a place we would need to update the reading width #}
+                            <section id="cite-this-page" class="spacing ons-reading-width">
                                 <h2 class="ons-u-fs-l">{{ _("Cite this analysis") }}</h2>
                                 <p>
                                     {%- set cite_link -%}

--- a/cms/static_src/sass/components/_spacing.scss
+++ b/cms/static_src/sass/components/_spacing.scss
@@ -7,3 +7,11 @@
         margin-bottom: 0;
     }
 }
+
+.ons-reading-width {
+    // Unit and location of class experimental for now - this class will be provided by the DS
+    // Using ch units could be interesting but would mean headings and rich text would appear as different lengths
+    // Using percentage widths means the reading width would vary depending on the parent width and the screen size
+    // The best opton may be rems
+    max-width: 500px;
+}


### PR DESCRIPTION
### What is the context of this PR?

See https://officefornationalstatistics.atlassian.net/browse/CMS-1242

This pr experiments with a new class `ons-reading-width` which would be provided by the DS, to see how it could be used to restrict the width of content in the CMS where a maximum width applies to meet accessibility standards for reading width.

It is not intended to be merged - this PR is to share the spike code.

The comments add details of where we might add restrictions in the CMS, and where they might be needed in the DS. It isn't exhaustive of the places we'd need to update to ensure the reading width was restricted - more an exploration of the kinds of places it might apply.

Note that the `wide` option currently sets the overall container width at 1280px, but this is going to increase to 1304px.

### How to review

You can check out the branch and view in your browser, but the main thing is to review the code changes and comments.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [ ] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
