### PR TITLE
fix: correct dataset duplicate detection in `DatasetStoryBlock`

### DIFF
--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -68,11 +68,28 @@ class DatasetStoryBlock(StreamBlock):
 
         block_errors = {}
         for block_indices in url_paths.values():
+            if len(block_indices) <= 1:
+                continue
+
+            # Manual links only carry a URL, with no edition/version, so they're
+            # considered a duplicate of anything else referencing the same URL.
+            manual_indices = {i for i in block_indices if cleaned_value[i].block_type != "dataset_lookup"}
+            if manual_indices:
+                duplicate_indices = block_indices
+            else:
+                # A looked up dataset is only a duplicate of another looked up dataset
+                # if the series, edition and version all match.
+                lookup_indices_by_compound_id = defaultdict(set)
+                for i in block_indices:
+                    lookup_indices_by_compound_id[cleaned_value[i].value.compound_id].add(i)
+                duplicate_indices = {
+                    i for indices in lookup_indices_by_compound_id.values() if len(indices) > 1 for i in indices
+                }
+
             # Add a block error for any index which contains a duplicate URL,
             # so that the validation error messages appear on the actual duplicate entries
-            if len(block_indices) > 1:
-                for index in block_indices:
-                    block_errors[index] = ValidationError("Duplicate datasets are not allowed")
+            for index in duplicate_indices:
+                block_errors[index] = ValidationError("Duplicate datasets are not allowed")
 
         if block_errors:
             raise StreamBlockValidationError(block_errors=block_errors)

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -78,6 +78,48 @@ class TestDatasetStoryBlock(TestCase):
             [
                 ("dataset_lookup", self.lookup_dataset.id),
                 (
+                    "dataset_lookup",
+                    Dataset.objects.create(
+                        # Same namespace as the first dataset, but different edition and version
+                        namespace=self.lookup_dataset.namespace,
+                        edition="test2_edition",
+                        version=2,
+                        title="test_title",
+                        description="test_description",
+                    ).id,
+                ),
+            ],
+            [
+                ("dataset_lookup", self.lookup_dataset.id),
+                (
+                    "dataset_lookup",
+                    Dataset.objects.create(
+                        # Same namespace and version as the first dataset, but different edition
+                        namespace=self.lookup_dataset.namespace,
+                        edition="test2_edition",
+                        version=1,
+                        title="test_title",
+                        description="test_description",
+                    ).id,
+                ),
+            ],
+            [
+                ("dataset_lookup", self.lookup_dataset.id),
+                (
+                    "dataset_lookup",
+                    Dataset.objects.create(
+                        # Same namespace and edition as the first dataset, but different version
+                        namespace=self.lookup_dataset.namespace,
+                        edition=self.lookup_dataset.edition,
+                        version=2,
+                        title="test_title",
+                        description="test_description",
+                    ).id,
+                ),
+            ],
+            [
+                ("dataset_lookup", self.lookup_dataset.id),
+                (
                     "manual_link",
                     {"title": "Dataset Title", "url": "https://example.com/datasets/foo/editions/bar/versions/1"},
                 ),
@@ -112,6 +154,8 @@ class TestDatasetStoryBlock(TestCase):
                     block,
                     stream_data=stream_data,
                 )
-
-                # Expect clean to not raise any errors
-                block.clean(value)
+                try:
+                    # Expect clean to not raise any errors
+                    block.clean(value)
+                except ValidationError as e:
+                    self.fail(f"ValidationError raised unexpectedly: {e}")


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses CMS-1255 and fixes the way duplicate datasets are detected in the `DatasetStoryBlock`.

Currently, the URL of a dataset just contains the namespace of the Dataset:

https://github.com/ONSdigital/dis-wagtail/blob/197fcf9906c562cf1f4463aad20182c076bfe1a8/cms/datasets/models.py#L247-L251

Meanwhile, the `clean()` method for the `DatasetStoryBlock` would only use the URLs to detect duplicates, creating false positives.

This change adds a more thorough checks for looked up datasets to consider namespace, edition and version of the dataset before flagging it as a duplicate.

### How to review

Follow the steps from the ticket and ensure no validation error is shown:
1. Create a new or select an existing Statistical Article page ensuring mandatory fields have been populated with valid data
2. Go to ‘Related data’ tab (Datasets) and click the + button and select 'Lookup Dataset option
3. ‘Choose a dataset' , select ‘Unpublished’ from the 'Published status’ dropdown and select at least two datasets. In this case it is two different editions for the same dataset.
4. As the user is currently unable to select more than one dataset at a time, steps 2 and 3 need to be performed twice
5. User selects to save the changes

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [CMS-1255](https://officefornationalstatistics.atlassian.net/browse/CMS-1255)

[CMS-1255]: https://officefornationalstatistics.atlassian.net/browse/CMS-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ