### PR TITLE
Correctly suppress codeql warning

### DIFF
--- a/cms/core/utils.py
+++ b/cms/core/utils.py
@@ -103,8 +103,8 @@ def redirect(
 
     User-provided redirect targets must be validated before calling this helper.
     """
-    # codeql[py/url-redirection] This intentionally preserves Django's redirect helper contract.
     return _redirect(
+        # codeql[py/url-redirection] This intentionally preserves Django's redirect helper contract.
         to,
         *args,
         permanent=permanent,


### PR DESCRIPTION
### What is the context of this PR?

The [CodeQL suppression that recently merged](https://github.com/ONSdigital/dis-wagtail/pull/672) was not quite correct. This should correctly suppress it. Note, this will only work if `AlertSupression.ql` is loaded by the codeql action (which it should be). Once merged, I will raise any follow-up PR if there are still issues.

### How to review

You could run it locally

1. `brew install --cask codeql`
2. `codeql pack download codeql/python-queries`
3. Run CodeQL:
```bash
rm -rf /tmp/codeql-db /tmp/codeql-results.sarif

codeql database create /tmp/codeql-db \
  --language=python \
  --source-root=.

codeql database analyze /tmp/codeql-db \
  codeql/python-queries \
  codeql/python-queries:AlertSuppression.ql \
  --format=sarif-latest \
  --output=/tmp/codeql-results.sarif
```
4. Check for the supression:
```bash
jq -r '
  .runs[].results[]
  | select(.ruleId == "py/url-redirection")
  | select(.locations[0].physicalLocation.artifactLocation.uri == "cms/core/utils.py")
  | {
      line: .locations[0].physicalLocation.region.startLine,
      message: .message.text,
      suppressions: (.suppressions // [])
    }
' /tmp/codeql-results.sarif
```
5. You should see:
```
{
  "line": 108,
  "message": "Untrusted URL redirection depends on a [user-provided value](1).",
  "suppressions": [
    {
      "kind": "inSource"
    }
  ]
}
```

**Note running the same on main should show the `suppressions` as `[]`.**


### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
