### PR TITLE
Successfully publish bundles with only datasets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "cms/settings/test.py",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 99
       }
     ],
     "cms/users/tests/test_signal_handlers.py": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T13:28:12Z"
+  "generated_at": "2026-05-29T12:11:17Z"
 }

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -153,6 +153,14 @@ class PublishBundlesCommandTestCase(TestCase):
         self.assertEqual(PageLogEntry.objects.filter(action="wagtail.publish.scheduled").count(), 0)
         self.assertTrue(PageLogEntry.objects.filter(action="wagtail.publish", page=self.statistical_article).exists())
 
+    def test_publish_bundle_with_only_datasets(self):
+        DatasetFactory()
+        BundleDatasetFactory(parent=self.bundle)
+        self.call_command()
+
+        self.bundle.refresh_from_db()
+        self.assertEqual(self.bundle.status, BundleStatus.PUBLISHED)
+
     def test_publish_bundle_with_release_calendar(self):
         """Test publishing a bundle with an associated release calendar page."""
         release_page = ReleaseCalendarPageFactory(release_date=self.publication_date)

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -154,6 +154,7 @@ class PublishBundlesCommandTestCase(TestCase):
         self.assertTrue(PageLogEntry.objects.filter(action="wagtail.publish", page=self.statistical_article).exists())
 
     def test_publish_bundle_with_only_datasets(self):
+        """Test publishing a bundle that only contains datasets and no pages publishes succesfully."""
         DatasetFactory()
         BundleDatasetFactory(parent=self.bundle)
         self.call_command()

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -518,7 +518,7 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         return False
 
     # we already handle failed pages, if the bundle only has datasets it still needs to be published successfully
-    if update_status and (pages_published > 0 or bundle.bundled_datasets.exists()) > 0:
+    if update_status and (pages_published > 0 or bundle.bundled_datasets.exists()):
         bundle.status = BundleStatus.PUBLISHED
         bundle.save(update_fields=["status"])
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -517,7 +517,8 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         )
         return False
 
-    if update_status and pages_published > 0:
+    # we already handle failed pages, if the bundle only has datasets it still needs to be published successfully
+    if update_status and (pages_published + bundle.bundled_datasets.count()) > 0:
         bundle.status = BundleStatus.PUBLISHED
         bundle.save(update_fields=["status"])
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -518,7 +518,7 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         return False
 
     # we already handle failed pages, if the bundle only has datasets it still needs to be published successfully
-    if update_status and (pages_published + bundle.bundled_datasets.count()) > 0:
+    if update_status and (pages_published > 0 or bundle.bundled_datasets.exists()) > 0:
         bundle.status = BundleStatus.PUBLISHED
         bundle.save(update_fields=["status"])
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -518,7 +518,7 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:
         return False
 
     # we already handle failed pages, if the bundle only has datasets it still needs to be published successfully
-    if update_status and (pages_published > 0 or bundle.bundled_datasets.exists()):
+    if update_status and (pages_published > 0 or bundle.has_datasets):
         bundle.status = BundleStatus.PUBLISHED
         bundle.save(update_fields=["status"])
 

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -89,6 +89,8 @@ XFF_STRICT = False
 # turn on the real Wagtail login form
 WAGTAIL_CORE_ADMIN_LOGIN_ENABLED = True
 
+# Don't send slack notifications from tests if env vars are set
+SLACK_NOTIFICATIONS_WEBHOOK_URL = None
 
 # Setting dummy environment variables for credentials and region in our test setup for the S3 storage tests.
 AWS_STORAGE_BUCKET_NAME = "test-bucket"


### PR DESCRIPTION
### What is the context of this PR?

Due to a change in the bundle publishing logic, we currently only update a bundle's status if it had at least 1 successfully published page. Given a bundle with only datasets we never update this.

Given we handle failed pages before we get to the page count check, I propose we check a count of published pages and count of datasets on the bundle.

### How to review

Try running tests, ensure logic is sound.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
