### PR TITLE
fix(docs): update link for Open Government Licence v3.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,4 +577,4 @@ Copyright © 2024 [Crown Copyright](https://www.nationalarchives.gov.uk/informat
 
 Unless stated otherwise, the codebase is released under the [MIT License](LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation in this repo are released under the [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+The documentation in this repo are released under the [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/).


### PR DESCRIPTION
### What is the context of this PR?

- Lychee's link checker (CI) was flagging `https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/` in the README with a `404`
- Confirmed via curl that the URL returns a genuine 404 directly from the National Archives server (not a transient/CI-only issue), the page has been moved/retired
- Updated the link to the current live page: `https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/`, verified to return `200` and cover the Open Government Licence

### How to review

- Make sure the new URL is all good and correct -> you can visit it, etc
- All the CI checks pass

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
