### PR TITLE
fix: hide edit button for published bundles

### DIFF
--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -752,6 +752,24 @@ class BundleViewSetInspectTestCase(BundleViewSetTestCaseBase):
                         response.context["message"], "Sorry, you do not have permission to access this area."
                     )
 
+    def test_inspect_view__edit_link__shown_for_non_published_bundles(self):
+        scenarios = [self.in_review_bundle, self.approved_bundle]
+        for bundle in scenarios:
+            with self.subTest(bundle=bundle):
+                response = self.client.get(reverse("bundle:inspect", args=[bundle.pk]))
+                edit_url = reverse("bundle:edit", args=[bundle.pk])
+                self.assertContains(response, edit_url)
+
+    def test_inspect_view__edit_link__hidden_for_published_bundles(self):
+        partially_published_bundle = BundleFactory(status=BundleStatus.PARTIALLY_PUBLISHED)
+        failed_bundle = BundleFactory(status=BundleStatus.FAILED)
+        scenarios = [self.published_bundle, partially_published_bundle, failed_bundle]
+        for bundle in scenarios:
+            with self.subTest(bundle_status=bundle.status):
+                response = self.client.get(reverse("bundle:inspect", args=[bundle.pk]))
+                edit_url = reverse("bundle:edit", args=[bundle.pk])
+                self.assertNotContains(response, edit_url)
+
     def test_inspect_view__managers__contains_all_fields(self):
         response = self.client.get(reverse("bundle:inspect", args=[self.in_review_bundle.pk]))
 

--- a/cms/bundles/viewsets/bundle.py
+++ b/cms/bundles/viewsets/bundle.py
@@ -472,6 +472,12 @@ class BundleInspectView(InspectView):
             return delete_url
         return ""
 
+    def get_edit_url(self) -> str | None:
+        if self.object.status not in PUBLISHED_BUNDLE_STATUSES:
+            edit_url: str | None = super().get_edit_url()
+            return edit_url
+        return ""
+
     def get_fields(self) -> list[str]:
         """Returns the list of fields to include in the inspect view.
 


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses CMS-1246 and removes the edit button on the inspect view for published bundles.

For the purpose of this PR, a "published bundle" is one that is either fully published, partially published, or has failed publishing (i.e. its status is in the `PUBLISHED_BUNDLE_STATUSES`).

### How to review

1. Inspect a published bundle (`/admin/bundle/inspect/ID`)
2. Click on the three dots at the top
3. Ensure that the "Edit" button is not present

<img width="414" height="180" alt="image" src="https://github.com/user-attachments/assets/a221ea2c-6eb0-4aa3-a056-80b76f127ac0" />


### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [CMS-1246](https://officefornationalstatistics.atlassian.net/browse/CMS-1246)

[CMS-1246]: https://officefornationalstatistics.atlassian.net/browse/CMS-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ