### PR TITLE
docs(notifications): document bundle status Slack feature flag

### DIFF
--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -36,11 +36,12 @@ The CMS is integrated with Slack to send notifications about important events, s
 
 ### Environment variables
 
-| Var                         | Notes                                                                                                                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `SLACK_BOT_TOKEN`           | The token for the Slack bot that will be used to send notifications. [Documentation](https://docs.slack.dev/tools/python-slack-sdk/web/) |
-| `SLACK_PUBLISH_LOG_CHANNEL` | The ID of the Slack channel where logs will be sent.                                                                                     |
-| `SLACK_ALARM_CHANNEL`       | The ID of the Slack channel where alarms will be sent.                                                                                   |
+| Var                                    | Notes                                                                                                                                    |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `SLACK_BOT_TOKEN`                      | The token for the Slack bot that will be used to send notifications. [Documentation](https://docs.slack.dev/tools/python-slack-sdk/web/) |
+| `SLACK_PUBLISH_LOG_CHANNEL`            | The ID of the Slack channel where logs will be sent.                                                                                     |
+| `SLACK_ALARM_CHANNEL`                  | The ID of the Slack channel where alarms will be sent.                                                                                   |
+| `SLACK_NOTIFY_ON_BUNDLE_STATUS_CHANGE` | Defaults to `false`. Feature flag for sending Slack messages on bundle status changes (before pre-publish, e.g. entering review)         |
 
 ### Technical details
 


### PR DESCRIPTION
### What is the context of this PR?

Adds the `SLACK_NOTIFY_ON_BUNDLE_STATUS_CHANGE` environment variable to the Slack notifications integration doc.

### How to review

1. Ensure changes make sense
2. Are there any other things worth documenting?

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
