### PR TITLE
chore(deps): upgrade Django to 6.0.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -831,14 +831,14 @@ django = ">=4.2"
 
 [[package]]
 name = "django"
-version = "6.0.6"
+version = "6.0.7"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2"},
-    {file = "django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713"},
+    {file = "django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e"},
+    {file = "django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890"},
 ]
 
 [package.dependencies]
@@ -3851,4 +3851,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14"
-content-hash = "157fe6244540e0df456ef174c007ed399182b2990e10105f39a77e740ca494bc"
+content-hash = "58a477fd99b21e0008477cc00cf5400ddebe405bb62f5c22ecfb3e3aed18efee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-poetry = ">=2.2"
 
 [tool.poetry.dependencies]
 python = "^3.14"
-django = "~6.0.6"
+django = "~6.0.7"
 wagtail = "~7.3.3"
 dj-database-url = "~3.1.2"
 django-defender = "~0.9.8"


### PR DESCRIPTION
### What is the context of this PR?

Upgrade Django to version 6.0.7 to address security issues (all medium severity).

Raised in pipeline here: https://github.com/ONSdigital/dis-wagtail/actions/runs/29093164869

OSV URLs:

- https://osv.dev/PYSEC-2026-2090
- https://osv.dev/PYSEC-2026-2091
- https://osv.dev/PYSEC-2026-2092 

### How to review

Ensure pipeline passes.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
