### PR TITLE
Update times in slack notifications to use Europe/London timezone

### DIFF
--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
+from django.utils import timezone
 
 from cms.core.slack import send_or_update_slack_message
 
@@ -77,15 +78,18 @@ def _get_publish_type(bundle: Bundle) -> str:
 
 
 def _format_publish_datetime(dt: datetime) -> str:
-    """Format datetime as DD/MM/YYYY - HH:MM:SS.sss.
+    """Format datetime as DD/MM/YYYY - HH:MM:SS.sss in Europe/London local time.
 
     Args:
         dt: The datetime to format.
 
     Returns:
-        Formatted string in DD/MM/YYYY - HH:MM:SS.sss format.
+        Formatted string in DD/MM/YYYY - HH:MM:SS.sss format, representing the
+        datetime in Europe/London local time.
     """
-    return f"{dt:%d/%m/%Y - %H:%M:%S}.{dt.microsecond // 1000:03d}"
+    local_dt = dt.astimezone(timezone.get_default_timezone())
+
+    return f"{local_dt:%d/%m/%Y - %H:%M:%S}.{local_dt.microsecond // 1000:03d}"
 
 
 def _get_example_page_url(bundle: Bundle) -> str | None:

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -341,7 +341,7 @@ def alert_slack_of_bundle_content_failure(
     """
     fields: list[dict[str, Any]] = [
         {"title": "Bundle Name", "value": f"<{bundle.full_inspect_url}|{bundle.name}>", "short": False},
-        {"title": "Timestamp", "value": _format_publish_datetime(datetime.now()), "short": True},
+        {"title": "Timestamp", "value": _format_publish_datetime(timezone.now()), "short": True},
         {"title": "Publish Type", "value": _get_publish_type(bundle), "short": True},
         {"title": "Alert Type", "value": alert_type, "short": True},
         {"title": "Exception", "value": exception_message, "short": False},

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -87,7 +87,7 @@ def _format_publish_datetime(dt: datetime) -> str:
         Formatted string in DD/MM/YYYY - HH:MM:SS.sss format, representing the
         datetime in Europe/London local time.
     """
-    local_dt = dt.astimezone(timezone.get_default_timezone())
+    local_dt = timezone.localtime(dt)
 
     return f"{local_dt:%d/%m/%Y - %H:%M:%S}.{local_dt.microsecond // 1000:03d}"
 

--- a/cms/bundles/notifications/slack.py
+++ b/cms/bundles/notifications/slack.py
@@ -78,14 +78,14 @@ def _get_publish_type(bundle: Bundle) -> str:
 
 
 def _format_publish_datetime(dt: datetime) -> str:
-    """Format datetime as DD/MM/YYYY - HH:MM:SS.sss in Europe/London local time.
+    """Format datetime as DD/MM/YYYY - HH:MM:SS.sss in the current active local time.
 
     Args:
         dt: The datetime to format.
 
     Returns:
         Formatted string in DD/MM/YYYY - HH:MM:SS.sss format, representing the
-        datetime in Europe/London local time.
+        datetime in the current active local time.
     """
     local_dt = timezone.localtime(dt)
 

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -862,6 +862,12 @@ class HelperFunctionsTestCase(TestCase):
         formatted = _format_publish_datetime(dt)
         self.assertEqual(formatted, "17/02/2026 - 14:30:45.234")
 
+    def test_format_publish_datetime_applies_bst_offset(self):
+        """Should return datetime with the BST offset."""
+        dt = datetime(2026, 6, 17, 14, 30, 45, 234000, tzinfo=UTC)
+        formatted = _format_publish_datetime(dt)
+        self.assertEqual(formatted, "17/06/2026 - 15:30:45.234")
+
     def test_format_publish_datetime_pads_milliseconds_zeros_if_not_in_datetime(self):
         """Milliseconds should be padded with 0s if they aren't specified in the datetime."""
         dt = datetime(2026, 2, 17, 14, 30, 45, tzinfo=UTC)

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from slack_sdk.errors import SlackApiError
 
 from cms.articles.tests.factories import StatisticalArticlePageFactory
@@ -865,7 +866,8 @@ class HelperFunctionsTestCase(TestCase):
     def test_format_publish_datetime_applies_bst_offset(self):
         """Should return datetime with the BST offset."""
         dt = datetime(2026, 6, 17, 14, 30, 45, 234000, tzinfo=UTC)
-        formatted = _format_publish_datetime(dt)
+        with timezone.override("Europe/London"):
+            formatted = _format_publish_datetime(dt)
         self.assertEqual(formatted, "17/06/2026 - 15:30:45.234")
 
     def test_format_publish_datetime_pads_milliseconds_zeros_if_not_in_datetime(self):


### PR DESCRIPTION
### What is the context of this PR?

Addresses [CMS-1351](https://officefornationalstatistics.atlassian.net/browse/CMS-1251)

Updates the timestamps in the slack notifications to be displayed using the Europe/London timezone.

### How to review

1. Connect a slack workspace using environment variables
2. Create a bundle and update the status
3. Review the slack message to ensure the changed at time is correctly displayed using the Europe/London timezone
4. Publish the bundle
5. Review slack messages to ensure the publish start and end times are correctly displayed using the Europe/London timezone

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
