### PR TITLE
fix: allow approval of pages-only bundles without dataset metadata validation

### DIFF
--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -209,7 +209,7 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
         On drift, the approval is blocked with a `ValidationError` listing the
         changed fields, forcing the approver to reconfirm by submitting again.
         """
-        if not settings.BUNDLE_DATASET_METADATA_VALIDATION_ENABLED or "bundled_datasets" not in self.formsets:
+        if not settings.BUNDLE_DATASET_METADATA_VALIDATION_ENABLED or not self._has_datasets():
             return
 
         if not self.datasets_bundle_api_user_access_token:

--- a/cms/bundles/tests/test_forms_with_bundle_api.py
+++ b/cms/bundles/tests/test_forms_with_bundle_api.py
@@ -593,7 +593,6 @@ class BundleDatasetMetadataValidationTestCase(TestCase):
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data), for_user=self.approver)
 
         self.assertTrue(form.is_valid(), form.errors)
-        self.mock_ons_dataset_class.objects.with_token.assert_not_called()
 
     def test_other_exceptions_raised_during_metadata_validation_are_not_caught(self):
         """Test that unexpected exceptions during metadata validation are not caught and handled gracefully,

--- a/cms/bundles/tests/test_forms_with_bundle_api.py
+++ b/cms/bundles/tests/test_forms_with_bundle_api.py
@@ -6,13 +6,15 @@ from django.test import TestCase, override_settings
 from wagtail.admin.panels import get_edit_handler
 from wagtail.test.utils.form_data import inline_formset, nested_form_data
 
+from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.bundles.clients.api import BundleAPIClient, BundleAPIClientError
 from cms.bundles.enums import BundleStatus
 from cms.bundles.models import Bundle
-from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory
+from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory, BundlePageFactory
 from cms.datasets.models import Dataset, ONSDatasetApiQuerySet
 from cms.datasets.tests.factories import DatasetFactory
 from cms.users.tests.factories import UserFactory
+from cms.workflows.tests.utils import mark_page_as_ready_to_publish
 
 
 @override_settings(DIS_DATASETS_BUNDLE_API_ENABLED=True)
@@ -571,6 +573,26 @@ class BundleDatasetMetadataValidationTestCase(TestCase):
             "Your session has expired. Please sign in again to approve the bundle.",
             form.non_field_errors(),
         )
+        self.mock_ons_dataset_class.objects.with_token.assert_not_called()
+
+    def test_no_datasets_skips_metadata_validation_and_token_check(self):
+        """A pages-only bundle can be approved without an access token, as there is no dataset metadata to
+        validate.
+        """
+        page = StatisticalArticlePageFactory(title="Statistical Article Page for Bundle")
+        mark_page_as_ready_to_publish(page, self.approver)
+        bundle_page = BundlePageFactory(parent=self.bundle, page=page)
+
+        raw_data = {
+            "name": self.bundle.name,
+            "status": BundleStatus.APPROVED,
+            "bundled_pages": inline_formset([{"id": bundle_page.id, "page": page.id, "ORDER": "1"}], initial=1),
+            "bundled_datasets": inline_formset([]),
+            "teams": inline_formset([]),
+        }
+        form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data), for_user=self.approver)
+
+        self.assertTrue(form.is_valid(), form.errors)
         self.mock_ons_dataset_class.objects.with_token.assert_not_called()
 
     def test_other_exceptions_raised_during_metadata_validation_are_not_caught(self):


### PR DESCRIPTION
### What is the context of this PR?

Fixes: https://officefornationalstatistics.atlassian.net/browse/CMS-1261

PR #619 introduced validation that checks bundled datasets' metadata is up to date on approval, guarded by a session-token check.

However, the early-return guard in `_validate_bundled_datasets_metadata` checked whether the `bundled_datasets` formset key exists `("bundled_datasets" not in self.formsets)` rather than whether the bundle actually contains datasets. Since the formset is always present on an editable bundle, just with zero forms when no datasets are added, approving a pages-only bundle incorrectly fell through to the access-token check and failed with: `"Your session has expired. Please sign in again to approve the bundle."`

This change replaces the formset-key check with the existing` _has_datasets()` helper, so the token check and metadata drift validation only run when the bundle genuinely contains datasets. Nothing is lost by the swap: `_has_datasets()` already returns `False` when the formset is absent, and additionally ignores empty, invalid, and deletion-marked dataset forms.

I added a regression test `test_no_datasets_skips_metadata_validation_and_token_check` covering the reported scenario end-to-end: a bundle with only a ready-to-publish page, an empty datasets formset, and no access token is submitted for approval; the form must validate, and the dataset API must never be queried. The test was confirmed to fail against the previous guard. The existing `test_missing_access_token_blocks_approval` continues to cover the inverse case (datasets present, no token → approval blocked).

### How to review
- Review the one-line guard change in cms/bundles/forms.py and the new test in cms/bundles/tests/test_forms_with_bundle_api.py.
- To reproduce manually, `DIS_DATASETS_BUNDLE_API_ENABLED=true`, otherwise the validator is skipped entirely, and the bug won't surface):
- On main, run `DIS_DATASETS_BUNDLE_API_ENABLED=true make runserver` and log in with the standard Wagtail login (so no access_token cookie is present).
  - Create a bundle, add a page and progress it to `Ready to publish`, save the bundle, then set the status to Approved; the `session has expired` error appears.
- On this branch, repeat the approval; the bundle is approved successfully.
- Run the tests: `poetry run python manage.py test cms.bundles --settings=cms.settings.test`  and make sure full `cms.bundles` suite passes; `ruff, pylint, and mypy` are clean).

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
