### PR TITLE
Fix casing of the time series header

### DIFF
--- a/cms/jinja2/templates/pages/topic_page.html
+++ b/cms/jinja2/templates/pages/topic_page.html
@@ -110,7 +110,7 @@
 
             {% if page.time_series_document_list %}
                 <section id="time-series" class="spacing">
-                    <h2>{{ _("Time Series") }}</h2>
+                    <h2>{{ _("Time series") }}</h2>
                     {# fmt:off #}
                         {{ onsDocumentList({
                                 "headingLevel": 3,

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -92,7 +92,8 @@ msgstr "Set ddata"
 msgid "Methodology"
 msgstr "Methodoleg"
 
-#: cms/core/enums.py:11 cms/topics/models.py:247
+#: cms/core/enums.py:11 cms/jinja2/templates/pages/topic_page.html:113
+#: cms/topics/models.py:247
 msgid "Time series"
 msgstr "Cyfres amser"
 
@@ -762,10 +763,6 @@ msgstr "Gweld yr holl erthyglau cysylltiedig"
 #: cms/jinja2/templates/pages/topic_page.html:105
 msgid "View all related data"
 msgstr "Gweld yr holl ddata cysylltiedig"
-
-#: cms/jinja2/templates/pages/topic_page.html:113
-msgid "Time Series"
-msgstr "Cyfres amser"
 
 #: cms/jinja2/templates/pages/topic_page.html:123
 msgid "View all related time series"

--- a/cms/topics/tests/test_models.py
+++ b/cms/topics/tests/test_models.py
@@ -995,6 +995,6 @@ class TopicPageSearchListingPagesTests(WagtailTestUtils, TestCase):
 
         response = self.client.get(self.topic_page.url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Time Series")
+        self.assertNotContains(response, "Time series")
         self.assertNotContains(response, "View all related time series")
         self.assertNotContains(response, f"/timeseriestool?topic={self.topic_tag.slug_path}")

--- a/cms/topics/tests/test_pages.py
+++ b/cms/topics/tests/test_pages.py
@@ -205,7 +205,7 @@ class TopicPageTests(WagtailPageTestCase):
 
         response = self.client.get(self.page.url)
 
-        self.assertContains(response, "<h2>Time Series</h2>")
+        self.assertContains(response, "<h2>Time series</h2>")
         self.assertContains(response, '<section id="time-series"')
 
         self.assertContains(response, title)

--- a/functional_tests/steps/topic_page.py
+++ b/functional_tests/steps/topic_page.py
@@ -150,7 +150,7 @@ def the_time_series_page_link_is_displayed_on_the_page(context: Context) -> None
     page = context.page
 
     expect(
-        page.locator("#time-series").get_by_role("heading", name="Time Series", exact=True)
+        page.locator("#time-series").get_by_role("heading", name="Time series", exact=True)
     ).to_be_visible()  # Section heading
     expect(page.locator("#time-series").get_by_role("link", name="Page title")).to_be_visible()
     expect(page.locator("#time-series").get_by_text("Time series", exact=True)).to_be_visible()  # Content type label
@@ -159,7 +159,7 @@ def the_time_series_page_link_is_displayed_on_the_page(context: Context) -> None
 
 @then("the time series item appears in the table of contents")
 def the_time_series_item_appears_in_the_table_of_contents(context: Context) -> None:
-    expect(context.page.get_by_role("heading", name="Time Series")).to_be_visible()
+    expect(context.page.get_by_role("heading", name="Time series")).to_be_visible()
 
 
 @then("the user sees the '{link_text}' link")

--- a/functional_tests/steps/topic_page.py
+++ b/functional_tests/steps/topic_page.py
@@ -153,7 +153,7 @@ def the_time_series_page_link_is_displayed_on_the_page(context: Context) -> None
         page.locator("#time-series").get_by_role("heading", name="Time series", exact=True)
     ).to_be_visible()  # Section heading
     expect(page.locator("#time-series").get_by_role("link", name="Page title")).to_be_visible()
-    expect(page.locator("#time-series").get_by_text("Time series", exact=True)).to_be_visible()  # Content type label
+    expect(page.locator("#time-series").locator("span", has_text="Time series")).to_be_visible()  # Content type label
     expect(page.locator("#time-series").get_by_text("Summary")).to_be_visible()
 
 


### PR DESCRIPTION
### What is the context of this PR?

Fixes DPD bug [DPD-2525](https://officefornationalstatistics.atlassian.net/browse/DPD-2525) - correcting the casing of the time series header on the topic page from "Time Series" to "Time series"

### How to review

1. Create a topic page
2. Add a time series page
3. Check the header is displayed on the page in sentence case as "Time series"

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
