### PR TITLE
fix(pr-standards): check for Jira link before update PR body

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -65,17 +65,16 @@ jobs:
             }
 
             const issueKey = match[0];
+            const jiraUrl = `https://officefornationalstatistics.atlassian.net/browse/${issueKey}`;
             const prBody = context.payload.pull_request?.body ?? "";
 
-            // Check if PR body already contains the issue key
-            if (prBody.includes(issueKey)) {
-              core.info('PR body already contains the JIRA issue key. Skipping JIRA link update.');
+            // Check if PR body already contains the Jira issue link
+            if (prBody.includes(jiraUrl)) {
+              core.info('PR body already contains the JIRA issue link. Skipping JIRA link update.');
               return;
             }
 
-            const jiraUrl = `https://officefornationalstatistics.atlassian.net/browse/${issueKey}`;
             const ticketLink = `Ticket: [${issueKey}](${jiraUrl})`;
-
             const updatedBody = prBody ? `${prBody}\n\n---\n${ticketLink}` : ticketLink;
 
             await github.rest.pulls.update({


### PR DESCRIPTION
### What is the context of this PR?

This swaps the PR standards workflow logic from checking for the Jira issue key to checking for the full Jira issue link before appending a ticket link to the PR body.

This ensures the workflow only skips updates when the canonical Jira link is already present, rather than when the issue key appears as plain text.

### How to review

Ensure the change makes sense

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
