### PR TITLE
Update breadcrumbs to exclude container pages

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -57,6 +57,8 @@ class ArticlesIndexPage(BasePage):  # type: ignore[django-manager-missing]
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     page_description = "A container for statistical article series. Used for URL structure purposes."
     preview_modes: ClassVar[list[str]] = []  # Disabling the preview mode as this redirects away
+    # The index page is a container that cannot be navigated to, so omit it from breadcrumbs.
+    exclude_from_breadcrumbs = True
 
     content_panels: ClassVar[list[Panel]] = [
         *Page.content_panels,

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -665,21 +665,33 @@ class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
         response = self.client.get(self.basic_page_url)
         self.assertNotContains(response, expected)
 
-    def test_breadcrumb_doesnt_contains_series_url(self):
+    def test_breadcrumb_excludes_container_pages(self):
         response = self.client.get(self.basic_page_url)
-        # confirm that current breadcrumb is there
+        dummy_request = get_dummy_request()
+        # confirm the series container page is not in the breadcrumb
         article_series = self.basic_page.get_parent()
+        series_url = article_series.get_full_url(request=dummy_request)
         self.assertNotContains(
             response,
-            f'<a class="ons-breadcrumbs__link" href="{article_series.full_url}">{article_series.title}</a>',
+            f'<a class="ons-breadcrumbs__link" href="{series_url}">{article_series.title}</a>',
             html=True,
         )
 
-        # confirm that current breadcrumb points to the parent page
-        topics_page = article_series.get_parent()
+        # confirm the articles index container page is not in the breadcrumb
+        articles_index = article_series.get_parent()
+        articles_index_url = articles_index.get_full_url(request=dummy_request)
+        self.assertNotContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
+            html=True,
+        )
+
+        # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
+        topic_page = articles_index.get_parent()
+        topic_url = topic_page.get_full_url(request=dummy_request)
         self.assertContains(
             response,
-            f'<a class="ons-breadcrumbs__link" href="{topics_page.full_url}">{topics_page.title}</a>',
+            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
             html=True,
         )
 
@@ -693,6 +705,15 @@ class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
         self.assertContains(
             response,
             f'<a class="ons-breadcrumbs__link" href="{self.basic_page.full_url}">PSF: November 2024</a>',
+            html=True,
+        )
+
+        # confirm the articles index container page is not in the related data breadcrumb
+        articles_index = self.basic_page.get_parent().get_parent()
+        articles_index_url = articles_index.get_full_url(request=get_dummy_request())
+        self.assertNotContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
             html=True,
         )
 
@@ -1199,16 +1220,24 @@ class PreviousReleasesWithoutPaginationTestCase(TestCase):
     def setUp(self):
         self.dummy_request = get_dummy_request()
 
-    def test_breadcrumb_does_contains_series_url(self):
+    def test_breadcrumb_excludes_articles_index(self):
         response = self.client.get(self.previous_releases_url)
-        parent_page = self.article_series.get_parent()
-        # confirm that current breadcrumb is there and that current breadcrumb points to the parent page
-        # TODO currently this test points to the article page not to the series page
-        # f'<a class="ons-breadcrumbs__link" href="{self.article_series.url}">{self.article_series.title}</a>',
 
+        # confirm the articles index container page is not in the breadcrumb
+        articles_index = self.article_series.get_parent()
+        articles_index_url = articles_index.get_full_url(request=self.dummy_request)
+        self.assertNotContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
+            html=True,
+        )
+
+        # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
+        topic_page = articles_index.get_parent()
+        topic_url = topic_page.get_full_url(request=self.dummy_request)
         self.assertContains(
             response,
-            f'<a class="ons-breadcrumbs__link" href="{parent_page.full_url}">{parent_page.title}</a>',
+            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
             html=True,
         )
 

--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -456,18 +456,19 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
         # Breadcrumbs
         content = response.content.decode(encoding="utf-8")
 
-        topic = self.page.get_parent().get_parent()
+        articles_index = self.page.get_parent().get_parent()
+        articles_index_full_url = articles_index.get_full_url(request=request)
+        topic = articles_index.get_parent()
         topic_full_url = topic.get_full_url(request=request)
-        theme = topic.get_parent()
-        theme_full_url = theme.get_full_url(request=request)
 
-        self.assertInHTML(
-            f'<a class="ons-breadcrumbs__link" href="{topic_full_url}">{topic.title}</a>',
+        # The articles index is a non-navigable container, so it is excluded from the breadcrumb.
+        self.assertNotIn(
+            f'<a class="ons-breadcrumbs__link" href="{articles_index_full_url}">{articles_index.title}</a>',
             content,
         )
 
         self.assertInHTML(
-            f'<a class="ons-breadcrumbs__link" href="{theme_full_url}">{theme.title}</a>',
+            f'<a class="ons-breadcrumbs__link" href="{topic_full_url}">{topic.title}</a>',
             content,
         )
 

--- a/cms/core/tests/test_models.py
+++ b/cms/core/tests/test_models.py
@@ -156,25 +156,22 @@ class PageBreadcrumbsTestCase(TestCase):
         """Test that get_breadcrumbs correctly outputs the parent pages in the correct format."""
         breadcrumbs_output = self.statistical_article.get_breadcrumbs(request=self.dummy_request)
 
-        series_parent = self.series.get_parent()
+        # The articles index page is a non-navigable container, so it is excluded from the trail.
+        topic = self.series.get_parent().get_parent()
 
         expected_entries = [
             {
-                "url": series_parent.get_site().root_url,
+                "url": self.statistical_article.get_site().root_url,
                 "text": "Home",
             },
             {
-                "url": series_parent.get_parent().get_full_url(request=self.dummy_request),
-                "text": series_parent.get_parent().title,
-            },
-            {
-                "url": series_parent.get_full_url(request=self.dummy_request),
-                "text": series_parent.title,
+                "url": topic.get_full_url(request=self.dummy_request),
+                "text": topic.title,
             },
         ]
 
         self.assertIsInstance(breadcrumbs_output, list)
-        self.assertEqual(len(breadcrumbs_output), 3)
+        self.assertEqual(len(breadcrumbs_output), 2)
         self.assertListEqual(breadcrumbs_output, expected_entries)
 
     def test_breadcrumbs_include_self(self):
@@ -182,20 +179,17 @@ class PageBreadcrumbsTestCase(TestCase):
         self.dummy_request.is_for_subpage = True
         breadcrumbs_output = self.statistical_article.get_breadcrumbs(request=self.dummy_request)
 
-        series_parent = self.series.get_parent()
+        # The articles index page is a non-navigable container, so it is excluded from the trail.
+        topic = self.series.get_parent().get_parent()
 
         expected_entries = [
             {
-                "url": series_parent.get_site().root_url,
+                "url": self.statistical_article.get_site().root_url,
                 "text": "Home",
             },
             {
-                "url": series_parent.get_parent().get_full_url(request=self.dummy_request),
-                "text": series_parent.get_parent().title,
-            },
-            {
-                "url": series_parent.get_full_url(request=self.dummy_request),
-                "text": series_parent.title,
+                "url": topic.get_full_url(request=self.dummy_request),
+                "text": topic.title,
             },
             {
                 "url": self.statistical_article.get_full_url(request=self.dummy_request),
@@ -204,7 +198,7 @@ class PageBreadcrumbsTestCase(TestCase):
         ]
 
         self.assertIsInstance(breadcrumbs_output, list)
-        self.assertEqual(len(breadcrumbs_output), 4)
+        self.assertEqual(len(breadcrumbs_output), 3)
         self.assertListEqual(breadcrumbs_output, expected_entries)
 
 

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -39,6 +39,8 @@ class MethodologyIndexPage(BasePage):  # type: ignore[django-manager-missing]
     parent_page_types: ClassVar[list[str]] = ["topics.TopicPage"]
     page_description = "A place for all methodologies."
     preview_modes: ClassVar[list[str]] = []  # Disabling the preview mode as this redirects away
+    # The index page is a container that cannot be navigated to, so omit it from breadcrumbs.
+    exclude_from_breadcrumbs = True
 
     content_panels: ClassVar[list[Panel]] = [
         *Page.content_panels,

--- a/cms/methodology/tests/test_pages.py
+++ b/cms/methodology/tests/test_pages.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 
 from django.urls import reverse
+from wagtail.coreutils import get_dummy_request
 from wagtail.rich_text import RichText
 from wagtail.test.utils import WagtailPageTestCase
 
@@ -44,6 +45,28 @@ class MethodologyPageTest(WagtailPageTestCase):
 
     def test_default_route_rendering(self):
         self.assertPageIsRenderable(self.page)
+
+    def test_breadcrumb_excludes_methodology_index(self):
+        response = self.client.get(self.page.url)
+        dummy_request = get_dummy_request()
+
+        # confirm the methodology index container page is not in the breadcrumb
+        methodology_index = self.page.get_parent()
+        methodology_index_url = methodology_index.get_full_url(request=dummy_request)
+        self.assertNotContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{methodology_index_url}">{methodology_index.title}</a>',
+            html=True,
+        )
+
+        # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
+        topic_page = methodology_index.get_parent()
+        topic_url = topic_page.get_full_url(request=dummy_request)
+        self.assertContains(
+            response,
+            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
+            html=True,
+        )
 
     def test_methodology_page_uses_correct_toc_class(self):
         """Test that the methodology page uses the correct table of contents class."""


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses CMS-987 and removes inaccessible pages from the Navigational Breadcrumb Trail.

Specifically, the Methodology Index Page and Articles Index Page are not linked to anymore.

### How to review

1. Create or go to an existing Methodology page
2. Look at the breadcrumbs
3. Ensure that the Methodology Index Page is not included in the trail
4. Create or go to an existing Statistical Article page
5. Look at the breadcrumbs
6. Ensure that the Article Index page is not included in the trail

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

From the ticket: _Theme pages are to be added/moved over to Wagtail in a later phase of delivery and then will have to be added in the Breadcrumb trail_
