### PR TITLE
Add milliseconds to bundle publish start and end times in slack notifications

### DIFF
--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -77,15 +77,15 @@ def _get_publish_type(bundle: Bundle) -> str:
 
 
 def _format_publish_datetime(dt: datetime) -> str:
-    """Format datetime as DD/MM/YYYY - HH:MM:SS.
+    """Format datetime as DD/MM/YYYY - HH:MM:SS.sss.
 
     Args:
         dt: The datetime to format.
 
     Returns:
-        Formatted string in DD/MM/YYYY - HH:MM:SS format.
+        Formatted string in DD/MM/YYYY - HH:MM:SS.sss format.
     """
-    return dt.strftime("%d/%m/%Y - %H:%M:%S")
+    return dt.strftime("%d/%m/%Y - %H:%M:%S.%f")[:-3]  # Trim microseconds to milliseconds
 
 
 def _get_example_page_url(bundle: Bundle) -> str | None:

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -85,7 +85,7 @@ def _format_publish_datetime(dt: datetime) -> str:
     Returns:
         Formatted string in DD/MM/YYYY - HH:MM:SS.sss format.
     """
-    return dt.strftime("%d/%m/%Y - %H:%M:%S.%f")[:-3]  # Trim microseconds to milliseconds
+    return f"{dt:%d/%m/%Y - %H:%M:%S}.{dt.microsecond // 1000:03d}"
 
 
 def _get_example_page_url(bundle: Bundle) -> str | None:

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -186,7 +186,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn(self.inspect_url, fields[0]["value"])
 
         self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
-        self.assertIn({"title": "Scheduled Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
+        self.assertIn({"title": "Scheduled Start", "value": "17/02/2026 - 10:00:00.000", "short": True}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
 
         self.bundle.refresh_from_db()
@@ -216,8 +216,8 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn(self.inspect_url, fields[0]["value"])
 
         self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
-        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
-        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01", "short": True}, fields)
+        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00.000", "short": True}, fields)
+        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01.234", "short": True}, fields)
         self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": True}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
         self.assertIn({"title": "Pages Published", "value": "1", "short": True}, fields)
@@ -255,7 +255,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn("First Bundle", fields[0]["value"])
         self.assertIn(self.bundle.full_inspect_url, fields[0]["value"])
 
-        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
+        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00.000", "short": True}, fields)
 
         self.bundle.refresh_from_db()
         self.assertEqual(message_timestamp, self.bundle.slack_notification_ts)
@@ -298,8 +298,8 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn({"title": "Alert Type", "value": "Critical", "short": True}, fields)
         self.assertIn({"title": "Exception", "value": "1 of 1 page(s) failed to publish", "short": False}, fields)
         self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
-        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
-        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01", "short": True}, fields)
+        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00.000", "short": True}, fields)
+        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01.234", "short": True}, fields)
         self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": True}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
         self.assertIn({"title": "Pages Published", "value": "0", "short": True}, fields)
@@ -335,8 +335,8 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn({"title": "Alert Type", "value": "Fail", "short": True}, fields)
         self.assertIn({"title": "Exception", "value": "1 of 2 page(s) failed to publish", "short": False}, fields)
         self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
-        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
-        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01", "short": True}, fields)
+        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00.000", "short": True}, fields)
+        self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01.234", "short": True}, fields)
         self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": True}, fields)
         self.assertIn({"title": "Page Count", "value": "2", "short": True}, fields)
         self.assertIn({"title": "Pages Published", "value": "1", "short": True}, fields)
@@ -726,10 +726,10 @@ class HelperFunctionsTestCase(TestCase):
         self.assertEqual(_get_publish_type(bundle), "Manual")
 
     def test_format_publish_datetime(self):
-        """Should format datetime as DD/MM/YYYY - HH:MM:SS."""
-        dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
+        """Should format datetime as DD/MM/YYYY - HH:MM:SS.sss."""
+        dt = datetime(2026, 2, 17, 14, 30, 45, 234000, tzinfo=UTC)
         formatted = _format_publish_datetime(dt)
-        self.assertEqual(formatted, "17/02/2026 - 14:30:45")
+        self.assertEqual(formatted, "17/02/2026 - 14:30:45.234")
 
     def test_get_example_page_url__release_calendar(self):
         """Should return release calendar URL when bundle has release_calendar_page_id."""

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -731,6 +731,12 @@ class HelperFunctionsTestCase(TestCase):
         formatted = _format_publish_datetime(dt)
         self.assertEqual(formatted, "17/02/2026 - 14:30:45.234")
 
+    def test_format_publish_datetime_pads_milliseconds_zeros_if_not_in_datetime(self):
+        """Milliseconds should be padded with 0s if they aren't specified in the datetime."""
+        dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
+        formatted = _format_publish_datetime(dt)
+        self.assertEqual(formatted, "17/02/2026 - 14:30:45.000")
+
     def test_get_example_page_url__release_calendar(self):
         """Should return release calendar URL when bundle has release_calendar_page_id."""
         release_page = ReleaseCalendarPageFactory()


### PR DESCRIPTION
### What is the context of this PR?

Part of [CMS-1252](https://officefornationalstatistics.atlassian.net/browse/CMS-1252).

Adds milliseconds to the start and end publish times to make very short publish times more readable.

### How to review

1. Connect a slack workspace using environment variables, and ensure `SLACK_NOTIFY_ON_BUNDLE_STATUS_CHANGE` is `True`.
2. Publish a bundle.
3. Review slack messages to ensure they correctly display the publish start and end times to the millisecond.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
