### PR TITLE
Preserve "changes_to_release_date" in release calendar page form before instance is created

### DIFF
--- a/cms/release_calendar/forms.py
+++ b/cms/release_calendar/forms.py
@@ -33,10 +33,6 @@ class ReleaseCalendarPageAdminForm(WagtailAdminPageForm):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        if not self.instance.pk:
-            # Remove the field from the form as there's no previous release date to reference
-            del self.fields["changes_to_release_date"]
-
         # Get the live version of the page for validation comparisons
         self.live_page: ReleaseCalendarPage | None = None
         if self.instance and self.instance.pk:

--- a/cms/release_calendar/tests/test_forms.py
+++ b/cms/release_calendar/tests/test_forms.py
@@ -648,13 +648,13 @@ class ReleaseCalendarPageAdminFormTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(form.cleaned_data["release_date"].second, 0)
 
-    def test_changes_to_release_date_is_removed_from_the_form_on_page_creation(self):
-        """Check that the changes_to_release_date field is not present when creating a new page."""
+    def test_changes_to_release_date_is_not_removed_from_the_form_on_page_creation(self):
+        """Check that the changes_to_release_date field is present when creating a new page."""
         unsaved_page = ReleaseCalendarPageFactory.build()
         form = self.form_class(instance=unsaved_page, data=self.form_data)
 
         self.assertTrue(form.is_valid())
-        self.assertNotIn("changes_to_release_date", form.fields)
+        self.assertIn("changes_to_release_date", form.fields)
 
     def test_changes_to_release_date_is_present_when_editing_an_existing_page(self):
         """Check that the changes_to_release_date field is present when editing an existing page."""


### PR DESCRIPTION
### What is the context of this PR?

Currently with autosave, attempting to submit a release calendar page that was created via autosave in the same editing session will fail with a 500 error.

This occurs because backend logic previously deleted the "changes_to_release_date" field when the page instance was being created, but then required it on subsequent saves. Without autosave a form submission would have caused a page refresh and inserted this back into the page, but this cannot occur when the page is saved via the autosave javascript.

The proposed solution is to keep the field in the form at all stages, and accept the minor UX edge cases that can occur when there is no previous release date to auto-populate the "Previous Date" field if the user attempts to add a "Changes to release date" sub item.

This PR introduces an edge case where a user could attempt to add a "Changes to release date" item, but the readonly input is empty. Attempting to manually save with this empty will refresh the page, flag a required field error but then populate the item with the current release date. This is considered an acceptable regression for now to enable autosave. Users generally should not be adding items to this list before it has been published once and then requires a change to the date that needs a reason for auditing purposes.

There is potentially a UX gap for users migrating release calendar pages from the legacy system, though that is pre-existing and unrelated to this change.

There are potentially some things we could do around this in javascript, but not currently considered worth the effort to maintain for the benefit, but very happy to hear from Torchbox devs if they have any ideas.

### How to review

Happy Path

1. Have autosave enabled
2. Go to create a release calendar page
3. Input minimally required fields
4. Wait for autosave to successfully submit
5. Hit save draft, and make other edits that cause autosave to run
6. Manual & autosaves should submit successfully

Accepted edge cases

1. Have autosave enabled
2. Go to create a release calendar page
3. Input minimally required fields
4. Add an item to the "Changes to release date" section
5. Attempt to save
6. Get a validation error, and "Previous Date" should now be populated
7. Should now be in regular valid form state, can submit or delete and re-add "Changes to release date" items with the correct auto-populated time

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
