### PR TITLE
Pass meta description to page config

### DIFF
--- a/cms/core/templatetags/page_config_tags.py
+++ b/cms/core/templatetags/page_config_tags.py
@@ -194,17 +194,20 @@ def _get_page_config(context: jinja2.runtime.Context, page: BasePage | None, sit
         page_title = context.get("page_title")
         canonical_url = absolute_url
         body_classes = ""
+        description = ""
     else:
         is_homepage = page.pk == site.root_page_id
         page_title = context.get("page_title") or page.seo_title or getattr(page, "display_title", page.title)
         canonical_url = page.get_canonical_url(request)
         body_classes = "template-" + page._meta.verbose_name.lower().replace(" ", "-")  # type: ignore[union-attr]
+        description = getattr(page, "search_description", "")
 
     page_config = {
         "title": _add_site_name_to_page_title(page_title, site, is_homepage) if page_title else None,
         "bodyClasses": body_classes,
         "header": {"language": {"languages": get_translation_urls(request)}},
         "meta": {"hrefLangs": get_hreflangs(request), "canonicalUrl": canonical_url},
+        "description": description,
         "absoluteUrl": absolute_url,
     }
 

--- a/cms/core/tests/test_pages.py
+++ b/cms/core/tests/test_pages.py
@@ -245,6 +245,32 @@ class SocialMetaTests(WagtailPageTestCase):
             f'<meta property="og:image" content="{settings.DEFAULT_OG_IMAGE_URL}" />',
         )
 
+    def test_meta_description(self):
+        """Test that the meta description tag is populated with the page's search description."""
+        self.page.search_description = "This is a search description."
+        self.page.save(update_fields=["search_description"])
+
+        response = self.client.get(self.page.get_url(request=self.dummy_request))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        self.assertContains(
+            response,
+            '<meta name="description" content="This is a search description." />',
+            html=True,
+        )
+
+    def test_no_meta_description_tag(self):
+        """Test that the meta description tag is not present when there is no
+        search description or its body is empty.
+        """
+        self.page.search_description = ""  # Set to empty string to test empty description case
+        self.page.save(update_fields=["search_description"])
+
+        response = self.client.get(self.page.get_url(request=self.dummy_request))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        self.assertNotContains(response, '<meta name="description"')
+
 
 class ErrorPageTests(TranslationResetMixin, WagtailPageTestCase):
     def get_template_side_effect(self, template_name, *args, **kwargs):

--- a/cms/core/tests/test_tags.py
+++ b/cms/core/tests/test_tags.py
@@ -355,6 +355,13 @@ class PageConfigTestCase(TestCase):
         config = get_page_config({"page": self.page, "request": self.request, "page_title": "custom title"})
         self.assertEqual(config["title"], "Office for National Statistics - custom title")
 
+    def test_page_meta_description(self):
+        self.page.search_description = "This is a search description."
+        self.page.save(update_fields=["search_description"])
+
+        config = get_page_config({"page": self.page, "request": self.request})
+        self.assertEqual(config["description"], "This is a search description.")
+
     def test_config_no_page(self):
         with self.assertNumQueries(6):
             config = get_page_config({"request": self.request, "page_title": "not found"})


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses DPD-4663 and ensures that the meta description defined in the Wagtail admin panel is passed to the page config, so that it is rendered in the appropriate meta tag.

<img width="377" height="166" alt="image" src="https://github.com/user-attachments/assets/0838f69f-0cda-4932-be8e-f7209cb3ab45" />


### How to review

1. Create or edit an existing page
2. Go to the _Promote_ tab
3. Set the _Meta Description_ field to `This is my description`
4. Save and publish the page
5. Load the page in a browser and inspect its markup
6. Confirm that `<meta name="description" content="This is my description">` is present in the `head`

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions
N/A
