### PR TITLE
Update fields in bundle publication slack notifications

### DIFF
--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -228,7 +228,7 @@ def notify_slack_of_publish_end(
         {"title": "Duration", "value": f"{(end_time - start_time).total_seconds():.3f} seconds", "short": True},
         {"title": "Page Count", "value": str(bundle_page_count), "short": bundle_page_count > 0},
     ]
-    if pages_published > 0:
+    if bundle_page_count > 0:
         fields.append({"title": "Pages Published", "value": str(pages_published), "short": True})
 
     fields.append(

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -183,10 +183,23 @@ def notify_slack_of_publication_start(
     """
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{url or bundle.full_inspect_url}|{bundle.name}>", "short": False},
-        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": True},
-        {"title": "Scheduled Start", "value": _format_publish_datetime(start_time), "short": True},
-        {"title": "Page Count", "value": str(bundle.get_bundled_pages().count()), "short": True},
+        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": _get_publish_type(bundle) != "Manual"},
     ]
+    if _get_publish_type(bundle) != "Manual":
+        fields.append(
+            {
+                "title": "Scheduled Date",
+                "value": _format_publish_datetime(bundle.scheduled_publication_date),
+                "short": True,
+            }
+        )
+    fields.extend(
+        [
+            {"title": "Publish Start", "value": _format_publish_datetime(start_time), "short": False},
+            {"title": "Page Count", "value": str(bundle.get_bundled_pages().count()), "short": False},
+            {"title": "Dataset Count", "value": str(bundle.bundled_datasets.count()), "short": False},
+        ]
+    )
 
     if example_page_url := _get_example_page_url(bundle):
         fields.append({"title": "Example Page", "value": example_page_url, "short": False})
@@ -222,12 +235,26 @@ def notify_slack_of_publish_end(
     bundle_dataset_count = bundle.bundled_datasets.count()
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{url or bundle.full_inspect_url}|{bundle.name}>", "short": False},
-        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": True},
-        {"title": "Publish Start", "value": _format_publish_datetime(start_time), "short": True},
-        {"title": "Publish End", "value": _format_publish_datetime(end_time), "short": True},
-        {"title": "Duration", "value": f"{(end_time - start_time).total_seconds():.3f} seconds", "short": True},
-        {"title": "Page Count", "value": str(bundle_page_count), "short": bundle_page_count > 0},
+        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": _get_publish_type(bundle) != "Manual"},
     ]
+    if _get_publish_type(bundle) != "Manual":
+        fields.append(
+            {
+                "title": "Scheduled Date",
+                "value": _format_publish_datetime(bundle.scheduled_publication_date),
+                "short": True,
+            }
+        )
+
+    fields.extend(
+        [
+            {"title": "Publish Start", "value": _format_publish_datetime(start_time), "short": True},
+            {"title": "Publish End", "value": _format_publish_datetime(end_time), "short": True},
+            {"title": "Duration", "value": f"{(end_time - start_time).total_seconds():.3f} seconds", "short": False},
+            {"title": "Page Count", "value": str(bundle_page_count), "short": bundle_page_count > 0},
+        ]
+    )
+
     if bundle_page_count > 0:
         fields.append({"title": "Pages Published", "value": str(pages_published), "short": True})
 

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -107,8 +107,9 @@ def _get_example_page_url(bundle: Bundle) -> str | None:
     return str(first_page.specific_deferred.full_url) if first_page else None
 
 
-def notify_slack_of_status_change(
+def notify_slack_of_status_change(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
     bundle: Bundle,
+    changed_at: datetime,
     old_status: _StrOrPromise,
     user: User | None = None,
     url: str | None = None,
@@ -119,10 +120,11 @@ def notify_slack_of_status_change(
         return
 
     fields: list[dict[str, Any]] = [
-        {"title": "Title", "value": bundle.name, "short": True},
-        {"title": "Changed by", "value": user.get_full_name() if user else "System", "short": True},
-        {"title": "Old status", "value": old_status, "short": True},
-        {"title": "New status", "value": bundle.get_status_display(), "short": True},
+        {"title": "Bundle Name", "value": bundle.name, "short": False},
+        {"title": "Changed By", "value": user.get_full_name() if user else "System", "short": True},
+        {"title": "Changed At", "value": _format_publish_datetime(changed_at), "short": True},
+        {"title": "Old Status", "value": old_status, "short": True},
+        {"title": "New Status", "value": bundle.get_status_display(), "short": True},
     ]
     if context_message:
         fields.append({"title": "Context", "value": context_message})

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -218,15 +218,22 @@ def notify_slack_of_publish_end(
         pages_published: Number of pages successfully published.
         url: The URL to link to the bundle (optional).
     """
+    bundle_page_count = bundle.get_bundled_pages().count()
+    bundle_dataset_count = bundle.bundled_datasets.count()
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{url or bundle.full_inspect_url}|{bundle.name}>", "short": False},
         {"title": "Publish Type", "value": _get_publish_type(bundle), "short": True},
         {"title": "Publish Start", "value": _format_publish_datetime(start_time), "short": True},
         {"title": "Publish End", "value": _format_publish_datetime(end_time), "short": True},
         {"title": "Duration", "value": f"{(end_time - start_time).total_seconds():.3f} seconds", "short": True},
-        {"title": "Page Count", "value": str(bundle.get_bundled_pages().count()), "short": True},
-        {"title": "Pages Published", "value": str(pages_published), "short": True},
+        {"title": "Page Count", "value": str(bundle_page_count), "short": bundle_page_count > 0},
     ]
+    if pages_published > 0:
+        fields.append({"title": "Pages Published", "value": str(pages_published), "short": True})
+
+    fields.append(
+        {"title": "Dataset Count", "value": str(bundle_dataset_count), "short": False},
+    )
 
     if example_page_url := _get_example_page_url(bundle):
         fields.append({"title": "Example Page", "value": example_page_url, "short": False})

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -120,7 +120,7 @@ def notify_slack_of_status_change(  # pylint: disable=too-many-arguments,too-man
         return
 
     fields: list[dict[str, Any]] = [
-        {"title": "Bundle Name", "value": bundle.name, "short": False},
+        {"title": "Bundle Name", "value": f"<{bundle.full_inspect_url}|{bundle.name}>", "short": False},
         {"title": "Changed By", "value": user.get_full_name() if user else "System", "short": True},
         {"title": "Changed At", "value": _format_publish_datetime(changed_at), "short": True},
         {"title": "Old Status", "value": old_status, "short": True},
@@ -183,9 +183,10 @@ def notify_slack_of_publication_start(
     """
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{url or bundle.full_inspect_url}|{bundle.name}>", "short": False},
-        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": _get_publish_type(bundle) != "Manual"},
+        # If there is a scheduled date make short to show both on same line, otherwise span full line.
+        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": bool(bundle.scheduled_publication_date)},
     ]
-    if _get_publish_type(bundle) != "Manual":
+    if bundle.scheduled_publication_date:
         fields.append(
             {
                 "title": "Scheduled Date",
@@ -235,9 +236,10 @@ def notify_slack_of_publish_end(
     bundle_dataset_count = bundle.bundled_datasets.count()
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{url or bundle.full_inspect_url}|{bundle.name}>", "short": False},
-        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": _get_publish_type(bundle) != "Manual"},
+        # If there is a scheduled date make short to show both on same line, otherwise span full line.
+        {"title": "Publish Type", "value": _get_publish_type(bundle), "short": bool(bundle.scheduled_publication_date)},
     ]
-    if _get_publish_type(bundle) != "Manual":
+    if bundle.scheduled_publication_date:
         fields.append(
             {
                 "title": "Scheduled Date",
@@ -251,6 +253,7 @@ def notify_slack_of_publish_end(
             {"title": "Publish Start", "value": _format_publish_datetime(start_time), "short": True},
             {"title": "Publish End", "value": _format_publish_datetime(end_time), "short": True},
             {"title": "Duration", "value": f"{(end_time - start_time).total_seconds():.3f} seconds", "short": False},
+            # If there are pages, make short to show "Pages Published" on the same line. Otherwise span full line.
             {"title": "Page Count", "value": str(bundle_page_count), "short": bundle_page_count > 0},
         ]
     )

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -160,7 +160,9 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn(self.inspect_url, fields[0]["value"])
 
         self.assertIn({"title": "Changed By", "value": "Publishing Officer", "short": True}, call_kwargs["fields"])
-        self.assertIn({"title": "Changed At", "value": "17/02/2026 - 10:00:00", "short": True}, call_kwargs["fields"])
+        self.assertIn(
+            {"title": "Changed At", "value": "17/02/2026 - 10:00:00.000", "short": True}, call_kwargs["fields"]
+        )
         self.assertIn({"title": "Old Status", "value": BundleStatus.DRAFT.label, "short": True}, call_kwargs["fields"])
         self.assertIn(
             {"title": "New Status", "value": BundleStatus.IN_REVIEW.label, "short": True}, call_kwargs["fields"]
@@ -191,11 +193,9 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn("First Bundle", fields[0]["value"])
         self.assertIn(self.inspect_url, fields[0]["value"])
 
-
         self.assertIn({"title": "Publish Type", "value": "Manual", "short": False}, fields)
         self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00.000", "short": False}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": False}, fields)
-
 
         self.bundle.refresh_from_db()
         self.assertEqual(message_timestamp, self.bundle.slack_notification_ts)
@@ -363,7 +363,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         # Publish Type should be short=True when scheduled_publication_date is set
         self.assertIn({"title": "Publish Type", "value": "Scheduled", "short": True}, fields)
         # Scheduled Date field should be present with correct formatted value
-        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00", "short": True}, fields)
+        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00.000", "short": True}, fields)
 
     @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
     @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
@@ -389,7 +389,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         # Publish Type should be short=True when scheduled_publication_date is set
         self.assertIn({"title": "Publish Type", "value": "Scheduled", "short": True}, fields)
         # Scheduled Date field should be present with correct formatted value
-        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00", "short": True}, fields)
+        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00.000", "short": True}, fields)
 
     @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="")
     def test_notify_slack_of_bundle_pre_publish__no_channel_configured(self):
@@ -867,12 +867,6 @@ class HelperFunctionsTestCase(TestCase):
         dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
         formatted = _format_publish_datetime(dt)
         self.assertEqual(formatted, "17/02/2026 - 14:30:45.000")
-
-    def test_format_publish_datetime_pads_milliseconds_zeros_if_not_in_datetime(self):
-        """Milliseconds should be padded with 0s if they aren't specified in the datetime."""
-        dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
-        formatted = _format_publish_datetime(dt)
-        self.assertEqual(formatted, "17/02/2026 - 14:30:45")
 
     def test_get_example_page_url__release_calendar(self):
         """Should return release calendar URL when bundle has release_calendar_page_id."""

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -156,9 +156,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertEqual(call_kwargs["color"], "good")
         self.assertIn({"title": "Bundle Name", "value": "First Bundle", "short": False}, call_kwargs["fields"])
         self.assertIn({"title": "Changed By", "value": "Publishing Officer", "short": True}, call_kwargs["fields"])
-        self.assertIn(
-            {"title": "Changed At", "value": "17/02/2026 - 10:00:00.000", "short": True}, call_kwargs["fields"]
-        )
+        self.assertIn({"title": "Changed At", "value": "17/02/2026 - 10:00:00", "short": True}, call_kwargs["fields"])
         self.assertIn({"title": "Old Status", "value": BundleStatus.DRAFT.label, "short": True}, call_kwargs["fields"])
         self.assertIn(
             {"title": "New Status", "value": BundleStatus.IN_REVIEW.label, "short": True}, call_kwargs["fields"]
@@ -810,7 +808,7 @@ class HelperFunctionsTestCase(TestCase):
         """Milliseconds should be padded with 0s if they aren't specified in the datetime."""
         dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
         formatted = _format_publish_datetime(dt)
-        self.assertEqual(formatted, "17/02/2026 - 14:30:45.000")
+        self.assertEqual(formatted, "17/02/2026 - 14:30:45")
 
     def test_get_example_page_url__release_calendar(self):
         """Should return release calendar URL when bundle has release_calendar_page_id."""

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -735,6 +735,12 @@ class HelperFunctionsTestCase(TestCase):
         formatted = _format_publish_datetime(dt)
         self.assertEqual(formatted, "17/02/2026 - 14:30:45")
 
+    def test_format_publish_datetime_pads_milliseconds_zeros_if_not_in_datetime(self):
+        """Milliseconds should be padded with 0s if they aren't specified in the datetime."""
+        dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)
+        formatted = _format_publish_datetime(dt)
+        self.assertEqual(formatted, "17/02/2026 - 14:30:45.000")
+
     def test_get_example_page_url__release_calendar(self):
         """Should return release calendar URL when bundle has release_calendar_page_id."""
         release_page = ReleaseCalendarPageFactory()

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -25,7 +25,7 @@ from cms.bundles.notifications.slack import (
     notify_slack_of_status_change,
     send_bundle_notification,
 )
-from cms.bundles.tests.factories import BundleFactory
+from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.users.tests.factories import UserFactory
 
@@ -225,6 +225,7 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": True}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
         self.assertIn({"title": "Pages Published", "value": "1", "short": True}, fields)
+        self.assertIn({"title": "Dataset Count", "value": "0", "short": False}, fields)
         self.assertIn(
             {
                 "title": "Example Page",
@@ -236,6 +237,76 @@ class BundleStatusNotificationsTestCase(TestCase):
 
         self.bundle.refresh_from_db()
         self.assertEqual(message_timestamp, self.bundle.slack_notification_ts)
+
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
+    def test_notify_slack_of_publish_end_does_not_contain_pages_published_if_no_pages(self, mock_send):
+        """Test publication end message doesn't include pages published if no pages in bundle."""
+        start_time = datetime(2026, 2, 17, 10, 0, 0, tzinfo=UTC)
+        end_time = datetime(2026, 2, 17, 10, 0, 1, 234000, tzinfo=UTC)
+        # create new bundle with no pages
+        no_pages_bundle = BundleFactory(name="Test Bundle", bundled_pages=[])
+        pages_published = 0
+        message_timestamp = "1503435956.000247"
+        mock_send.return_value = message_timestamp
+
+        notify_slack_of_publish_end(no_pages_bundle, start_time, end_time, pages_published, self.inspect_url)
+
+        call_kwargs = mock_send.call_args[1]
+
+        self.assertEqual(call_kwargs["text"], "Publishing the bundle has ended")
+        self.assertEqual(call_kwargs["color"], "good")  # Green
+
+        fields = call_kwargs["fields"]
+
+        self.assertFalse(any(f.get("title") == "Pages Published" for f in fields))
+
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
+    def test_notify_slack_of_publish_end_displays_correct_dataset_count(self, mock_send):
+        """Test publication end message doesn't include pages published if no pages in bundle."""
+        start_time = datetime(2026, 2, 17, 10, 0, 0, tzinfo=UTC)
+        end_time = datetime(2026, 2, 17, 10, 0, 1, 234000, tzinfo=UTC)
+        # add dataset to bundle
+        BundleDatasetFactory(parent=self.bundle)
+        pages_published = 0
+        message_timestamp = "1503435956.000247"
+        mock_send.return_value = message_timestamp
+
+        notify_slack_of_publish_end(self.bundle, start_time, end_time, pages_published, self.inspect_url)
+
+        call_kwargs = mock_send.call_args[1]
+
+        self.assertEqual(call_kwargs["text"], "Publishing the bundle has ended")
+        self.assertEqual(call_kwargs["color"], "good")  # Green
+
+        fields = call_kwargs["fields"]
+
+        self.assertIn({"title": "Dataset Count", "value": "1", "short": False}, fields)
+
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
+    def test_notify_slack_of_publish_end_contains_long_page_count_if_no_pages(self, mock_send):
+        """Test publication end message includes count when there are no pages in bundle, and it takes up a line."""
+        start_time = datetime(2026, 2, 17, 10, 0, 0, tzinfo=UTC)
+        end_time = datetime(2026, 2, 17, 10, 0, 1, 234000, tzinfo=UTC)
+        # create new bundle with zero pages
+        no_pages_bundle = BundleFactory(name="Test Bundle", bundled_pages=[])
+        pages_published = 0
+        message_timestamp = "1503435956.000247"
+        mock_send.return_value = message_timestamp
+
+        notify_slack_of_publish_end(no_pages_bundle, start_time, end_time, pages_published, self.inspect_url)
+
+        call_kwargs = mock_send.call_args[1]
+
+        self.assertEqual(call_kwargs["text"], "Publishing the bundle has ended")
+        self.assertEqual(call_kwargs["color"], "good")  # Green
+
+        fields = call_kwargs["fields"]
+
+        # Page count should be present and take whole line
+        self.assertIn({"title": "Page Count", "value": "0", "short": False}, fields)
 
     @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
     @patch("cms.bundles.notifications.slack.send_or_update_slack_message")

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -143,21 +143,25 @@ class BundleStatusNotificationsTestCase(TestCase):
     def test_notify_slack_of_status_change(self, mock_send):
         """Should send status updates when bundle status changes and the feature flag is enabled."""
         self.bundle.status = BundleStatus.IN_REVIEW
+        updated_time = datetime(2026, 2, 17, 10, 0, 0, tzinfo=UTC)
         message_timestamp = "1503435956.000247"
         mock_send.return_value = message_timestamp
 
-        notify_slack_of_status_change(self.bundle, BundleStatus.DRAFT.label, self.user, self.inspect_url)
+        notify_slack_of_status_change(self.bundle, updated_time, BundleStatus.DRAFT.label, self.user, self.inspect_url)
 
         mock_send.assert_called_once()
         call_kwargs = mock_send.call_args[1]
 
         self.assertEqual(call_kwargs["text"], "Bundle status changed")
         self.assertEqual(call_kwargs["color"], "good")
-        self.assertIn({"title": "Title", "value": "First Bundle", "short": True}, call_kwargs["fields"])
-        self.assertIn({"title": "Changed by", "value": "Publishing Officer", "short": True}, call_kwargs["fields"])
-        self.assertIn({"title": "Old status", "value": BundleStatus.DRAFT.label, "short": True}, call_kwargs["fields"])
+        self.assertIn({"title": "Bundle Name", "value": "First Bundle", "short": False}, call_kwargs["fields"])
+        self.assertIn({"title": "Changed By", "value": "Publishing Officer", "short": True}, call_kwargs["fields"])
         self.assertIn(
-            {"title": "New status", "value": BundleStatus.IN_REVIEW.label, "short": True}, call_kwargs["fields"]
+            {"title": "Changed At", "value": "17/02/2026 - 10:00:00.000", "short": True}, call_kwargs["fields"]
+        )
+        self.assertIn({"title": "Old Status", "value": BundleStatus.DRAFT.label, "short": True}, call_kwargs["fields"])
+        self.assertIn(
+            {"title": "New Status", "value": BundleStatus.IN_REVIEW.label, "short": True}, call_kwargs["fields"]
         )
         self.assertIn({"title": "Link", "value": self.inspect_url, "short": False}, call_kwargs["fields"])
 

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -154,7 +154,11 @@ class BundleStatusNotificationsTestCase(TestCase):
 
         self.assertEqual(call_kwargs["text"], "Bundle status changed")
         self.assertEqual(call_kwargs["color"], "good")
-        self.assertIn({"title": "Bundle Name", "value": "First Bundle", "short": False}, call_kwargs["fields"])
+
+        fields = call_kwargs["fields"]
+        self.assertIn("First Bundle", fields[0]["value"])
+        self.assertIn(self.inspect_url, fields[0]["value"])
+
         self.assertIn({"title": "Changed By", "value": "Publishing Officer", "short": True}, call_kwargs["fields"])
         self.assertIn({"title": "Changed At", "value": "17/02/2026 - 10:00:00", "short": True}, call_kwargs["fields"])
         self.assertIn({"title": "Old Status", "value": BundleStatus.DRAFT.label, "short": True}, call_kwargs["fields"])
@@ -187,9 +191,9 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn("First Bundle", fields[0]["value"])
         self.assertIn(self.inspect_url, fields[0]["value"])
 
-        self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
-        self.assertIn({"title": "Scheduled Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
-        self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
+        self.assertIn({"title": "Publish Type", "value": "Manual", "short": False}, fields)
+        self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": False}, fields)
+        self.assertIn({"title": "Page Count", "value": "1", "short": False}, fields)
 
         self.bundle.refresh_from_db()
         self.assertEqual(message_timestamp, self.bundle.slack_notification_ts)
@@ -217,10 +221,10 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.assertIn("First Bundle", fields[0]["value"])
         self.assertIn(self.inspect_url, fields[0]["value"])
 
-        self.assertIn({"title": "Publish Type", "value": "Manual", "short": True}, fields)
+        self.assertIn({"title": "Publish Type", "value": "Manual", "short": False}, fields)
         self.assertIn({"title": "Publish Start", "value": "17/02/2026 - 10:00:00", "short": True}, fields)
         self.assertIn({"title": "Publish End", "value": "17/02/2026 - 10:00:01", "short": True}, fields)
-        self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": True}, fields)
+        self.assertIn({"title": "Duration", "value": "1.234 seconds", "short": False}, fields)
         self.assertIn({"title": "Page Count", "value": "1", "short": True}, fields)
         self.assertIn({"title": "Pages Published", "value": "1", "short": True}, fields)
         self.assertIn({"title": "Dataset Count", "value": "0", "short": False}, fields)

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -337,6 +337,57 @@ class BundleStatusNotificationsTestCase(TestCase):
         self.bundle.refresh_from_db()
         self.assertEqual(message_timestamp, self.bundle.slack_notification_ts)
 
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
+    def test_notify_slack_of_publication_start_for_scheduled_bundle(self, mock_send):
+        """Test start message includes Scheduled Date and short Publish Type when bundle has a scheduled date."""
+        scheduled_date = datetime(2026, 2, 17, 9, 0, 0, tzinfo=UTC)
+        scheduled_bundle = BundleFactory(
+            name="Scheduled Bundle",
+            bundled_pages=[StatisticalArticlePageFactory()],
+            publication_date=scheduled_date,
+        )
+        start_time = datetime(2026, 2, 17, 9, 0, 0, tzinfo=UTC)
+        mock_send.return_value = "1503435956.000247"
+
+        notify_slack_of_publication_start(scheduled_bundle, start_time, self.inspect_url)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args[1]
+
+        fields = call_kwargs["fields"]
+
+        # Publish Type should be short=True when scheduled_publication_date is set
+        self.assertIn({"title": "Publish Type", "value": "Scheduled", "short": True}, fields)
+        # Scheduled Date field should be present with correct formatted value
+        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00", "short": True}, fields)
+
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @patch("cms.bundles.notifications.slack.send_or_update_slack_message")
+    def test_notify_slack_of_publish_end_for_scheduled_bundle(self, mock_send):
+        """Test end message includes Scheduled Date and short Publish Type when bundle has a scheduled date."""
+        scheduled_date = datetime(2026, 2, 17, 9, 0, 0, tzinfo=UTC)
+        scheduled_bundle = BundleFactory(
+            name="Scheduled Bundle",
+            bundled_pages=[StatisticalArticlePageFactory()],
+            publication_date=scheduled_date,
+        )
+        start_time = datetime(2026, 2, 17, 9, 0, 0, tzinfo=UTC)
+        end_time = datetime(2026, 2, 17, 9, 0, 1, 234000, tzinfo=UTC)
+        mock_send.return_value = "1503435956.000247"
+
+        notify_slack_of_publish_end(scheduled_bundle, start_time, end_time, 1, self.inspect_url)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args[1]
+
+        fields = call_kwargs["fields"]
+
+        # Publish Type should be short=True when scheduled_publication_date is set
+        self.assertIn({"title": "Publish Type", "value": "Scheduled", "short": True}, fields)
+        # Scheduled Date field should be present with correct formatted value
+        self.assertIn({"title": "Scheduled Date", "value": "17/02/2026 - 09:00:00", "short": True}, fields)
+
     @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="")
     def test_notify_slack_of_bundle_pre_publish__no_channel_configured(self):
         """Should return early and log warning if no channel is configured."""

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -225,7 +225,7 @@ class BundleEditView(EditView):
         if instance.status == BundleStatus.APPROVED:
             action = "bundles.approve"
             kwargs["data"] = {"old": original_status}
-            notify_slack_of_status_change(instance, original_status, user=self.request.user, url=url)
+            notify_slack_of_status_change(instance, timezone.now(), original_status, user=self.request.user, url=url)
         elif instance.status == BundleStatus.PUBLISHED.value:
             action = "wagtail.publish"
             self.start_time = time.time()
@@ -235,7 +235,7 @@ class BundleEditView(EditView):
                 "old": original_status,
                 "new": instance.get_status_display(),
             }
-            notify_slack_of_status_change(instance, original_status, user=self.request.user, url=url)
+            notify_slack_of_status_change(instance, timezone.now(), original_status, user=self.request.user, url=url)
 
         # now log the status change
         log(


### PR DESCRIPTION
### What is the context of this PR?

Second half of [CMS-1252](https://officefornationalstatistics.atlassian.net/browse/CMS-1252).

- Updates status change field headers to Title Case to be more in line with publication start/end messages
- Add "Changed At" field to status change notification
- Always display "Page Count" and "Dataset Count" fields
- Conditionally display "Pages Published" field, and if it is hidden take the entire line with the page count so bundles have their own line

### How to review

- Create and change status of a bundle to ensure notification displays timestamp
- Publish bundle and ensure count fields show correct values

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
