### PR TITLE
Conditionally display footnotes for iframe visualisations

### DIFF
--- a/cms/datavis/blocks/charts.py
+++ b/cms/datavis/blocks/charts.py
@@ -821,11 +821,12 @@ class IframeBlock(BaseVisualisationBlock):
             "caption": value.get("caption"),
             "description": value.get("audio_description"),
             "iframeUrl": value.get("iframe_source_url"),
-            "footnotes": {
-                "title": _("Footnotes"),
-                "content": str(value.get("footnotes", "")),
-            },
         }
+        if footnotes := value.get("footnotes"):
+            config["footnotes"] = {
+                "title": _("Footnotes"),
+                "content": str(footnotes),
+            }
 
         return config
 

--- a/cms/datavis/tests/test_iframe_block.py
+++ b/cms/datavis/tests/test_iframe_block.py
@@ -187,15 +187,7 @@ class IframeBlockTestCase(BaseVisualisationBlockTestCase):
         )
 
     def test_footnotes_configuration(self):
-        """Test that footnotes are configured correctly in the component config."""
-        # Test base case: empty footnotes
-        config = self.get_component_config()
-        self.assertIn("footnotes", config)
-        self.assertEqual(config["footnotes"]["title"], "Footnotes")
-        # IframeBlock always includes footnotes structure with empty content wrapped in rich text
-        self.assertEqual(config["footnotes"]["content"], '<div class="rich-text"></div>')
-
-        # Test with footnotes content
+        """Test that footnotes are configured correctly in the component config when set."""
         self.raw_data["footnotes"] = "Important note: This is test footnote text"
         config = self.get_component_config()
         self.assertEqual(
@@ -205,3 +197,9 @@ class IframeBlockTestCase(BaseVisualisationBlockTestCase):
                 "content": '<div class="rich-text">Important note: This is test footnote text</div>',
             },
         )
+
+    def test_footnotes_not_in_config_when_not_set(self):
+        """Footnotes should be omitted from the component config when no footnotes have been entered."""
+        self.raw_data["footnotes"] = ""
+        config = self.get_component_config()
+        self.assertNotIn("footnotes", config)


### PR DESCRIPTION


### What is the context of this PR?


This is a fix following on from https://github.com/ONSdigital/dis-wagtail/pull/586.

See this comment on https://officefornationalstatistics.atlassian.net/browse/DPD-2500?focusedCommentId=754707

The 'footnotes' accordion should only display if footnotes have been added.

### How to review

Edit a statistical article page, and add 2 visualisations. Add footnotes to one, but not to the other. Ensure that for the one that has no footnotes added, you don't see the accordion with the heading 'footnotes'.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
