### PR TITLE
fix: add GTM data attributes to breadcrumbs component

### DIFF
--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from http import HTTPStatus
 from urllib.parse import urlparse
 
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory, TestCase, override_settings
@@ -667,33 +668,24 @@ class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
 
     def test_breadcrumb_excludes_container_pages(self):
         response = self.client.get(self.basic_page_url)
+        soup = BeautifulSoup(response.content, "html.parser")
         dummy_request = get_dummy_request()
         # confirm the series container page is not in the breadcrumb
         article_series = self.basic_page.get_parent()
         series_url = article_series.get_full_url(request=dummy_request)
-        self.assertNotContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{series_url}">{article_series.title}</a>',
-            html=True,
-        )
+        self.assertIsNone(soup.find("a", class_="ons-breadcrumbs__link", href=series_url, string=article_series.title))
 
         # confirm the articles index container page is not in the breadcrumb
         articles_index = article_series.get_parent()
         articles_index_url = articles_index.get_full_url(request=dummy_request)
-        self.assertNotContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
-            html=True,
+        self.assertIsNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=articles_index_url, string=articles_index.title)
         )
 
         # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
         topic_page = articles_index.get_parent()
         topic_url = topic_page.get_full_url(request=dummy_request)
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
-            html=True,
-        )
+        self.assertIsNotNone(soup.find("a", class_="ons-breadcrumbs__link", href=topic_url, string=topic_page.title))
 
     def test_related_data_breadcrumb_shows_full_title(self):
         self.basic_page.datasets = StreamValue(
@@ -702,19 +694,16 @@ class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
         )
         self.basic_page.save_revision().publish()
         response = self.client.get(f"{self.basic_page_url}/related-data")
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{self.basic_page.full_url}">PSF: November 2024</a>',
-            html=True,
+        soup = BeautifulSoup(response.content, "html.parser")
+        self.assertIsNotNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=self.basic_page.full_url, string="PSF: November 2024")
         )
 
         # confirm the articles index container page is not in the related data breadcrumb
         articles_index = self.basic_page.get_parent().get_parent()
         articles_index_url = articles_index.get_full_url(request=get_dummy_request())
-        self.assertNotContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
-            html=True,
+        self.assertIsNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=articles_index_url, string=articles_index.title)
         )
 
     def test_pagination_is_not_shown(self):
@@ -1222,24 +1211,19 @@ class PreviousReleasesWithoutPaginationTestCase(TestCase):
 
     def test_breadcrumb_excludes_articles_index(self):
         response = self.client.get(self.previous_releases_url)
+        soup = BeautifulSoup(response.content, "html.parser")
 
         # confirm the articles index container page is not in the breadcrumb
         articles_index = self.article_series.get_parent()
         articles_index_url = articles_index.get_full_url(request=self.dummy_request)
-        self.assertNotContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{articles_index_url}">{articles_index.title}</a>',
-            html=True,
+        self.assertIsNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=articles_index_url, string=articles_index.title)
         )
 
         # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
         topic_page = articles_index.get_parent()
         topic_url = topic_page.get_full_url(request=self.dummy_request)
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
-            html=True,
-        )
+        self.assertIsNotNone(soup.find("a", class_="ons-breadcrumbs__link", href=topic_url, string=topic_page.title))
 
     def test_page_content(self):
         response = self.client.get(self.previous_releases_url)

--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from http import HTTPStatus
 
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import override_settings
@@ -79,14 +80,17 @@ class ArticleSeriesPageTests(WagtailPageTestCase):
         """Test that the previous releases page includes a breadcrumb for the latest article."""
         StatisticalArticlePageFactory(parent=self.article_series_page, title="Latest Article")
         response = self.client.get(f"{self.article_series_page.url}/editions")
+        soup = BeautifulSoup(response.content, "html.parser")
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # Check the breadcrumbs include the series page link, which serves the evergreen latest article
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{self.article_series_page.full_url}">'
-            f"{self.article_series_page.title}</a>",
-            html=True,
+        self.assertIsNotNone(
+            soup.find(
+                "a",
+                class_="ons-breadcrumbs__link",
+                href=self.article_series_page.full_url,
+                string=self.article_series_page.title,
+            )
         )
 
     def test_analytics_content_type(self):
@@ -456,6 +460,7 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
         request = get_dummy_request()
         page_url = self.page.get_url(request=request)
         response = self.client.get(page_url)
+        soup = BeautifulSoup(response.content, "html.parser")
 
         # Breadcrumbs
         content = response.content.decode(encoding="utf-8")
@@ -466,15 +471,11 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
         topic_full_url = topic.get_full_url(request=request)
 
         # The articles index is a non-navigable container, so it is excluded from the breadcrumb.
-        self.assertNotIn(
-            f'<a class="ons-breadcrumbs__link" href="{articles_index_full_url}">{articles_index.title}</a>',
-            content,
+        self.assertIsNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=articles_index_full_url, string=articles_index.title)
         )
 
-        self.assertInHTML(
-            f'<a class="ons-breadcrumbs__link" href="{topic_full_url}">{topic.title}</a>',
-            content,
-        )
+        self.assertIsNotNone(soup.find("a", class_="ons-breadcrumbs__link", href=topic_full_url, string=topic.title))
 
         # Census
         self.assertNotContains(response, "ons-hero__census-logo")

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -158,10 +158,12 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
             "data-ga-event": "navigation-click",
             "data-ga-navigation-type": "breadcrumb",
             "data-ga-link-text": link_text,
-            "data-ga-click-content-type": page.analytics_content_type,
             "data-ga-click-path": page.get_url(request=request),
             "data-ga-click-position": position,
         }
+
+        if content_type := page.analytics_content_type:
+            attributes["data-ga-click-content-type"] = content_type
 
         if content_group := page.analytics_content_group:
             attributes["data-ga-click-content-group"] = content_group

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -340,6 +340,7 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
             return cast(str, parent_topic_or_theme.slug)
         return None
 
+    # TODO: Revisit once the theme/page relationship is defined and the attribute's requirements are finalised.
     @cached_property
     def analytics_content_theme(self) -> str | None:
         """Returns the title of the top ancestor taxonomic topic for the pages parent topic or theme page,

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 from django.conf import settings
 from django.core.cache import cache
@@ -150,6 +150,27 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
         # Override in subclasses where the breadcrumb label should differ from the page title.
         return str(self.title)
 
+    @staticmethod
+    def get_gtm_attributes_for_breadcrumbs(
+        page: BasePage, request: HttpRequest, link_text: str, position: int
+    ) -> dict[str, Any]:
+        attributes = {
+            "data-ga-event": "navigation-click",
+            "data-ga-navigation-type": "breadcrumb",
+            "data-ga-link-text": link_text,
+            "data-ga-click-content-type": page.analytics_content_type,
+            "data-ga-click-path": page.get_url(request=request),
+            "data-ga-click-position": position,
+        }
+
+        if content_group := page.analytics_content_group:
+            attributes["data-ga-click-content-group"] = content_group
+
+        if content_theme := page.analytics_content_theme:
+            attributes["data-ga-click-content-theme"] = content_theme
+
+        return attributes
+
     def get_breadcrumbs(self, request: HttpRequest) -> list[dict[str, object]]:
         """Returns the breadcrumbs for the page as a list of dictionaries compatible with the ONS design system
         breadcrumbs component.
@@ -163,11 +184,39 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
             if ancestor_page.is_root():
                 continue
             if ancestor_page.depth <= homepage_depth:
-                breadcrumbs.append({"url": self.get_site().root_url, "text": _("Home")})
+                breadcrumb_url = self.get_site().root_url
+                breadcrumb_text = _("Home")
+
             elif not getattr(ancestor_page, "exclude_from_breadcrumbs", False):
-                breadcrumbs.append({"url": ancestor_page.get_full_url(request=request), "text": ancestor_page.title})
+                breadcrumb_url = ancestor_page.get_full_url(request=request)
+                breadcrumb_text = ancestor_page.title
+
+            else:
+                continue
+
+            breadcrumb_position = len(breadcrumbs) + 1
+            breadcrumbs.append(
+                {
+                    "url": breadcrumb_url,
+                    "text": breadcrumb_text,
+                    "attributes": self.get_gtm_attributes_for_breadcrumbs(
+                        ancestor_page, request, breadcrumb_text, breadcrumb_position
+                    ),
+                }
+            )
+
         if getattr(request, "is_for_subpage", False):
-            breadcrumbs.append({"url": self.get_full_url(request=request), "text": self.breadcrumb_title})
+            breadcrumb_position = len(breadcrumbs) + 1
+            breadcrumbs.append(
+                {
+                    "url": self.get_full_url(request=request),
+                    "text": self.breadcrumb_title,
+                    "attributes": self.get_gtm_attributes_for_breadcrumbs(
+                        self, request, self.breadcrumb_title, breadcrumb_position
+                    ),
+                }
+            )
+
         self._breadcrumbs = breadcrumbs  # pylint: disable=attribute-defined-outside-init
         return breadcrumbs
 

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -180,7 +180,7 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
         if prebuilt_breadcrumbs := getattr(self, "_breadcrumbs", None):
             return prebuilt_breadcrumbs  # type: ignore[no-any-return]
 
-        breadcrumbs = []
+        breadcrumbs: list[dict[str, object]] = []
         homepage_depth = 2
         for ancestor_page in self.get_ancestors().specific(defer=True):
             if ancestor_page.is_root():
@@ -202,7 +202,7 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
                     "url": breadcrumb_url,
                     "text": breadcrumb_text,
                     "attributes": self.get_gtm_attributes_for_breadcrumbs(
-                        ancestor_page, request, breadcrumb_text, breadcrumb_position
+                        ancestor_page, request, str(breadcrumb_text), breadcrumb_position
                     ),
                 }
             )

--- a/cms/core/tests/test_models.py
+++ b/cms/core/tests/test_models.py
@@ -7,7 +7,7 @@ from wagtail.test.utils.form_data import rich_text
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
 
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
-from cms.core.models import ContactDetails, Definition
+from cms.core.models import BasePage, ContactDetails, Definition
 from cms.home.models import HomePage
 from cms.standard_pages.tests.factories import InformationPageFactory
 from cms.taxonomy.models import Topic
@@ -246,6 +246,36 @@ class PageBreadcrumbsTestCase(TestCase):
         self.assertIsInstance(breadcrumbs_output, list)
         self.assertEqual(len(breadcrumbs_output), 3)
         self.assertListEqual(breadcrumbs_output, expected_entries)
+
+    def test_get_gtm_attributes_for_breadcrumbs_excludes_data_attributes_when_none(self):
+        """Test that data attributes are not included in GTM attributes when the page has no value for them."""
+
+        class DummyPage:
+            analytics_content_type = None
+            analytics_content_group = None
+            analytics_content_theme = None
+
+            @staticmethod
+            def get_url(request):
+                return "/dummy-path"
+
+        attributes = BasePage.get_gtm_attributes_for_breadcrumbs(
+            page=DummyPage(),
+            request=self.dummy_request,
+            link_text="Dummy",
+            position=1,
+        )
+
+        self.assertDictEqual(
+            attributes,
+            {
+                "data-ga-event": "navigation-click",
+                "data-ga-navigation-type": "breadcrumb",
+                "data-ga-link-text": "Dummy",
+                "data-ga-click-path": "/dummy-path",
+                "data-ga-click-position": 1,
+            },
+        )
 
 
 class CanonicalFullUrlsTestCase(TestCase):

--- a/cms/core/tests/test_models.py
+++ b/cms/core/tests/test_models.py
@@ -157,16 +157,34 @@ class PageBreadcrumbsTestCase(TestCase):
         breadcrumbs_output = self.statistical_article.get_breadcrumbs(request=self.dummy_request)
 
         # The articles index page is a non-navigable container, so it is excluded from the trail.
-        topic = self.series.get_parent().get_parent()
+        topic = self.series.get_parent().get_parent().specific
 
         expected_entries = [
             {
                 "url": self.statistical_article.get_site().root_url,
                 "text": "Home",
+                "attributes": {
+                    "data-ga-event": "navigation-click",
+                    "data-ga-navigation-type": "breadcrumb",
+                    "data-ga-link-text": "Home",
+                    "data-ga-click-content-type": "homepage",
+                    "data-ga-click-path": "/",
+                    "data-ga-click-position": 1,
+                },
             },
             {
                 "url": topic.get_full_url(request=self.dummy_request),
                 "text": topic.title,
+                "attributes": {
+                    "data-ga-event": "navigation-click",
+                    "data-ga-navigation-type": "breadcrumb",
+                    "data-ga-link-text": topic.title,
+                    "data-ga-click-content-type": topic.analytics_content_type,
+                    "data-ga-click-path": topic.get_url(request=self.dummy_request),
+                    "data-ga-click-position": 2,
+                    "data-ga-click-content-group": topic.analytics_content_group,
+                    "data-ga-click-content-theme": topic.analytics_content_theme,
+                },
             },
         ]
 
@@ -180,20 +198,48 @@ class PageBreadcrumbsTestCase(TestCase):
         breadcrumbs_output = self.statistical_article.get_breadcrumbs(request=self.dummy_request)
 
         # The articles index page is a non-navigable container, so it is excluded from the trail.
-        topic = self.series.get_parent().get_parent()
+        topic = self.series.get_parent().get_parent().specific
 
         expected_entries = [
             {
                 "url": self.statistical_article.get_site().root_url,
                 "text": "Home",
+                "attributes": {
+                    "data-ga-event": "navigation-click",
+                    "data-ga-navigation-type": "breadcrumb",
+                    "data-ga-link-text": "Home",
+                    "data-ga-click-content-type": "homepage",
+                    "data-ga-click-path": "/",
+                    "data-ga-click-position": 1,
+                },
             },
             {
                 "url": topic.get_full_url(request=self.dummy_request),
                 "text": topic.title,
+                "attributes": {
+                    "data-ga-event": "navigation-click",
+                    "data-ga-navigation-type": "breadcrumb",
+                    "data-ga-link-text": topic.title,
+                    "data-ga-click-content-type": topic.analytics_content_type,
+                    "data-ga-click-path": topic.get_url(request=self.dummy_request),
+                    "data-ga-click-position": 2,
+                    "data-ga-click-content-group": topic.analytics_content_group,
+                    "data-ga-click-content-theme": topic.analytics_content_theme,
+                },
             },
             {
                 "url": self.statistical_article.get_full_url(request=self.dummy_request),
                 "text": self.statistical_article.breadcrumb_title,
+                "attributes": {
+                    "data-ga-event": "navigation-click",
+                    "data-ga-navigation-type": "breadcrumb",
+                    "data-ga-link-text": self.statistical_article.breadcrumb_title,
+                    "data-ga-click-content-type": self.statistical_article.analytics_content_type,
+                    "data-ga-click-path": self.statistical_article.get_url(request=self.dummy_request),
+                    "data-ga-click-position": 3,
+                    "data-ga-click-content-group": self.statistical_article.analytics_content_group,
+                    "data-ga-click-content-theme": self.statistical_article.analytics_content_theme,
+                },
             },
         ]
 

--- a/cms/methodology/tests/test_pages.py
+++ b/cms/methodology/tests/test_pages.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+from bs4 import BeautifulSoup
 from django.urls import reverse
 from wagtail.coreutils import get_dummy_request
 from wagtail.rich_text import RichText
@@ -48,25 +49,21 @@ class MethodologyPageTest(WagtailPageTestCase):
 
     def test_breadcrumb_excludes_methodology_index(self):
         response = self.client.get(self.page.url)
+        soup = BeautifulSoup(response.content, "html.parser")
         dummy_request = get_dummy_request()
 
         # confirm the methodology index container page is not in the breadcrumb
         methodology_index = self.page.get_parent()
         methodology_index_url = methodology_index.get_full_url(request=dummy_request)
-        self.assertNotContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{methodology_index_url}">{methodology_index.title}</a>',
-            html=True,
+
+        self.assertIsNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=methodology_index_url, string=methodology_index.title)
         )
 
         # confirm the breadcrumb points to the topic page (the closest navigable ancestor)
         topic_page = methodology_index.get_parent()
         topic_url = topic_page.get_full_url(request=dummy_request)
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{topic_url}">{topic_page.title}</a>',
-            html=True,
-        )
+        self.assertIsNotNone(soup.find("a", class_="ons-breadcrumbs__link", href=topic_url, string=topic_page.title))
 
     def test_methodology_page_uses_correct_toc_class(self):
         """Test that the methodology page uses the correct table of contents class."""

--- a/cms/standard_pages/tests/test_pages.py
+++ b/cms/standard_pages/tests/test_pages.py
@@ -1,5 +1,6 @@
 from unittest import skip
 
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.test import RequestFactory, override_settings
 from wagtail.models import Site
@@ -35,6 +36,7 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
 
     def test_get_cookies_page(self):
         response = self.client.get(self.cookies_page.url)
+        soup = BeautifulSoup(response.content, "html.parser")
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
@@ -49,21 +51,18 @@ class CookiesPageTest(TranslationResetMixin, WagtailPageTestCase):
         )
         self.assertContains(response, "Cookie settings")
         # Check the breadcrumbs include the home page link
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{self.english_site.root_url}">Home</a>',
-            html=True,
+        self.assertIsNotNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=self.english_site.root_url, string="Home")
         )
 
     def test_welsh_cookies_page_renders_translated_furniture(self):
         response = self.client.get(self.welsh_cookies_page.url, headers={"host": "cy.ons.localhost"})
+        soup = BeautifulSoup(response.content, "html.parser")
         self.assertEqual(response.status_code, 200)
 
         # Check the breadcrumbs include the home page link
-        self.assertContains(
-            response,
-            f'<a class="ons-breadcrumbs__link" href="{self.welsh_site.root_url}">Cartref</a>',
-            html=True,
+        self.assertIsNotNone(
+            soup.find("a", class_="ons-breadcrumbs__link", href=self.welsh_site.root_url, string="Cartref")
         )
 
     # TODO: Remove skip when translations for Cookies page are available


### PR DESCRIPTION
### What is the context of this PR?

Adds the following GTM data attributes to the breadcrumbs links:

- `data-ga-event`
- `data-ga-navigation-type`
- `data-ga-link-text`
- `data-ga-click-content-group`
- `data-ga-click-content-type`
- `data-ga-click-path`
- `data-ga-click-content-theme`
- `data-ga-click-position`

See the ticket and specification attached to it for the expected values for each attribute.

### How to review

1. Using browser dev tools, inspect the breadcrumb links on a published page and ensure the data attributes listed above are added to each breadcrumb link
2. Ensure the expected values match the specification
3. For pages that don't have a content type, content theme or content group, the associated data attribute should not be added to the breadcrumb link
4. Verify the following specific cases:
   -  The Home page doesn't have a content group or content theme so `data-ga-click-content-group` and `data-ga-click-content-theme` should not be present
   - The Release Index page doesn't have a content type so `data-ga-click-content-type` should not be present

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [DPD-4319](https://officefornationalstatistics.atlassian.net/browse/DPD-4319)

[DPD-4319]: https://officefornationalstatistics.atlassian.net/browse/DPD-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ