### PR TITLE
feat(cache): generalise title change signal for cache purge

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import models, transaction
+from django.db import models
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
@@ -24,7 +24,6 @@ from wagtail.templatetags.wagtailcore_tags import richtext
 from cms.articles.enums import SortingChoices
 from cms.articles.forms import StatisticalArticlePageAdminForm
 from cms.articles.panels import HeadlineFiguresFieldPanel
-from cms.articles.signals import series_title_changed
 from cms.articles.utils import serialize_correction_or_notice
 from cms.bundles.mixins import BundledPageMixin
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, bool_to_yes_no, format_date_for_gtm
@@ -48,8 +47,6 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.template.response import TemplateResponse
     from wagtail.admin.panels import Panel
-
-    from cms.users.models import User
 
 
 logger = logging.getLogger(__name__)
@@ -122,31 +119,6 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         """Returns the summary of the latest article in the series."""
         # TODO: update to include drafts when looking at previews holistically.
         return latest.summary if (latest := self.get_latest()) else ""
-
-    @transaction.atomic
-    def save(  # type: ignore[override]
-        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
-    ) -> ArticleSeriesPage | None:
-        # typing ignored as we need TypedDict but mypy struggles with it
-        original_values = None  # typing: ignore[var-annotated]
-        if self.pk:
-            original_values = ArticleSeriesPage.objects.values("title", "slug").filter(pk=self.pk).first()
-
-        instance: ArticleSeriesPage | None = super().save(  # type: ignore[call-arg]
-            clean=clean, user=user, log_action=log_action, **kwargs
-        )
-
-        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
-            # The title has changed, but not the slug.
-            # The slug change is already handled by the `page_slug_changed` signal.
-            transaction.on_commit(
-                lambda: series_title_changed.send(
-                    sender=self.__class__,
-                    instance=self,
-                )
-            )
-
-        return instance
 
     def get_latest(self) -> StatisticalArticlePage | None:
         latest: StatisticalArticlePage | None = (

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import models, transaction
+from django.db import models
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
@@ -24,7 +24,6 @@ from wagtail.templatetags.wagtailcore_tags import richtext
 from cms.articles.enums import SortingChoices
 from cms.articles.forms import StatisticalArticlePageAdminForm
 from cms.articles.panels import HeadlineFiguresFieldPanel
-from cms.articles.signals import series_title_changed
 from cms.articles.utils import serialize_correction_or_notice
 from cms.bundles.mixins import BundledPageMixin
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, bool_to_yes_no, format_date_for_gtm
@@ -48,8 +47,6 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.template.response import TemplateResponse
     from wagtail.admin.panels import Panel
-
-    from cms.users.models import User
 
 
 logger = logging.getLogger(__name__)
@@ -125,31 +122,6 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         """Returns the summary of the latest article in the series."""
         # TODO: update to include drafts when looking at previews holistically.
         return latest.summary if (latest := self.get_latest()) else ""
-
-    @transaction.atomic
-    def save(  # type: ignore[override]
-        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
-    ) -> ArticleSeriesPage | None:
-        # typing ignored as we need TypedDict but mypy struggles with it
-        original_values = None  # typing: ignore[var-annotated]
-        if self.pk:
-            original_values = ArticleSeriesPage.objects.values("title", "slug").filter(pk=self.pk).first()
-
-        instance: ArticleSeriesPage | None = super().save(  # type: ignore[call-arg]
-            clean=clean, user=user, log_action=log_action, **kwargs
-        )
-
-        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
-            # The title has changed, but not the slug.
-            # The slug change is already handled by the `page_slug_changed` signal.
-            transaction.on_commit(
-                lambda: series_title_changed.send(
-                    sender=self.__class__,
-                    instance=self,
-                )
-            )
-
-        return instance
 
     def get_latest(self) -> StatisticalArticlePage | None:
         latest: StatisticalArticlePage | None = (

--- a/cms/articles/signals.py
+++ b/cms/articles/signals.py
@@ -1,3 +1,0 @@
-from django.dispatch import Signal
-
-series_title_changed = Signal()

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 from django.conf import settings
+from django.db import transaction
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -17,6 +18,7 @@ from cms.core.cache import get_default_cache_control_decorator
 from cms.core.forms import DeduplicateTopicsAdminForm, ONSCopyForm
 from cms.core.permission_testers import BasePagePermissionTester
 from cms.core.query import order_by_pk_position
+from cms.core.signals import page_title_changed
 from cms.locale.utils import get_mapped_site_root_paths
 from cms.taxonomy.mixins import ExclusiveTaxonomyMixin
 
@@ -107,6 +109,23 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
     def permissions_for_user(self, user: User) -> BasePagePermissionTester:
         """Override the permission tester class to use for our page models."""
         return BasePagePermissionTester(user, self)
+
+    @transaction.atomic
+    def save(  # type: ignore[override]
+        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
+    ) -> Self | None:
+        original_values = type(self).objects.values("title", "slug").filter(pk=self.pk).first() if self.pk else None
+
+        instance: Self | None = super().save(  # type: ignore[call-arg]
+            clean=clean, user=user, log_action=log_action, **kwargs
+        )
+
+        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
+            # The title has changed, but not the slug.
+            # The slug change is already handled by the `page_slug_changed` signal.
+            transaction.on_commit(lambda: page_title_changed.send(sender=type(self), instance=self))
+
+        return instance
 
     @cached_property
     def related_pages(self) -> PageQuerySet:

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -122,6 +122,8 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
         self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
     ) -> Self | None:
         update_fields = kwargs.get("update_fields")
+        # Determine if the title field is being updated and fetch the original title if it exists.
+        # If update_fields is None, no field restrictions are applied, so the title could be updated.
         title_is_persisted = update_fields is None or "title" in update_fields
         original_title = (
             type(self).objects.values_list("title", flat=True).filter(pk=self.pk).first()

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -121,8 +121,12 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
     def save(  # type: ignore[override]
         self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
     ) -> Self | None:
+        update_fields = kwargs.get("update_fields")
+        title_is_persisted = update_fields is None or "title" in update_fields
         original_title = (
-            type(self).objects.values_list("title", flat=True).filter(pk=self.pk).first() if self.pk else None
+            type(self).objects.values_list("title", flat=True).filter(pk=self.pk).first()
+            if self.pk and title_is_persisted
+            else None
         )
 
         instance: Self | None = super().save(  # type: ignore[call-arg]

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import transaction
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -20,6 +21,7 @@ from cms.core.cache import get_default_cache_control_decorator
 from cms.core.forms import DeduplicateTopicsAdminForm, ONSCopyForm
 from cms.core.permission_testers import BasePagePermissionTester
 from cms.core.query import order_by_pk_position
+from cms.core.signals import page_title_changed
 from cms.locale.utils import get_mapped_site_root_paths
 from cms.taxonomy.mixins import ExclusiveTaxonomyMixin
 
@@ -114,6 +116,23 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
     def permissions_for_user(self, user: User) -> BasePagePermissionTester:
         """Override the permission tester class to use for our page models."""
         return BasePagePermissionTester(user, self)
+
+    @transaction.atomic
+    def save(  # type: ignore[override]
+        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
+    ) -> Self | None:
+        original_values = type(self).objects.values("title", "slug").filter(pk=self.pk).first() if self.pk else None
+
+        instance: Self | None = super().save(  # type: ignore[call-arg]
+            clean=clean, user=user, log_action=log_action, **kwargs
+        )
+
+        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
+            # The title has changed, but not the slug.
+            # The slug change is already handled by the `page_slug_changed` signal.
+            transaction.on_commit(lambda: page_title_changed.send(sender=type(self), instance=self))
+
+        return instance
 
     @cached_property
     def related_pages(self) -> PageQuerySet:

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -121,15 +121,15 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
     def save(  # type: ignore[override]
         self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
     ) -> Self | None:
-        original_values = type(self).objects.values("title", "slug").filter(pk=self.pk).first() if self.pk else None
+        original_title = (
+            type(self).objects.values_list("title", flat=True).filter(pk=self.pk).first() if self.pk else None
+        )
 
         instance: Self | None = super().save(  # type: ignore[call-arg]
             clean=clean, user=user, log_action=log_action, **kwargs
         )
 
-        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
-            # The title has changed, but not the slug.
-            # The slug change is already handled by the `page_slug_changed` signal.
+        if original_title is not None and self.title != original_title:
             transaction.on_commit(lambda: page_title_changed.send(sender=type(self), instance=self))
 
         return instance

--- a/cms/core/signals.py
+++ b/cms/core/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+# Sent when a page's title changes without its slug changing.
+page_title_changed = Signal()

--- a/cms/core/signals.py
+++ b/cms/core/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-# Sent when a page's title changes without its slug changing.
+# Sent when a persisted page title changes.
 page_title_changed = Signal()

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -247,9 +247,10 @@ def purge_old_page_paths_from_cache_after_move(
         purge_urls_from_cache(urls)
 
 
-def purge_series_children_from_cache(page: ArticleSeriesPage) -> None:
-    # when an article series title changes, we want to purge all child articles too
-    # so they get the updated title
+def purge_descendants_from_cache(page: Page) -> None:
+    # when a page's title changes, we want to purge all descendant pages too, as they
+    # display the title in their breadcrumbs (e.g. an article series title on its editions,
+    # or a topic title on the articles and methodologies beneath it)
     urls = set()
     source_page_ids = set()
     for child in page.get_descendants().live().specific(defer=True).iterator():

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -12,19 +12,19 @@ from wagtail.contrib.redirects.signal_handlers import (
 from wagtail.models import Page, get_page_models
 from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move, published, unpublished
 
-from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage
-from cms.articles.signals import series_title_changed
+from cms.articles.models import ArticlesIndexPage
 from cms.core.models import BasePage, ContactDetails, Definition
+from cms.core.signals import page_title_changed
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage
 from cms.release_calendar.models import ReleaseCalendarIndex
 
 from .cache import (
+    purge_descendants_from_cache,
     purge_old_page_paths_from_cache_after_move,
     purge_old_page_slugs_from_frontend_cache,
     purge_page_containing_snippet_from_cache,
     purge_page_from_frontend_cache,
-    purge_series_children_from_cache,
 )
 
 if TYPE_CHECKING:
@@ -61,8 +61,8 @@ def purge_page_from_frontend_cache_after_move(
     )
 
 
-def purges_series_children_from_frontend_cache(instance: ArticleSeriesPage, **kwargs: Any) -> None:
-    purge_series_children_from_cache(instance)
+def purge_descendants_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
+    purge_descendants_from_cache(instance)
 
 
 def purge_pages_containing_the_published_snippet_from_frontend_cache(instance: Model, **kwargs: Any) -> None:
@@ -106,8 +106,8 @@ def register_signal_handlers() -> None:
         page_published.connect(purge_published_page_from_frontend_cache, sender=model)
         page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
         page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
+        page_title_changed.connect(purge_descendants_from_frontend_cache, sender=model)
 
-    series_title_changed.connect(purges_series_children_from_frontend_cache, sender=ArticleSeriesPage)
     post_page_move.connect(purge_page_from_frontend_cache_after_move)
 
     for model in [ContactDetails, Definition]:

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -289,6 +289,48 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             ]
         )
 
+    def _all_purged_urls(self, patched_purge_urls):
+        """Return the union of all URLs across every purge_urls_from_cache call."""
+        urls: set[str] = set()
+        for purge_call in patched_purge_urls.call_args_list:
+            urls |= purge_call.args[0]
+        return urls
+
+    def test_page_publish__topic_title_change_purges_descendants(self, patched_purge_urls):
+        # The topic title is shown in the breadcrumbs of all pages beneath it, so a title
+        # change must purge the whole descendant subtree (incl. Welsh aliases).
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.title = "New topic title"
+            self.topic_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.topic_page_url, purged)
+        self.assertIn(self.article_url, purged)
+        self.assertIn(self.article_related_data_url, purged)
+        self.assertIn(self.series_url, purged)
+        self.assertIn(self.methodology_page_url, purged)
+        # the Welsh alias of a descendant is purged too
+        self.assertIn(self.methodology_page_translation_url, purged)
+
+    def test_page_publish__topic_without_title_change_skips_descendants(self, patched_purge_urls):
+        # Republishing without a title change must not cascade to descendants.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.topic_page_url, purged)
+        self.assertNotIn(self.article_url, purged)
+        self.assertNotIn(self.methodology_page_url, purged)
+
+    def test_page_publish__index_title_change_purges_descendants(self, patched_purge_urls):
+        with self.captureOnCommitCallbacks(execute=True):
+            self.index_page.title = "New index title"
+            self.index_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.index_page_url, purged)
+        self.assertIn(self.information_page_url, purged)
+
     def test_page_publish__methodology(self, patched_purge_urls):
         self.methodology_page.save_revision().publish()
 

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -322,6 +322,15 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
         self.assertNotIn(self.article_url, purged)
         self.assertNotIn(self.methodology_page_url, purged)
 
+    def test_page_save_revision__title_change_without_publish_skips_descendants(self, patched_purge_urls):
+        # Changing the title on a draft (without publishing) must not purge the cache,
+        # as the live `title` field is untouched until publish.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.title = "New draft topic title"
+            self.topic_page.save_revision()
+
+        patched_purge_urls.assert_not_called()
+
     def test_page_publish__index_title_change_purges_descendants(self, patched_purge_urls):
         with self.captureOnCommitCallbacks(execute=True):
             self.index_page.title = "New index title"

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from datetime import timedelta
 from unittest.mock import call, patch
 


### PR DESCRIPTION
### What is the context of this PR?

This change generalises the title change signal created in PR #505.

It sends a signal whenever a page title changes so that all of its descendants can be purged. This is to update any mentioning of the titles in breadcrumbs etc..

This PR targets the branch of that PR.

### How to review

Ensure that tests pass.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Approve and merge PR #505 

---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ