### PR TITLE
bug: Show full series and edition title in release calendar preview

### DIFF
--- a/cms/bundles/tests/test_utils.py
+++ b/cms/bundles/tests/test_utils.py
@@ -2,6 +2,7 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
 from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
@@ -21,6 +22,7 @@ from cms.bundles.utils import (
     in_active_bundle,
     in_bundle_ready_to_be_published,
     publish_bundle,
+    serialize_bundle_content_for_preview_release_calendar_page,
     serialize_bundle_content_for_published_release_calendar_page,
 )
 from cms.core.tests.utils import rebuild_internal_search_index
@@ -654,3 +656,26 @@ class PublishBundleFailureTests(TestCase):
 
         # Failure notification should still be sent when update_status=False
         mock_notify_failure.assert_called_once()
+
+
+class SerializePreviewBundleContentTests(TestCase):
+    """Tests for serialize_bundle_content_for_preview_release_calendar_page."""
+
+    def setUp(self):
+        series = ArticleSeriesPageFactory(title="Business demography, UK")
+        self.article = StatisticalArticlePageFactory(
+            parent=series,
+            title="2024",
+            news_headline="",
+        )
+        self.bundle = BundleFactory()
+        BundlePageFactory(parent=self.bundle, page=self.article)
+
+    def test_preview_publication_title_includes_series_name(self):
+        """Publication links in preview must show 'Series: Edition', not just 'Edition'."""
+        content = serialize_bundle_content_for_preview_release_calendar_page(self.bundle, AnonymousUser())
+
+        self.assertEqual(
+            content[0]["value"]["links"][0]["value"]["title"],
+            self.article.display_title + " (Draft)",
+        )

--- a/cms/bundles/tests/test_views.py
+++ b/cms/bundles/tests/test_views.py
@@ -538,8 +538,8 @@ class PreviewBundleReleaseCalendarViewTestCase(WagtailTestUtils, TestCase):
         response = self.client.get(self.preview_url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-        self.assertContains(response, statistical_article.title)
-        self.assertContains(response, methodology_article.title)
+        self.assertContains(response, statistical_article.display_title)
+        self.assertContains(response, methodology_article.display_title)
         self.assertContains(response, bundle_dataset_a.dataset.title)
         self.assertContains(response, bundle_dataset_b.dataset.title)
         self.assertContains(response, bundle_dataset_c.dataset.title)
@@ -553,19 +553,19 @@ class PreviewBundleReleaseCalendarViewTestCase(WagtailTestUtils, TestCase):
         response = self.client.get(self.preview_url)
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertContains(response, f"{statistical_article.title} (Draft)")
+        self.assertContains(response, f"{statistical_article.display_title} (Draft)")
 
         workflow_state = mark_page_as_ready_for_review(statistical_article, self.publishing_officer)
 
         response = self.client.get(self.preview_url)
 
-        self.assertContains(response, f"{statistical_article.title} (In Preview)")
+        self.assertContains(response, f"{statistical_article.display_title} (In Preview)")
 
         progress_page_workflow(workflow_state)
 
         response = self.client.get(self.preview_url)
 
-        self.assertContains(response, f"{statistical_article.title} (Ready to publish)")
+        self.assertContains(response, f"{statistical_article.display_title} (Ready to publish)")
 
     def test_preview_release_calendar_page_has_preview_bar(self):
         self.client.force_login(self.publishing_officer)

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -183,7 +183,7 @@ def serialize_preview_page(page: Page, bundle_id: int, is_previewable: bool) -> 
         "type": "item",
         "value": {
             "page": None,
-            "title": f"{specific_page.title} ({state})",
+            "title": getattr(specific_page, "display_title", specific_page.title) + " (" + state + ")",
             "description": getattr(specific_page, "summary", ""),
             "external_url": (reverse("bundles:preview", args=[bundle_id, page.pk]) if is_previewable else "#"),
         },


### PR DESCRIPTION
### What is the context of this PR?

Ticket: [DPD-3542](https://officefornationalstatistics.atlassian.net/browse/DPD-3542?atlOrigin=eyJpIjoiZWY4YjZiOTVmZjlhNDY3YWIxM2VjODk5MDc0NTEyOTciLCJwIjoiaiJ9)

Under the Publications section of a release calendar entry, the link text for a statistical article showed only the edition (e.g. "2024") rather than the full series and edition title (e.g. "Business demography, UK: 2024"). This affected the preview view during the build, published view was unaffected because it resolves the title from the live page object.

### How to review

1. Create an article series page (e.g. "Business demography, UK")
2. Create a statistical article page under it (e.g. titled "2024")
3. Create a bundle, attach a release calendar entry, and add the article to the bundle
4. Preview the release calendar entry
5. Under Publications, the link should now read "Business demography, UK: 2024 (Draft)" rather than "2024 (Draft)"

### Deployment Safety

- [x] Safe to auto-deploy

### Follow-up Actions

None.