### PR TITLE
chore(config): revert dependabot ignore config and update grype/osv-scanner configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,9 +48,5 @@ updates:
         applies-to: version-updates
         patterns:
           - '*'
-    ignore:
-      - dependency-name: cryptography
-        update-types:
-          - 'version-update:semver-major'
     cooldown:
       default-days: 7

--- a/.github/linters/.grype.yaml
+++ b/.github/linters/.grype.yaml
@@ -1,0 +1,4 @@
+ignore:
+  - package:
+      name: 'cryptography'
+      version: '48.0.1'

--- a/.github/linters/.grype.yaml
+++ b/.github/linters/.grype.yaml
@@ -1,3 +1,0 @@
-ignore:
-  - package:
-      name: 'cryptography'

--- a/.github/linters/osv-scanner.toml
+++ b/.github/linters/osv-scanner.toml
@@ -2,3 +2,10 @@
 ecosystem = "npm"
 group = "dev"
 ignore = true
+
+[[PackageOverrides]]
+ecosystem = "PyPI"
+name = "cryptography"
+version = "48.0.1"
+vulnerability.ignore = true
+reason = "Local only pinned to 48.0.1 for intel mac compatibility, not used in production."

--- a/.github/linters/osv-scanner.toml
+++ b/.github/linters/osv-scanner.toml
@@ -2,8 +2,3 @@
 ecosystem = "npm"
 group = "dev"
 ignore = true
-
-[[PackageOverrides]]
-ecosystem = "PyPI"
-name = "cryptography"
-ignore = true


### PR DESCRIPTION
### What is the context of this PR?

Given https://github.com/ONSdigital/dis-wagtail/pull/756, remove changes to dependabot config and see what it does

### How to review

Review dependabot config file

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
