### PR TITLE
fix: calendar entries showing "Add to Bundle" after being added to a bundle

### DIFF
--- a/cms/bundles/tests/test_utils.py
+++ b/cms/bundles/tests/test_utils.py
@@ -30,6 +30,7 @@ from cms.core.tests.utils import rebuild_internal_search_index
 from cms.methodology.models import MethodologyPage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.release_calendar.models import ReleaseCalendarPage
+from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.standard_pages.models import IndexPage, InformationPage
 from cms.topics.models import TopicPage
 
@@ -65,6 +66,13 @@ class BundlesUtilsTestCase(TestCase):
 
     def test_get_pages_in_active_bundles(self):
         self.assertEqual(get_pages_in_active_bundles(), [self.page_in_active_bundle.pk])
+
+    def test_get_pages_in_active_bundles__includes_release_calendar_page_of_active_bundle(self):
+        """An RC page set as release_calendar_page for an active bundle must also be excluded."""
+        rc_page = ReleaseCalendarPageFactory()
+        BundleFactory(release_calendar_page=rc_page)  # DRAFT = active
+
+        self.assertIn(rc_page.pk, get_pages_in_active_bundles())
 
     def test_in_active_bundle(self):
         self.assertTrue(in_active_bundle(self.page_in_active_bundle))

--- a/cms/bundles/tests/test_views.py
+++ b/cms/bundles/tests/test_views.py
@@ -151,6 +151,17 @@ class AddToBundleViewTestCase(WagtailTestUtils, TestCase):
         self.assertRedirects(response, "/admin/")
         self.assertContains(response, "Page &#x27;PSF: November 2024&#x27; is already in a bundle")
 
+    def test_dispatch__warning_includes_bundle_name_for_rc_page_added_via_bundlepage(self):
+        """Warning message must name the bundle when an RC page is in a bundle via the BundlePage path."""
+        rc_page = ReleaseCalendarPageFactory()
+        bundle = BundleFactory(name="RC Bundle", bundled_pages=[rc_page])
+        add_url = reverse("bundles:add_to_bundle", args=[rc_page.id])
+
+        response = self.client.get(add_url, follow=True)
+
+        self.assertRedirects(response, "/admin/")
+        self.assertContains(response, f"is already in a bundle (&#x27;{bundle.name}&#x27;)")
+
     def test_post__successful(self):
         """Checks that on successful post, the page is added to the bundle and
         we get redirected to the valid next URL.

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -1644,6 +1644,17 @@ class BundlePageChooserViewsetTestCase(WagtailTestUtils, TestCase):
 
         self.assertContains(response, self.page_draft_in_bundle.get_admin_display_title())
 
+    def test_choose_view__excludes_release_calendar_page_of_active_bundle(self):
+        """An RC page that is the release_calendar_page for an active bundle must not appear in the chooser."""
+        rc_page = ReleaseCalendarPageFactory(title="RC page set as schedule for active bundle")
+        rc_page.save_revision()
+        BundleFactory(release_calendar_page=rc_page)  # DRAFT = active
+
+        response = self.client.get(self.chooser_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, rc_page.get_admin_display_title())
+
     def test_choose_view__excludes_aliases(self):
         # create an alias for one of the pages
         self.page_draft.copy_for_translation(

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -116,11 +116,19 @@ def get_bundleable_page_types() -> list[type[Page]]:
 
 def get_pages_in_active_bundles() -> list[int]:
     # using this rather than inline import to placate pyright complaining about cyclic imports
+    bundle_class = resolve_model_string("bundles.Bundle")
     bundle_page_class = resolve_model_string("bundles.BundlePage")
 
-    return list(
-        bundle_page_class.objects.filter(parent__status__in=ACTIVE_BUNDLE_STATUSES).values_list("page", flat=True)
+    bundled_page_ids = bundle_page_class.objects.filter(parent__status__in=ACTIVE_BUNDLE_STATUSES).values_list(
+        "page", flat=True
     )
+
+    rc_page_ids = bundle_class.objects.filter(
+        status__in=ACTIVE_BUNDLE_STATUSES,
+        release_calendar_page__isnull=False,
+    ).values_list("release_calendar_page", flat=True)
+
+    return list(set(bundled_page_ids) | set(rc_page_ids))
 
 
 def _create_content_dict_for_pages(

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -281,6 +281,8 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
 
     @cached_property
     def active_bundles(self) -> QuerySet[Bundle]:
+        # Release Calendar pages can be associated with an active bundle either as the bundle's
+        # release calendar page or through BundlePage; the two paths are mutually exclusive.
         queryset: QuerySet[Bundle] = Bundle.objects.none()
         if self.pk:
             queryset = Bundle.objects.filter(

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -280,12 +280,13 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
         return items
 
     @cached_property
-    def active_bundles(self) -> QuerySet[Bundle]:  # type: ignore[override]
-        if not self.pk:
-            return Bundle.objects.none()
-        return Bundle.objects.filter(
-            Q(release_calendar_page=self) | Q(pk__in=self.bundlepage_set.values_list("parent", flat=True))
-        ).active()
+    def active_bundles(self) -> QuerySet[Bundle]:
+        queryset: QuerySet[Bundle] = Bundle.objects.none()
+        if self.pk:
+            queryset = Bundle.objects.filter(
+                Q(release_calendar_page=self) | Q(pk__in=self.bundlepage_set.values_list("parent", flat=True))
+            ).active()
+        return queryset
 
     @property
     def live_status(self) -> ReleaseStatus | None:

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from django.utils.text import slugify
@@ -13,6 +14,7 @@ from wagtail.models import Page
 from wagtail.search import index
 
 from cms.bundles.mixins import BundledPageMixin
+from cms.bundles.models import Bundle
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, format_date_for_gtm
 from cms.core.custom_date_format import ons_date_format, ons_default_datetime
 from cms.core.fields import StreamField
@@ -39,8 +41,6 @@ if TYPE_CHECKING:
     from django.http import HttpResponse
     from django.template.response import TemplateResponse
     from wagtail.locks import BaseLock
-
-    from cms.bundles.models import Bundle
 
 
 RELEASE_CALENDAR_REDIRECT_PATH = "/releasecalendar"
@@ -283,7 +283,15 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
     def active_bundle(self) -> Bundle | None:
         if not self.pk:
             return None
-        bundle: Bundle | None = self.bundles.active().first()
+        # self.bundles only finds bundles linked via the release_calendar_page FK,
+        # so pages added via BundlePage would be missed. Query both paths directly.
+        bundle: Bundle | None = (
+            Bundle.objects.filter(
+                Q(release_calendar_page=self) | Q(pk__in=self.bundlepage_set.values_list("parent", flat=True))
+            )
+            .active()
+            .first()
+        )
         return bundle
 
     @property

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from django.utils.text import slugify
@@ -280,19 +280,12 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
         return items
 
     @cached_property
-    def active_bundle(self) -> Bundle | None:
+    def active_bundles(self) -> QuerySet[Bundle]:  # type: ignore[override]
         if not self.pk:
-            return None
-        # self.bundles only finds bundles linked via the release_calendar_page FK,
-        # so pages added via BundlePage would be missed. Query both paths directly.
-        bundle: Bundle | None = (
-            Bundle.objects.filter(
-                Q(release_calendar_page=self) | Q(pk__in=self.bundlepage_set.values_list("parent", flat=True))
-            )
-            .active()
-            .first()
-        )
-        return bundle
+            return Bundle.objects.none()
+        return Bundle.objects.filter(
+            Q(release_calendar_page=self) | Q(pk__in=self.bundlepage_set.values_list("parent", flat=True))
+        ).active()
 
     @property
     def live_status(self) -> ReleaseStatus | None:

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -342,6 +342,11 @@ class ReleaseCalendarPageModelTestCase(WagtailTestUtils, TestCase):
         BundleFactory(release_calendar_page=self.page, status=BundleStatus.APPROVED)
         self.assertIsInstance(self.page.get_lock(), ReleasePageInBundleReadyToBePublishedLock)
 
+    def test_active_bundles__includes_bundle_when_added_as_bundled_page(self):
+        """active_bundles must cover the BundlePage path, not only the release_calendar_page FK."""
+        bundle = BundleFactory(bundled_pages=[self.page])
+        self.assertIn(bundle, self.page.active_bundles)
+
 
 class ReleaseCalendarPageAdminTests(WagtailTestUtils, TestCase):
     @classmethod

--- a/cms/release_calendar/tests/test_panels.py
+++ b/cms/release_calendar/tests/test_panels.py
@@ -7,6 +7,8 @@ from wagtail.coreutils import get_dummy_request
 from wagtail.test.utils import WagtailTestUtils
 
 from cms.bundles.enums import BundleStatus
+from cms.bundles.models import BundlePage
+from cms.bundles.panels import BundleNotePanel
 from cms.bundles.tests.factories import BundleFactory
 from cms.release_calendar.panels import ReleaseCalendarBundleNotePanel
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
@@ -75,3 +77,17 @@ class BundleNotePanelTestCase(WagtailTestUtils, TestCase):
                 self.bundle.save(update_fields=["status"])
                 self.assertEqual(self.get_bound_panel(self.page).status, panel_status)
                 del self.page.active_bundle
+
+    def test_bundle_note_panel_shows_bundle_info_when_added_via_bundle_page(self):
+        """Once a page is in a bundle, the panel should show the bundle name, not the 'Add to Bundle' prompt."""
+        page = ReleaseCalendarPageFactory()
+        bundle = BundleFactory(name="Via BundlePage Bundle", status=BundleStatus.DRAFT)
+
+        bundle.bundled_pages.add(BundlePage(page=page))
+        bundle.save()
+
+        panel = BundleNotePanel()
+        bound_panel = panel.bind_to_model(page._meta.model).get_bound_panel(instance=page, request=self.request)
+
+        self.assertNotIn("Add to Bundle", bound_panel.content)
+        self.assertIn("Via BundlePage Bundle", bound_panel.content)

--- a/cms/release_calendar/tests/test_viewsets.py
+++ b/cms/release_calendar/tests/test_viewsets.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from wagtail.models import GroupPagePermission, Locale
 from wagtail.test.utils import WagtailTestUtils
 
-from cms.bundles.tests.factories import BundleFactory
+from cms.bundles.tests.factories import BundleFactory, BundlePageFactory
 from cms.core.tests.utils import rebuild_internal_search_index
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
@@ -86,6 +86,17 @@ class TestFutureReleaseCalendarChooserViewSet(WagtailTestUtils, TestCase):
         self.assertNotContains(response, self.cancelled.title)
         self.assertNotContains(response, self.published.title)
         self.assertNotContains(response, self.past.title)
+
+    def test_chooser_excludes_rc_page_added_as_bundled_page_to_active_bundle(self):
+        """Chooser must exclude RC pages in an active bundle via BundlePage,
+        not only via the release_calendar_page FK.
+        """
+        BundlePageFactory(parent=BundleFactory(), page=self.provisional)
+
+        response = self.client.get(self.chooser_url)
+
+        self.assertNotContains(response, self.provisional.title)
+        self.assertContains(response, self.confirmed.title)
 
     def test_chooser_excludes_aliases(self):
         provisional_alias = self.provisional.copy_for_translation(self.welsh_locale, copy_parents=True, alias=True)

--- a/cms/release_calendar/viewsets.py
+++ b/cms/release_calendar/viewsets.py
@@ -32,6 +32,7 @@ class FutureReleaseCalendarMixin:
             Q(status__in=[ReleaseStatus.CANCELLED, ReleaseStatus.PUBLISHED])
             | Q(release_date__lt=timezone.now())
             | Q(bundles__status__in=ACTIVE_BUNDLE_STATUSES)
+            | Q(bundlepage__parent__status__in=ACTIVE_BUNDLE_STATUSES)
             | Q(alias_of__isnull=False)
         )
         pages: QuerySet[ReleaseCalendarPage] = (


### PR DESCRIPTION
### What is the context of this PR?

Fixes [DPD-2416](https://officefornationalstatistics.atlassian.net/browse/DPD-2416?atlOrigin=eyJpIjoiNjA5MzRiYTE4Y2Q0NDNkYWE5OTRiMjU0NTVmNTNhOWMiLCJwIjoiaiJ9)

Calendar entries still showed the "Add to Bundle" button after being added to bundle via the "Add to Bundle" flow from the page editor.

### How to review

1. Go to Bundles and create a new bundle. Leave page blank.
2. Go to Pages > Release Calendar Index and create or edit a calendar page.
3. At the top of the editor you should see a Bundle panel with an "Add to Bundle" button.
4. Click "Add to Bundle", select the bundle created in step 1, and submit.
5. Redirect happens.
6. Edit the calander page again, you should see instead of 'Add to bundle' at the top: "This page is in the following bundle: \<name\> (Status: Draft)".

**Before**

<img width="459" height="156" alt="Screenshot 2026-06-19 at 11-13-38 Editing Release calendar page test - Wagtail" src="https://github.com/user-attachments/assets/2aba9dfd-f33d-4284-b649-29cf33c0df27" />


**After**

<img width="455" height="163" alt="Screenshot 2026-06-19 at 11-18-33 Editing Release calendar page test - Wagtail" src="https://github.com/user-attachments/assets/e870bc0a-d08c-43e3-9e76-2f173d9ed92b" />

### Deployment Safety

- [x] Safe to auto-deploy

### Follow-up Actions

None