### PR TITLE
feat(logs): log viewing of snippets in admin panel

### DIFF
--- a/cms/core/tests/test_wagtail_hooks.py
+++ b/cms/core/tests/test_wagtail_hooks.py
@@ -160,9 +160,9 @@ class SnippetEditViewAuditLogTestCase(WagtailTestUtils, TestCase):
         self.assertEqual(log_entry.user, self.superuser)
         self.assertEqual(log_entry.message, "Viewed snippet editor for contact details")
 
-        reponse = self.client.get(self.definition_edit_url)
+        response = self.client.get(self.definition_edit_url)
 
-        self.assertEqual(reponse.status_code, HTTPStatus.OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         log_entry = ModelLogEntry.objects.filter(object_id=self.definition.pk, action="snippets.edit_view").first()
         self.assertIsNotNone(log_entry)

--- a/cms/core/tests/test_wagtail_hooks.py
+++ b/cms/core/tests/test_wagtail_hooks.py
@@ -9,10 +9,13 @@ from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
-from wagtail.models import Locale, PageLogEntry
+from wagtail.models import Locale, ModelLogEntry, PageLogEntry
 from wagtail.test.utils import WagtailTestUtils
 
 from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.core.models import ContactDetails
+from cms.core.models.snippets import Definition
+from cms.core.tests.factories import ContactDetailsFactory, DefinitionFactory
 from cms.standard_pages.models import InformationPage
 from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
 from cms.users.tests.factories import UserFactory
@@ -123,6 +126,141 @@ class PageEditViewAuditLogTestCase(WagtailTestUtils, TestCase):
 
         page_ids = set(log_entries.values_list("page_id", flat=True))
         self.assertEqual(page_ids, {self.page.pk, other_page.pk})
+
+
+class SnippetEditViewAuditLogTestCase(WagtailTestUtils, TestCase):
+    """Tests for the snippet edit view audit logging via before_edit_snippet hook."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = cls.create_superuser(username="admin")
+        cls.other_user = cls.create_superuser(username="other_admin")
+        cls.contact_details = ContactDetailsFactory(name="Test Contact")
+        cls.definition = DefinitionFactory(name="Test Definition")
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+        self.contact_edit_url = reverse(
+            ContactDetails.snippet_viewset.get_url_name("edit"),  # pylint: disable=no-member
+            args=[self.contact_details.pk],
+        )
+        self.definition_edit_url = reverse(
+            Definition.snippet_viewset.get_url_name("edit"),  # pylint: disable=no-member
+            args=[self.definition.pk],
+        )
+
+    def test_edit_view__creates_audit_log_entry(self):
+        """Test that viewing the snippet edit view creates an audit log entry."""
+        response = self.client.get(self.contact_edit_url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        log_entry = ModelLogEntry.objects.filter(object_id=self.contact_details.pk, action="snippets.edit_view").first()
+        self.assertIsNotNone(log_entry)
+        self.assertEqual(log_entry.user, self.superuser)
+        self.assertEqual(log_entry.message, "Viewed snippet editor for contact details")
+
+        reponse = self.client.get(self.definition_edit_url)
+
+        self.assertEqual(reponse.status_code, HTTPStatus.OK)
+
+        log_entry = ModelLogEntry.objects.filter(object_id=self.definition.pk, action="snippets.edit_view").first()
+        self.assertIsNotNone(log_entry)
+        self.assertEqual(log_entry.user, self.superuser)
+        self.assertEqual(log_entry.message, "Viewed snippet editor for definition")
+
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    def test_edit_view__audit_log_cooldown_prevents_duplicate_entries(self):
+        """Test that viewing the snippet edit view multiple times within the cooldown period
+        only creates one audit log entry.
+        """
+        ModelLogEntry.objects.filter(object_id=self.contact_details.pk, action="snippets.edit_view").delete()
+        cache.clear()
+
+        # First visit - should create a log entry
+        self.client.get(self.contact_edit_url)
+        first_count = ModelLogEntry.objects.filter(
+            object_id=self.contact_details.pk, action="snippets.edit_view"
+        ).count()
+        self.assertEqual(first_count, 1)
+
+        # Second visit within cooldown - should NOT create another log entry
+        self.client.get(self.contact_edit_url)
+        second_count = ModelLogEntry.objects.filter(
+            object_id=self.contact_details.pk, action="snippets.edit_view"
+        ).count()
+        self.assertEqual(second_count, 1)
+
+        # Third visit within cooldown - still no new entry
+        self.client.get(self.contact_edit_url)
+        third_count = ModelLogEntry.objects.filter(
+            object_id=self.contact_details.pk, action="snippets.edit_view"
+        ).count()
+        self.assertEqual(third_count, 1)
+
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    def test_edit_view__audit_log_cooldown_allows_new_entry_after_expiry(self):
+        """Test that a new audit log entry is created after the cooldown expires."""
+        ModelLogEntry.objects.filter(object_id=self.contact_details.pk, action="snippets.edit_view").delete()
+        cache.clear()
+
+        # First visit
+        self.client.get(self.contact_edit_url)
+        first_count = ModelLogEntry.objects.filter(
+            object_id=self.contact_details.pk, action="snippets.edit_view"
+        ).count()
+        self.assertEqual(first_count, 1)
+
+        # Clear cache to simulate cooldown expiry
+        cache.clear()
+
+        # Second visit after cooldown expiry - should create a new log entry
+        self.client.get(self.contact_edit_url)
+        second_count = ModelLogEntry.objects.filter(
+            object_id=self.contact_details.pk, action="snippets.edit_view"
+        ).count()
+        self.assertEqual(second_count, 2)
+
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    def test_edit_view__audit_log_different_users_get_separate_cooldowns(self):
+        """Test that different users have separate cooldown periods."""
+        ModelLogEntry.objects.filter(object_id=self.contact_details.pk, action="snippets.edit_view").delete()
+        cache.clear()
+
+        # First user views the snippet
+        self.client.force_login(self.superuser)
+        self.client.get(self.contact_edit_url)
+
+        # Second user views the same snippet - should also create a log entry
+        self.client.force_login(self.other_user)
+        self.client.get(self.contact_edit_url)
+
+        log_entries = ModelLogEntry.objects.filter(object_id=self.contact_details.pk, action="snippets.edit_view")
+        self.assertEqual(log_entries.count(), 2)
+
+        users = set(log_entries.values_list("user_id", flat=True))
+        self.assertEqual(users, {self.superuser.pk, self.other_user.pk})
+
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    def test_edit_view__audit_log_different_snippets_get_separate_cooldowns(self):
+        """Test that different snippets have separate cooldown periods for the same user."""
+        other_snippet = ContactDetailsFactory(name="Other Contact")
+        ModelLogEntry.objects.filter(action="snippets.edit_view").delete()
+        cache.clear()
+
+        # View first snippet
+        self.client.get(self.contact_edit_url)
+
+        # View second snippet - should also create a log entry
+        self.client.get(
+            reverse(ContactDetails.snippet_viewset.get_url_name("edit"), args=[other_snippet.pk])  # pylint: disable=no-member
+        )
+
+        log_entries = ModelLogEntry.objects.filter(action="snippets.edit_view")
+        self.assertEqual(log_entries.count(), 2)
+
+        object_ids = set(log_entries.values_list("object_id", flat=True))
+        self.assertEqual(object_ids, {str(self.contact_details.pk), str(other_snippet.pk)})
 
 
 class PreventDeleteOfPreviouslyPublishedPageHookTests(WagtailTestUtils, TestCase):

--- a/cms/core/wagtail_hooks.py
+++ b/cms/core/wagtail_hooks.py
@@ -67,6 +67,9 @@ register_snippet(DefinitionViewSet)
 @hooks.register("before_edit_page")
 def log_page_edit_view(request: HttpRequest, page: Page) -> None:
     """Log when a user views the page edit view, with a cooldown to prevent duplicate entries."""
+    if request.method != "GET":
+        return
+
     cache_key = f"page_edit_view_log:{page.pk}:{request.user.pk}"
 
     if cache.get(cache_key):
@@ -79,6 +82,9 @@ def log_page_edit_view(request: HttpRequest, page: Page) -> None:
 @hooks.register("before_edit_snippet")
 def log_snippet_edit_view(request: HttpRequest, instance: Model) -> None:
     """Log when a user views the snippet edit view, with a cooldown to prevent duplicate entries."""
+    if request.method != "GET":
+        return
+
     cache_key = f"snippet_edit_view_log:{instance._meta.label}:{instance.pk}:{request.user.pk}"
 
     if cache.get(cache_key):

--- a/cms/core/wagtail_hooks.py
+++ b/cms/core/wagtail_hooks.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db.models import Model
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
@@ -72,6 +73,18 @@ def log_page_edit_view(request: HttpRequest, page: Page) -> None:
         return
 
     log(action="pages.edit_view", instance=page)
+    cache.set(cache_key, True, timeout=settings.CMS_AUDIT_LOG_COOLDOWN_SECONDS)
+
+
+@hooks.register("before_edit_snippet")
+def log_snippet_edit_view(request: HttpRequest, instance: Model) -> None:
+    """Log when a user views the snippet edit view, with a cooldown to prevent duplicate entries."""
+    cache_key = f"snippet_edit_view_log:{instance._meta.label}:{instance.pk}:{request.user.pk}"
+
+    if cache.get(cache_key):
+        return
+
+    log(action="snippets.edit_view", instance=instance)
     cache.set(cache_key, True, timeout=settings.CMS_AUDIT_LOG_COOLDOWN_SECONDS)
 
 
@@ -237,6 +250,21 @@ def register_core_log_actions(actions: LogActionRegistry) -> None:
         def format_message(self, log_entry: ModelLogEntry) -> Any:
             """Returns the formatted log message."""
             return "Viewed page editor"
+
+    @actions.register_action("snippets.edit_view")
+    class SnippetEditView(LogFormatter):  # pylint: disable=unused-variable
+        """LogFormatter class for viewing the snippet edit view."""
+
+        label = "View snippet editor"
+
+        def format_message(self, log_entry: ModelLogEntry) -> Any:
+            """Returns the formatted log message."""
+            msg = "Viewed snippet editor"
+            try:
+                model_name = log_entry.content_type.model_class()._meta.verbose_name
+                return f"{msg} for {model_name}"
+            except AttributeError:
+                return msg
 
     @actions.register_action("pages.preview_mode_used")
     class PreviewModeUse(LogFormatter):  # pylint: disable=unused-variable


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses CMS-1298 and adds logging support for snippets (contact details, definitions etc.)

Creation, editing and deletion of snippets is already recorded in the log. This PR adds functionality to log the viewing of snippets, the same way it is implemented for viewing pages.

This builds on top of work done in #446.

### How to review

1. Create a snippet such as contact details
2. Open the snippet for editing
3. Go to Site History (`/admin/reports/site-history/`)
4. Ensure that a log entry is present

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [CMS-1298](https://officefornationalstatistics.atlassian.net/browse/CMS-1298)

[CMS-1298]: https://officefornationalstatistics.atlassian.net/browse/CMS-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ