### PR TITLE
Normalise non breaking spaces in table content

### DIFF
--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -7,7 +7,7 @@ from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.contrib.table_block.blocks import TableBlock as WagtailTableBlock
-from wagtail_tinytableblock.blocks import TinyTableBlock
+from wagtail_tinytableblock.blocks import TinyTableBlock, TinyTableFieldBlock
 
 from cms.core.utils import strip_unwanted_control_chars_from_json
 from cms.data_downloads.utils import flatten_table_data
@@ -127,6 +127,17 @@ class BasicTableBlock(WagtailTableBlock):
         return rendered
 
 
+class NormalisingTinyTableFieldBlock(TinyTableFieldBlock):
+    """A TinyTableFieldBlock that normalises non-breaking spaces before parsing."""
+
+    @staticmethod
+    def _normalise_html(value: str) -> str:
+        return value.replace("\u00a0", " ").replace("&nbsp;", " ")
+
+    def value_from_form(self, value: str) -> dict:
+        return super().value_from_form(self._normalise_html(value))
+
+
 class ONSTableBlock(TinyTableBlock):
     """The ONS table block."""
 
@@ -134,11 +145,32 @@ class ONSTableBlock(TinyTableBlock):
     footnotes = blocks.RichTextBlock(label="Footnotes", features=settings.RICH_TEXT_BASIC, required=False)
 
     def __init__(
-        self, *, local_blocks: list[blocks.Block] | None = None, search_index: bool = True, **kwargs: Any
+        self,
+        *,
+        local_blocks: list[blocks.Block] | None = None,
+        search_index: bool = True,
+        allow_links: bool = False,
+        enable_context_menu: bool = False,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(local_blocks=local_blocks, search_index=search_index, **kwargs)
+        super().__init__(
+            local_blocks=local_blocks,
+            search_index=search_index,
+            allow_links=allow_links,
+            enable_context_menu=enable_context_menu,
+            **kwargs,
+        )
         # relabeled to match the publishing team's terminology
         self.child_blocks["caption"].label = "Sub-heading"
+        # replace the data block with our normalising subclass, forwarding the
+        # same kwargs that TinyTableBlock passes to TinyTableFieldBlock
+        normalising_data_block = NormalisingTinyTableFieldBlock(
+            required=False,
+            allow_links=allow_links,
+            enable_context_menu=enable_context_menu,
+        )
+        normalising_data_block.set_name("data")
+        self.child_blocks["data"] = normalising_data_block
 
     def _align_to_ons_classname(self, alignment: str) -> str:
         match alignment:

--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -135,7 +135,8 @@ class NormalisingTinyTableFieldBlock(TinyTableFieldBlock):
         return value.replace("\u00a0", " ").replace("&nbsp;", " ")
 
     def value_from_form(self, value: str) -> dict:
-        return super().value_from_form(self._normalise_html(value))
+        # mypy doesn't correctly read the type from the imported TinyTableFieldBlock method so explicitly cast
+        return cast(dict, super().value_from_form(self._normalise_html(value)))
 
 
 class ONSTableBlock(TinyTableBlock):

--- a/cms/core/tests/test_blocks.py
+++ b/cms/core/tests/test_blocks.py
@@ -1006,6 +1006,27 @@ class ONSTableBlockTestCase(WagtailTestUtils, TestCase):
         self.assertTrue(any("Footnotes" in tag.get_text() for tag in h3_tags))
         self.assertTrue(any("Download this table" in tag.get_text() for tag in h3_tags))
 
+    def test_value_from_form_normalises_nbsp(self):
+        """Test that &nbsp; and unicode non-breaking spaces are normalised to regular spaces on save."""
+        block = ONSTableBlock()
+        # Simulate submitting HTML with &nbsp; in cell content
+        html = (
+            "<table><thead><tr><th>header&nbsp;cell</th></tr></thead>"
+            "<tbody><tr><td>row\u00a0cell</td></tr></tbody></table>"
+        )
+        data_block = block.child_blocks["data"]
+        result = data_block.value_from_form(html)
+
+        header_value = result["headers"][0][0]["value"]
+        row_value = result["rows"][0][0]["value"]
+
+        self.assertNotIn("&nbsp;", header_value)
+        self.assertNotIn("\u00a0", header_value)
+        self.assertNotIn("&nbsp;", row_value)
+        self.assertNotIn("\u00a0", row_value)
+        self.assertEqual(header_value, "header cell")
+        self.assertEqual(row_value, "row cell")
+
     def test_ons_table_block_download_config_missing_without_page(self):
         """Test that download is empty when page is missing from context."""
         context = {


### PR DESCRIPTION
### What is the context of this PR?

Addresses DPD-4630

Currently when copying tables from word it adds non breaking spaces to attempt to preserve formatting in other apps, but this causes undesirable behaviour when interacting with wagtail and CSV conversion.

This removes non breaking spaces and normalises them to regular ones when processing the html content of the block.

### How to review

1. Try pasting in content with non breaking spaces
2. Save and view the preview/published page
3. Inspect HTML and CSV download and ensure content is preserved as is

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Possibly look at moving this logic up to the table block library to update the [paste_postprocess function](https://github.com/torchbox/wagtail-tinytableblock/blob/89e179b8a226ada2df3bfadbd8b71f91b59c233e/src/wagtail_tinytableblock/static/wagtail_tinytableblock/js/tiny-table-block.js#L118), or push for tinymce to address https://github.com/tinymce/tinymce/issues/9017.
