### PR TITLE
fix(tables): report all table block validation errors

### DIFF
--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -149,12 +149,19 @@ class ONSTableBlock(TinyTableBlock):
 
     def clean(self, value: dict) -> dict:
         """Validate that a subtitle is only present when a title is also provided."""
-        cleaned_value: dict = super().clean(value)
+        block_errors: dict = {}
+
+        try:
+            cleaned_value: dict = super().clean(value)
+        except StructBlockValidationError as e:
+            block_errors = dict(e.block_errors)
+            cleaned_value = value
 
         if cleaned_value.get("subtitle") and not cleaned_value.get("title"):
-            raise StructBlockValidationError(
-                block_errors={"subtitle": ValidationError("Please add a title if you want to add a subtitle.")}
-            )
+            block_errors["subtitle"] = ValidationError("Please add a title if you want to add a subtitle.")
+
+        if block_errors:
+            raise StructBlockValidationError(block_errors=block_errors)
 
         return cleaned_value
 

--- a/cms/core/tests/test_blocks.py
+++ b/cms/core/tests/test_blocks.py
@@ -694,6 +694,25 @@ class ONSTableBlockTestCase(WagtailTestUtils, TestCase):
             "Please add a title if you want to add a subtitle.",
         )
 
+    def test_clean__missing_accessible_label_and_subtitle_without_title_raises_both(self):
+        """Both errors are reported when accessible label is missing and subtitle has no title."""
+        value = self.block.to_python(
+            {
+                "subtitle": "A subtitle",
+                "data": self.simple_table_data,
+            }
+        )
+
+        with self.assertRaises(StructBlockValidationError) as info:
+            self.block.clean(value)
+
+        self.assertIn("caption", info.exception.block_errors)
+        self.assertIn("subtitle", info.exception.block_errors)
+        self.assertEqual(
+            info.exception.block_errors["subtitle"].message,
+            "Please add a title if you want to add a subtitle.",
+        )
+
     def test_clean__subtitle_with_title(self):
         """A subtitle paired with a title is allowed."""
         value = self.block.to_python(


### PR DESCRIPTION


### What is the context of this PR?
Addresses this comment from testing: https://officefornationalstatistics.atlassian.net/browse/CMS-1207?focusedCommentId=777873

This change ensures that the validation for the table block reports field validation errors and the custom 'subtitle without title' validation error at the same time, rather than separately.

### How to review

- Add a table to an information page, with a subtitle, but no title. Don't add an accessible label
- Try to save the page
- You should see 2 validation issues reported at the same time - the missing accessible label, and the fact that you can't have a subtitle without a title.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
