### PR TITLE
chore: disable bleed deploy on merges to main

### DIFF
--- a/ci/concourse.yaml
+++ b/ci/concourse.yaml
@@ -10,8 +10,11 @@ helm:
       # so we intentionally update both bleed and sandbox configuration together.
       # This format will be changing in the near future and be relabeled as merges,
       # rc tags, prod tags etc. instead of env names.
-      - values/dis-bleed-internal.yaml
-      - values/dis-bleed-external.yaml
+      # Temporarily disabled while we deploy some featur/spike branches to bleed for testing.
+      # Once the testing is complete, we will revert to the original configuration.
+      # TODO: Revert once feature/spike branch testing is complete.
+      #      - values/dis-bleed-internal.yaml
+      #      - values/dis-bleed-external.yaml
       - values/dis-sandbox-internal.yaml
       - values/dis-sandbox-external.yaml
     staging:


### PR DESCRIPTION
### What is the context of this PR?

Temporarily disable bleed deploys on merges to main while we deploy some feature/spikes branch to bleed for testing.

### How to review

Ensure the bleed values files have been commented out so that the Concourse job ignores them.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
