### PR TITLE
chore(deps): ignore all cryptography updates including security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,5 +50,7 @@ updates:
           - '*'
     ignore:
       - dependency-name: cryptography
+        # Currently 49 and up don't support intel mac
+        versions: ['>=49.0.0']
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,5 @@ updates:
           - '*'
     ignore:
       - dependency-name: cryptography
-        update-types:
-          - 'version-update:semver-major'
     cooldown:
       default-days: 7


### PR DESCRIPTION
### What is the context of this PR?

Previous PR (https://github.com/ONSdigital/dis-wagtail/pull/753) doesn't apply to security updates, change ignore config so dependabot doesn't apply any updates to cryptography.

See https://github.com/ONSdigital/dis-wagtail/pull/750 for why we're doing this.

### How to review

Check config.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
