### PR TITLE
fix: route API failure notifications to alarm channel

### DIFF
--- a/cms/bundles/notifications/api_failures.py
+++ b/cms/bundles/notifications/api_failures.py
@@ -44,7 +44,7 @@ def notify_slack_of_dataset_api_failure(
         )
 
     send_or_update_slack_message(
-        text="Dataset API Call Failure", color="danger", fields=fields, channel=settings.SLACK_PUBLISH_LOG_CHANNEL
+        text="Dataset API Call Failure", color="danger", fields=fields, channel=settings.SLACK_ALARM_CHANNEL
     )
 
 
@@ -89,4 +89,4 @@ def notify_slack_of_third_party_api_failure(
             {"title": "Page Name", "value": f"<{page.full_url}|{admin_url}>", "short": False},
         )
 
-    send_or_update_slack_message(text=title, color="danger", fields=fields, channel=settings.SLACK_PUBLISH_LOG_CHANNEL)
+    send_or_update_slack_message(text=title, color="danger", fields=fields, channel=settings.SLACK_ALARM_CHANNEL)

--- a/cms/bundles/tests/test_slack_notifications.py
+++ b/cms/bundles/tests/test_slack_notifications.py
@@ -628,7 +628,7 @@ class NotifyDatasetAPIFailureTestCase(TestCase):
     def setUpTestData(cls):
         cls.page = StatisticalArticlePageFactory(title="Test Page")
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_dataset_api_failure__with_page(self, mock_get_client):
         """Should send notification with page context."""
@@ -660,7 +660,7 @@ class NotifyDatasetAPIFailureTestCase(TestCase):
         self.assertEqual(fields[2]["title"], "Exception")
         self.assertEqual(fields[2]["value"], "Timeout when fetching dataset")
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_dataset_api_failure__without_page(self, mock_get_client):
         """Should send notification without page context."""
@@ -685,7 +685,7 @@ class NotifyDatasetAPIFailureTestCase(TestCase):
         self.assertEqual(fields[1]["title"], "Exception")
         self.assertEqual(fields[1]["value"], "Server error: HTTP 500")
 
-    @override_settings(SLACK_PUBLISH_LOG_CHANNEL="")
+    @override_settings(SLACK_ALARM_CHANNEL="")
     def test_notify_dataset_api_failure__no_channel_configured(self):
         """Should not send notification when channel is not configured."""
         with self.assertLogs("cms.core.slack", level="INFO") as logs:
@@ -696,7 +696,7 @@ class NotifyDatasetAPIFailureTestCase(TestCase):
             )
             self.assertIn("Skipping sending Slack message (token or channel not configured)", logs.output[0])
 
-    @override_settings(SLACK_BOT_TOKEN=None, SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN=None, SLACK_ALARM_CHANNEL="C024BE91L")
     def test_notify_dataset_api_failure__no_bot_token(self):
         """Should not send notification when bot token is not configured."""
         with self.assertLogs("cms.core.slack", level="INFO") as logs:
@@ -707,7 +707,7 @@ class NotifyDatasetAPIFailureTestCase(TestCase):
             )
             self.assertIn("Skipping sending Slack message (token or channel not configured)", logs.output[0])
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_dataset_api_failure__slack_api_error(self, mock_get_client):
         """Should log error when Slack API call fails."""
@@ -730,7 +730,7 @@ class NotifyThirdPartyAPIFailureTestCase(TestCase):
         cls.bundle = BundleFactory(name="Test Bundle")
         cls.page = StatisticalArticlePageFactory(title="Test Page")
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_third_party_api_failure__with_bundle(self, mock_get_client):
         """Should send notification with bundle context."""
@@ -763,7 +763,7 @@ class NotifyThirdPartyAPIFailureTestCase(TestCase):
         self.assertEqual(fields[2]["title"], "Exception")
         self.assertEqual(fields[2]["value"], "HTTP 500 error: Internal Server Error")
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_third_party_api_failure__with_page(self, mock_get_client):
         """Should send notification with page context."""
@@ -787,7 +787,7 @@ class NotifyThirdPartyAPIFailureTestCase(TestCase):
         self.assertEqual(fields[0]["title"], "Page Name")
         self.assertIn("Test Page", fields[0]["value"])
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_third_party_api_failure__without_context(self, mock_get_client):
         """Should send notification without bundle or page context."""
@@ -810,7 +810,7 @@ class NotifyThirdPartyAPIFailureTestCase(TestCase):
         self.assertEqual(fields[0]["title"], "Alert Type")
         self.assertEqual(fields[1]["title"], "Exception")
 
-    @override_settings(SLACK_PUBLISH_LOG_CHANNEL="")
+    @override_settings(SLACK_ALARM_CHANNEL="")
     def test_notify_third_party_api_failure__no_channel_configured(self):
         """Should log when channel is not configured."""
         with self.assertLogs("cms.core.slack", level="INFO") as logs:
@@ -821,7 +821,7 @@ class NotifyThirdPartyAPIFailureTestCase(TestCase):
             )
             self.assertIn("Skipping sending Slack message (token or channel not configured)", logs.output[0])
 
-    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_PUBLISH_LOG_CHANNEL="C024BE91L")
+    @override_settings(SLACK_BOT_TOKEN="xoxb-test-token", SLACK_ALARM_CHANNEL="C024BE91L")
     @patch("cms.core.slack.get_slack_client")
     def test_notify_third_party_api_failure__slack_api_error(self, mock_get_client):
         """Should log error when Slack API call fails."""


### PR DESCRIPTION
### What is the context of this PR?

Dataset and third-party API failure alerts were being sent to the publish log Slack channel, which is incorrect. This PR routes those failure notifications to `SLACK_ALARM_CHANNEL` so they are surfaced in the appropriate alerting channel.

### How to review

Confirm that both dataset API failure and third-party API failure notifications now pass `settings.SLACK_ALARM_CHANNEL` to `send_or_update_slack_message`.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
