### PR TITLE
feat: enforce specific version of `poetry`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           python-version-file: .python-version
           cache: ${{ steps.cache-flag.outputs.poetry-cache }} # disabled on release branches via setup-cache-flag action
+      - name: Check poetry lock file version
+        run: make check-poetry-version
 
       - name: Install dependencies
         run: poetry install --no-root

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,15 @@ repos:
         # Only run on changes to pyproject.toml
         files: ^pyproject.toml$
 
+  - repo: local
+    hooks:
+      - id: check-poetry-version
+        name: check-poetry-version
+        language: system
+        entry: ./scripts/check-poetry-version.sh
+        pass_filenames: false
+        files: ^(pyproject\.toml|poetry\.lock)$
+
   # Template linting
   - repo: https://github.com/rtts/djhtml
     rev: 3.0.11

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ npm-build: ## Build the front-end assets
 	@if [ -f "$$HOME/.nvm/nvm.sh" ]; then . $$HOME/.nvm/nvm.sh && nvm use; fi && npm run build
 
 .PHONY: lint
-lint: lint-py lint-html lint-frontend lint-migrations ## Run all linters (python, html, front-end, migrations)
+lint: lint-py lint-html lint-frontend lint-migrations check-poetry-version ## Run all linters (python, html, front-end, migrations)
 
 .PHONY: lint-py
 lint-py:  ## Run all Python linters (ruff/pylint/mypy).
@@ -67,6 +67,10 @@ lint-frontend:  ## Run front-end linters
 .PHONY: lint-migrations
 lint-migrations: ## Run django-migration-linter
 	poetry run python manage.py lintmigrations --quiet ignore ok
+
+.PHONY: check-poetry-version
+check-poetry-version: ## Check pyproject.toml and poetry.lock use the same Poetry version
+	./scripts/check-poetry-version.sh
 
 .PHONY: test
 test:  ## Run the tests and check coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry]
 package-mode = false
-requires-poetry = ">=2.2"
+requires-poetry = "2.4.1"
 
 [tool.poetry.dependencies]
 python = "^3.14"

--- a/scripts/check-poetry-version.sh
+++ b/scripts/check-poetry-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pyproject_file="${PYPROJECT_FILE:-pyproject.toml}"
+lock_file="${LOCK_FILE:-poetry.lock}"
+
+required_version=$(grep -m1 '^requires-poetry' "${pyproject_file}" | sed -E 's/^requires-poetry[[:space:]]*=[[:space:]]*"([^"]+)"/\1/')
+
+if [[ -z "${required_version}" ]]; then
+    echo "Unable to find 'requires-poetry' in ${pyproject_file}." >&2
+    exit 1
+fi
+
+lock_version=$(head -n1 "${lock_file}" | sed -E 's/.*Poetry ([0-9][^ ]*).*/\1/')
+
+if [[ -z "${lock_version}" ]]; then
+    echo "Unable to determine the Poetry version used to generate ${lock_file}." >&2
+    exit 1
+fi
+
+if [[ "${required_version}" != "${lock_version}" ]]; then
+    echo "Poetry version mismatch: ${pyproject_file} requires '${required_version}' but ${lock_file} was generated with '${lock_version}'." >&2
+    exit 1
+fi
+
+echo "Poetry version '${required_version}' matches between ${pyproject_file} and ${lock_file}."


### PR DESCRIPTION
### What is the context of this PR?

This PR enforces the usage of a specific version of `poetry`, to avoid any inconsistencies.

This involves:
* Pinning the exact version of `poetry` in `pyproject.toml` (previously set to `>=2.2`)
* Adding a simple linter checking the message at the top of the `poetry.lock` file
* Adding the inter to the `pre-commit` setup and the GitHub `ci.yml` configuration as a new step

Note: In order to install a specific version of poetry, you can use the following commands:

If you used the official installer:
```bash
poetry self update 2.4.1
```

If you use `pipx`:
```bash
pipx install poetry==2.4.1 --force
```
If you installed it using a different method, consult the [documentation](https://python-poetry.org/docs/#installation).

### How to review

1. Install a version of poetry different from `2.4.1`
2. Trigger `pre-commit`
3. Ensure that it fails, complaining about the version
4. Re-generate the lock file using a different version, or manually change it to something else
5. Repeat steps 2 and 3

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
