### PR TITLE
Remove unpreviewable pages from bundle previews

### DIFF
--- a/cms/bundles/models.py
+++ b/cms/bundles/models.py
@@ -14,6 +14,7 @@ from wagtail.admin.panels import FieldRowPanel
 from wagtail.models import Orderable, Page
 from wagtail.search import index
 
+from cms.articles.models import ArticleSeriesPage
 from cms.core.widgets import ONSAdminDateTimeInput
 from cms.home.models import HomePage
 from cms.topics.models import TopicPage
@@ -44,7 +45,7 @@ if TYPE_CHECKING:
 
     from cms.teams.models import Team
 
-PREVIEWER_EXCLUDED_PAGE_TYPES = (HomePage, TopicPage)
+PREVIEWER_EXCLUDED_PAGE_TYPES = (HomePage, TopicPage, ArticleSeriesPage)
 
 
 class BundlePage(Orderable):

--- a/cms/bundles/tests/test_models.py
+++ b/cms/bundles/tests/test_models.py
@@ -4,12 +4,13 @@ from django.urls import reverse
 from django.utils import timezone
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
 
-from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
 from cms.bundles.enums import BundleStatus
 from cms.bundles.models import BundleTeam
 from cms.bundles.tests.factories import BundleFactory, BundlePageFactory
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.teams.models import Team
+from cms.topics.tests.factories import TopicPageFactory
 from cms.users.tests.factories import UserFactory
 from cms.workflows.tests.utils import mark_page_as_ready_to_publish
 
@@ -135,6 +136,28 @@ class BundleModelTestCase(TestCase):
             with self.subTest(status=status):
                 self.bundle.status = status
                 self.assertEqual(self.bundle.has_unpublished_changes, expected)
+
+    def test_get_pages_for_previewers(self):
+        """Test that get_pages_for_previewers returns the correct pages."""
+        topic_page = TopicPageFactory()
+        article_series_page = ArticleSeriesPageFactory()
+
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+        BundlePageFactory(parent=self.bundle, page=topic_page)
+        BundlePageFactory(parent=self.bundle, page=article_series_page)
+
+        mark_page_as_ready_to_publish(self.statistical_article)
+        mark_page_as_ready_to_publish(topic_page)
+        mark_page_as_ready_to_publish(article_series_page)
+
+        pages_for_previewers = self.bundle.get_pages_for_previewers()
+
+        self.assertEqual(len(pages_for_previewers), 1)
+
+        self.assertIn(self.statistical_article, pages_for_previewers)
+
+        self.assertNotIn(topic_page, pages_for_previewers)
+        self.assertNotIn(article_series_page, pages_for_previewers)
 
 
 class BundledPageMixinTestCase(WagtailTestUtils, TestCase):

--- a/cms/bundles/tests/test_utils.py
+++ b/cms/bundles/tests/test_utils.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
+from django.urls import reverse
 
 from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
@@ -17,6 +18,7 @@ from cms.bundles.utils import (
     get_dataset_preview_key,
     get_language_code_from_page,
     get_pages_in_active_bundles,
+    get_preview_items_for_bundle,
     in_active_bundle,
     in_bundle_ready_to_be_published,
     publish_bundle,
@@ -629,3 +631,42 @@ class PublishBundleFailureTests(TestCase):
 
         # Failure notification should still be sent when update_status=False
         mock_notify_failure.assert_called_once()
+
+
+class GetPreviewItemsForBundleTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.bundle = BundleFactory()
+        # StatisticalArticlePage defines preview modes and can be previewed.
+        cls.article_page = StatisticalArticlePageFactory(title="The article")
+        # ArticleSeriesPage sets preview_modes = [] and cannot be previewed.
+        cls.series_page = ArticleSeriesPageFactory(title="The series")
+
+    def test_includes_pages_with_preview_modes(self):
+        items = get_preview_items_for_bundle(
+            bundle=self.bundle,
+            current_id=self.article_page.pk,
+            pages_in_bundle=[self.article_page],
+        )
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["value"], reverse("bundles:preview", args=[self.bundle.id, self.article_page.pk]))
+
+    def test_excludes_pages_without_preview_modes(self):
+        items = get_preview_items_for_bundle(
+            bundle=self.bundle,
+            current_id=self.series_page.pk,
+            pages_in_bundle=[self.series_page],
+        )
+
+        self.assertEqual(items, [])
+
+    def test_excludes_only_pages_without_preview_modes_when_mixed(self):
+        items = get_preview_items_for_bundle(
+            bundle=self.bundle,
+            current_id=self.article_page.pk,
+            pages_in_bundle=[self.article_page, self.series_page],
+        )
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["value"], reverse("bundles:preview", args=[self.bundle.id, self.article_page.pk]))

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -19,7 +19,7 @@ from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.form_data import inline_formset, nested_form_data
 
-from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
 from cms.bundles.clients.api import BundleAPIClientError
 from cms.bundles.enums import PUBLISHED_BUNDLE_STATUSES, BundleStatus
 from cms.bundles.models import Bundle, BundleTeam
@@ -915,6 +915,33 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
         self.assertContains(
             response,
             f'<a href="{expected_preview_url}" class="button button-small button-secondary">Preview</a>',
+            html=True,
+        )
+
+    def test_inspect_view__no_preview_button_for_pages_without_preview_modes(self):
+        # ArticleSeriesPage sets preview_modes = [] and cannot be previewed.
+        page = ArticleSeriesPageFactory(title="Series without preview")
+        BundlePageFactory(parent=self.bundle, page=page)
+
+        response = self.client.get(reverse("bundle:inspect", args=[self.bundle.pk]))
+
+        preview_url = reverse("bundles:preview", args=[self.bundle.pk, page.pk])
+        self.assertContains(response, page.get_admin_display_title())
+        self.assertNotContains(response, f'<a href="{preview_url}"')
+
+    def test_inspect_view__shows_view_live_for_published_page_without_preview_modes(self):
+        # A page without preview modes should still get a "View Live" link once published.
+        page = ArticleSeriesPageFactory(title="Published series without preview", live=True)
+        BundlePageFactory(parent=self.bundle, page=page)
+        self.bundle.status = BundleStatus.PUBLISHED
+        self.bundle.save(update_fields=["status"])
+
+        response = self.client.get(reverse("bundle:inspect", args=[self.bundle.pk]))
+
+        expected_live_url = page.get_url(request=get_dummy_request())
+        self.assertContains(
+            response,
+            f'<a href="{expected_live_url}" class="button button-small button-secondary">View Live</a>',
             html=True,
         )
 

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -289,6 +289,7 @@ def get_preview_items_for_bundle(
             "selected": item.pk == current_id,
         }
         for item in pages_in_bundle
+        if item.specific_class.preview_modes != []  # Exclude pages with no preview modes
     ]
 
     if release_calendar_page := bundle.release_calendar_page:

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -3,7 +3,7 @@ from __future__ import annotations  # needed for unquoted forward references bec
 import logging
 import textwrap
 import time
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -52,6 +52,8 @@ logger = logging.getLogger(__name__)
 
 # Fallback value for missing dataset metadata
 MISSING_VALUE = "Data missing"
+
+PREVIEW_BUTTON_LABEL = "Preview"
 
 
 def add_exception_cause_to_form(exception: Exception, *, form: BaseForm) -> None:
@@ -468,7 +470,20 @@ class BundleInspectView(InspectView):
                         page.pk,
                     ),
                 ),
-                "Preview",
+                PREVIEW_BUTTON_LABEL,
+            )
+
+        def get_button(page: Page) -> Literal[""] | SafeString:
+            url, label = get_action(page)
+
+            # Pages with no preview modes cannot be previewed
+            if label == PREVIEW_BUTTON_LABEL and page.specific_class.preview_modes == []:
+                return ""
+
+            return format_html(
+                '<a href="{}" class="button button-small button-secondary">{}</a>',
+                url,
+                label,
             )
 
         data = (
@@ -477,15 +492,14 @@ class BundleInspectView(InspectView):
                 page.get_admin_display_title(),
                 page.get_verbose_name(),
                 get_page_status(page),
-                *get_action(page),
+                get_button(page),
             )
             for page in pages
         )
 
         page_data = format_html_join(
             "\n",
-            '<tr><td class="title"><strong><a href="{}">{}</a></strong></td><td>{}</td><td>{}</td> '
-            '<td><a href="{}" class="button button-small button-secondary">{}</a></td></tr>',
+            '<tr><td class="title"><strong><a href="{}">{}</a></strong></td><td>{}</td><td>{}</td> <td>{}</td></tr>',
             data,
         )
 


### PR DESCRIPTION
### What is the context of this PR?

This PR relates to CMS-986 and addresses an issue discovered during the testing of that ticket.

Specifically, it was discovered that Article Series pages in a bundle were allowed to be previewed. They weren't supposed to have a "Preview" button, nor be listed in the list of pages in the dropdown.

This change fixes that by hiding the Preview button for all page types which do not have any preview modes.

### How to review

1. Ensure you have an article series page and and a statistical article page which are able to be added to a bundle
2. Create a new bundle
3. Add both the series and article pages
4. Save the bundle
5. Go to the inspect view
6. Confirm that the Preview button is not present next to the Article Series page's entry in the table
7. Confirm that the Preview button _is_ present next to the article page
8. View the preview of the article page
9. Click on the dropdown
10. Confirm that the article series page is not listed there.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
