### PR TITLE
bug: Missing GTM Content Type on Previous Releases page

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -87,6 +87,8 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
 ):
     """The article series model."""
 
+    _analytics_content_type = "previous-releases"
+
     parent_page_types: ClassVar[list[str]] = ["ArticlesIndexPage"]
     subpage_types: ClassVar[list[str]] = ["StatisticalArticlePage"]
     preview_modes: ClassVar[list[str]] = []  # Disabling the preview mode due to it being a container page.

--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -89,6 +89,10 @@ class ArticleSeriesPageTests(WagtailPageTestCase):
             html=True,
         )
 
+    def test_analytics_content_type(self):
+        """Test that the GTM content type is 'previous-releases'."""
+        self.assertEqual(self.article_series_page.analytics_content_type, "previous-releases")
+
 
 class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
     @classmethod


### PR DESCRIPTION
### What is the context of this PR?

Ticket: [DPD-4501](https://officefornationalstatistics.atlassian.net/browse/DPD-4501?atlOrigin=eyJpIjoiNDU3NjJmMjllMDY5NDI3MWE2ZmM5YzMxYzYzMzAzYWEiLCJwIjoiaiJ9)

`ArticleSeriesPage` was missing a `_analytics_content_type` class variable. Fix is just to define: `_analytics_content_type = "previous-releases"`.

### How to review

1. Visit a Previous Releases page, e.g. `<series-url>/editions`
2. Open DevTools Console and run `dataLayer` to inspect the values
3. Confirm `contentType: "previous-releases"` is present

### Deployment Safety

- [x] Safe to auto-deploy

### Follow-up Actions

None.