### PR TITLE
ignore vuln in `http-proxy-middleware` for now

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,3 +5,7 @@ reason = "Keeping dependencies in line with design system until further discussi
 [[IgnoredVulns]]
 id = "GHSA-h67p-54hq-rp68"
 reason = "Keeping dependencies in line with design system until further discussions"
+
+[[IgnoredVulns]]
+id = "GHSA-64mm-vxmg-q3vj"
+reason = "No valid upgrade path"


### PR DESCRIPTION
### What is the context of this PR?

Ignore osv-scanner flagging issue with `http-proxy-middleware` as there currently is no valid upgrade path.

### How to review

Check ID is correct and reasoning is valid.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
