### PR TITLE
fix(csp): align iframe frame-src with allowed domain validation

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1004,6 +1004,14 @@ if "IFRAME_VISUALISATION_ALLOWED_DOMAINS" in env:
 else:  # Default to ONS allowed link domains if not set
     IFRAME_VISUALISATION_ALLOWED_DOMAINS = ONS_ALLOWED_LINK_DOMAINS
 
+# CSP wildcards do not match the apex domain, so include both `example.com`
+# and `*.example.com` to mirror iframe URL validation.
+IFRAME_VISUALISATION_CSP_SOURCES = [
+    host
+    for domain in IFRAME_VISUALISATION_ALLOWED_DOMAINS
+    for host in (domain, f"*.{domain}" if not domain.startswith(("www.", "*.", "http://", "https://")) else domain)
+]
+
 
 # Allowed path prefixes for iframe visualisations
 IFRAME_VISUALISATION_PATH_PREFIXES = env.get(
@@ -1128,7 +1136,7 @@ WAGTAIL_AUTOSAVE_INTERVAL = int(env.get("WAGTAIL_AUTOSAVE_INTERVAL", 500))
 static_sources = [ONS_CDN_URL, "cdnjs.cloudflare.com"]
 SECURE_CSP: dict[str, list] = {
     "default-src": [CSP.SELF],
-    "frame-src": [CSP.SELF, *IFRAME_VISUALISATION_ALLOWED_DOMAINS],
+    "frame-src": [CSP.SELF, *IFRAME_VISUALISATION_CSP_SOURCES],
     # UNSAFE_INLINE is required by mathjax
     "style-src": [CSP.SELF, *static_sources, CSP.UNSAFE_INLINE, "*.hotjar.com"],
     "img-src": [CSP.SELF, ONS_CDN_URL, "www.googletagmanager.com", "*.hotjar.com"],

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -53,6 +53,16 @@ class SettingsTestCase(TestCase):
             self.assertNotIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
             self.assertEqual(reloaded_base.SECURE_CSP["frame-ancestors"], [CSP.NONE])
 
+    def test_iframe_visualisation_csp_sources_include_subdomains(self):
+        self.addCleanup(importlib.reload, base)
+
+        with mock.patch.dict(os.environ, {"IFRAME_VISUALISATION_ALLOWED_DOMAINS": "example.com"}, clear=False):
+            reloaded_base = importlib.reload(base)
+            self.assertEqual(
+                reloaded_base.IFRAME_VISUALISATION_CSP_SOURCES,
+                ["example.com", "*.example.com"],
+            )
+
 
 class CSPTestCase(TestCase):
     urls = frozenset(["/", "/test404", reverse_lazy("wagtailadmin_login")])
@@ -142,9 +152,9 @@ class CSPTestCase(TestCase):
 
                 csp = self._parse_csp(response.headers["Content-Security-Policy"])
 
-                for allowed_domain in settings.IFRAME_VISUALISATION_ALLOWED_DOMAINS:
-                    with self.subTest(allowed_domain):
-                        self.assertIn(allowed_domain, self._get_csp_expressions(csp, "frame-src"))
+                for allowed_source in settings.IFRAME_VISUALISATION_CSP_SOURCES:
+                    with self.subTest(allowed_source):
+                        self.assertIn(allowed_source, self._get_csp_expressions(csp, "frame-src"))
 
     def test_wagtail_csp(self):
         """https://github.com/wagtail/wagtail/issues?q=is%3Aissue%20state%3Aopen%20csp."""


### PR DESCRIPTION
### What is the context of this PR?

Updates the iframe CSP configuration so `frame-src` matches the existing iframe URL validation rules.

Previously, `IFRAME_VISUALISATION_ALLOWED_DOMAINS` was used directly in CSP, which only allowed exact hosts in `frame-src` meaning domains such as `www.ons.gov.uk` was failings to render visualisaiton.
The Iframe field validation already accepts the apex domain and any subdomain via `is_hostname_in_domain()` so this ensure the CSP policy matches that logic.

This PR adds a derived `IFRAME_VISUALISATION_CSP_SOURCES` setting that expands each allowed domain to:
- `example.com`
- `*.example.com`

This keeps the existing validation behaviour and makes CSP consistent with it.

### How to review

Inspect the response for a Wagtail page and ensure the CSP header shows `frame-src 'self' ons.gov.uk *.ons.gov.uk`

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

- Ensure iframes are now rendering correctly in Sandbox post deploy.
