### PR TITLE
fix: ensure teardown on migration tests goes to latest project state

### DIFF
--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -96,31 +96,32 @@ class MigrationTestCase(_TransactionTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+        # register class cleanup to ensure it runs even if setUpClass fails
+        cls.addClassCleanup(cls._restore_latest_state)
         if cls.next_migration is None:
             cls.next_migration = cls.executor.loader.graph.leaf_nodes()
         cls.executor.migrate(cls.next_migration)
         cls.apps = cls.executor.loader.project_state(cls.next_migration).apps
 
-    def tearDown(self):
-        """Restore the migration state to the next_migration after each test."""
-        self.migrate_to(self.next_migration)
-        super().tearDown()
+    def setUp(self):
+        """Restore the migration state to the next_migration before each test."""
+        super().setUp()
 
-    @classmethod
-    def tearDownClass(cls):
-        """Restore the migration state to the latest migration after test cases run.
-
-        Ensures that if anything in the test class fails we still restore correct state for other tests.
-        """
-        cls.executor.loader.build_graph()
-        cls.executor.migrate(cls.executor.loader.graph.leaf_nodes())
-        super().tearDownClass()
+        # Use addCleanup to ensure it runs even if a previous test fails.
+        self.addCleanup(self.migrate_to, self.next_migration)
 
     def migrate_to(self, target: Sequence[tuple[str, str]] | None = None):
         """Helper to migrate to a specific target state."""
+        self.executor.loader.build_graph()
         self.executor.migrate(target)
         self.apps = self.executor.loader.project_state(target).apps
 
     def get_model(self, app_label, model_name):
         """Helper to get a model from the historical version of the app registry."""
         return self.apps.get_model(app_label, model_name)
+
+    @classmethod
+    def _restore_latest_state(cls):
+        """Restore the latest migration state."""
+        cls.executor.loader.build_graph()
+        cls.executor.migrate(cls.executor.loader.graph.leaf_nodes())

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -101,10 +101,11 @@ class MigrationTestCase(_TransactionTestCase):
         cls.executor.migrate(cls.next_migration)
         cls.apps = cls.executor.loader.project_state(cls.next_migration).apps
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """Restore the migration state to the latest migration after each test."""
-        self.executor.loader.build_graph()
-        self.migrate_to(self.executor.loader.graph.leaf_nodes())
+        cls.executor.loader.build_graph()
+        cls.migrate_to(cls.executor.loader.graph.leaf_nodes())
         super().tearDown()
 
     def migrate_to(self, target: Sequence[tuple[str, str]] | None = None):

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -113,7 +113,7 @@ class MigrationTestCase(_TransactionTestCase):
         Ensures that if anything in the test class fails we still restore correct state for other tests.
         """
         cls.executor.loader.build_graph()
-        cls.migrate_to(cls.executor.loader.graph.leaf_nodes())
+        cls.executor.migrate(cls.executor.loader.graph.leaf_nodes())
         super().tearDownClass()
 
     def migrate_to(self, target: Sequence[tuple[str, str]] | None = None):

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -102,9 +102,8 @@ class MigrationTestCase(_TransactionTestCase):
         cls.apps = cls.executor.loader.project_state(cls.next_migration).apps
 
     def tearDown(self):
-        """Restore the migration state to the latest migration after each test."""
-        self.executor.loader.build_graph()
-        self.migrate_to(self.executor.loader.graph.leaf_nodes())
+        """Restore the migration state to the next_migration after each test."""
+        self.migrate_to(self.next_migration)
         super().tearDown()
 
     @classmethod

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -103,7 +103,7 @@ class MigrationTestCase(_TransactionTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """Restore the migration state to the latest migration after each test."""
+        """Restore the migration state to the latest migration after test cases run."""
         cls.executor.loader.build_graph()
         cls.migrate_to(cls.executor.loader.graph.leaf_nodes())
         super().tearDown()

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -101,12 +101,21 @@ class MigrationTestCase(_TransactionTestCase):
         cls.executor.migrate(cls.next_migration)
         cls.apps = cls.executor.loader.project_state(cls.next_migration).apps
 
+    def tearDown(self):
+        """Restore the migration state to the latest migration after each test."""
+        self.executor.loader.build_graph()
+        self.migrate_to(self.executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
     @classmethod
     def tearDownClass(cls):
-        """Restore the migration state to the latest migration after test cases run."""
+        """Restore the migration state to the latest migration after test cases run.
+
+        Ensures that if anything in the test class fails we still restore correct state for other tests.
+        """
         cls.executor.loader.build_graph()
         cls.migrate_to(cls.executor.loader.graph.leaf_nodes())
-        super().tearDown()
+        super().tearDownClass()
 
     def migrate_to(self, target: Sequence[tuple[str, str]] | None = None):
         """Helper to migrate to a specific target state."""

--- a/cms/core/tests/__init__.py
+++ b/cms/core/tests/__init__.py
@@ -96,8 +96,16 @@ class MigrationTestCase(_TransactionTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+        if cls.next_migration is None:
+            cls.next_migration = cls.executor.loader.graph.leaf_nodes()
         cls.executor.migrate(cls.next_migration)
         cls.apps = cls.executor.loader.project_state(cls.next_migration).apps
+
+    def tearDown(self):
+        """Restore the migration state to the latest migration after each test."""
+        self.executor.loader.build_graph()
+        self.migrate_to(self.executor.loader.graph.leaf_nodes())
+        super().tearDown()
 
     def migrate_to(self, target: Sequence[tuple[str, str]] | None = None):
         """Helper to migrate to a specific target state."""

--- a/cms/topics/tests/test_migrations.py
+++ b/cms/topics/tests/test_migrations.py
@@ -14,9 +14,6 @@ from cms.topics.tests.factories import (
 class TestMigration0009Rollback(MigrationTestCase):
     app = "topics"
     previous_migration: ClassVar[Sequence[tuple[str, str]]] = [("topics", "0008_topicpage_time_series")]
-    next_migration: ClassVar[Sequence[tuple[str, str]]] = [
-        ("topics", "0010_topicpagerelatedarticle_content_type_and_more")
-    ]
 
     def test_rollback(self):
         # Setup on latest version


### PR DESCRIPTION
### What is the context of this PR?

Guarantees that we tear down to latest project state on migration testcase teardown.

I've only noticed this issue on one PR so far, but occasionally tests run after the migration test cases could potentially error due to the database state not matching the model state. By fetching the leaf nodes from the migration tree we can ensure we always leave the database in a clean state.

Also defaults the `next_migration` var to latest project state if not specified to avoid manually updating the string when new migrations are created.

### How to review

- Ensure CI is green.
- Sense check approach

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
