### PR TITLE
Update django to v6.0.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -853,14 +853,14 @@ django = ">=4.2"
 
 [[package]]
 name = "django"
-version = "6.0.5"
+version = "6.0.6"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0"},
-    {file = "django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269"},
+    {file = "django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2"},
+    {file = "django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713"},
 ]
 
 [package.dependencies]
@@ -3894,4 +3894,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14"
-content-hash = "f625f17ce8ae5e30d77c649f159e0b5245d54ba5ddce1133cd6a84cf3b333a07"
+content-hash = "fc148a7bdb04ad70abd54b2bebd7295ef5a9adf4688694a85334fd2f7dc213e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-poetry = ">=2.2"
 
 [tool.poetry.dependencies]
 python = "^3.14"
-django = "~6.0.5"
+django = "~6.0.6"
 wagtail = "~7.3.2"
 dj-database-url = "~3.1.0"
 django-csp = "~4.0"


### PR DESCRIPTION
### What is the context of this PR?

Update django to version 6.0.6 to address several low severity security issues.

### How to review

- Ensure change looks correct
- Review [release notes](https://docs.djangoproject.com/en/6.0/releases/6.0.6/) and ensure we aren't missing any compatability changes (none I can see so far) 

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
