### PR TITLE
Allow multiple related links blocks per section

### DIFF
--- a/cms/core/blocks/section_blocks.py
+++ b/cms/core/blocks/section_blocks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from django.utils.text import slugify
 from wagtail.blocks import RichTextBlock, StreamBlock, StructBlock
@@ -57,7 +57,6 @@ class SectionContentBlock(StreamBlock):
 
     class Meta:
         template = "templates/components/streamfield/stream_block.html"
-        block_counts: ClassVar[dict[str, dict]] = {"related_links": {"max_num": 1}}
 
 
 class SectionBlock(StructBlock):


### PR DESCRIPTION
### What is the context of this PR?

Ticket [DPD-2549](https://officefornationalstatistics.atlassian.net/browse/DPD-2549?atlOrigin=eyJpIjoiOGE5NmU3NDRjNTU0NDgxY2IxMjI0NjQ3MzZiM2RlNzUiLCJwIjoiaiJ9)

Small change to remove the `max_num=1` constraint on `related_links` blocks within `SectionContentBlock`, allowing editors to add more than one related links block per section on statistical article and methodology pages. 

 ### How to review

1. Go to a statistical article or methodology page in the admin.
2. Open a section and add two **Related links** content blocks.
3. Save, previously this would show: _"Related links: The maximum number of items is 1"_.
4. Confirm the page saves without a validation error.

### Deployment Safety

- [x] Safe to auto-deploy

### Follow-up Actions

None.
