### PR TITLE
chore(kics): remove redundant SHA pinning exclusion

### DIFF
--- a/.github/linters/kics.config
+++ b/.github/linters/kics.config
@@ -3,7 +3,6 @@
 # https://docs.kics.io/latest/
 exclude-queries:
   - "451d79dc-0588-476a-ad03-3c7f0320abb3"  # Container Traffic Not Bound To Host Interface Severity: Medium
-  - "555ab8f9-2001-455e-a077-f2d0f41e2fb9"  # Allow not pinning to commit SHA in GitHub CI
   - "610e266e-6c12-4bca-9925-1ed0cd29742b"  # Security Opt Not Set
   # Docker Compose Healthcheck Not Set Check containers periodically to see if they are running properly.
   # Run as local not relevant


### PR DESCRIPTION
### What is the context of this PR?

Remove the KICS exclusion for unpinned GitHub Actions.

Commit SHA pinning is already enforced by [zizmor](https://github.com/zizmorcore/zizmor), so this disable is misleading, as it is still checked (just by another linter atm), so this override is unnecessary and can coexist with zizmor, which also checks the same rule.

### How to review

Ensure changes make sense.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
