### PR TITLE
refactor(bundles): avoid suppressing signals for post publish actions

### DIFF
--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -205,6 +205,38 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
     @patch("cms.bundles.utils.notify_slack_of_publish_end")
     @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
     @patch("cms.search.signal_handlers.get_publisher")
+    def test_publish_bundle_clears_stale_actions(
+        self,
+        mock_get_publisher,  # pylint: disable=unused-argument
+        mock_notify_post_publish_end,  # pylint: disable=unused-argument
+        mock_notify_end,  # pylint: disable=unused-argument
+        mock_notify_start,  # pylint: disable=unused-argument
+    ):
+        """Test all actions from a previous publish are cleared before a new publish."""
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+
+        stale_alias_action = PostPublishAction.objects.create(
+            bundle=self.bundle,
+            page=self.methodology_article,
+            action_type=PostPublishActionType.SEARCH_UPDATED,
+            status=PostPublishActionStatus.FAILED,
+            finished_at=timezone.now(),
+        )
+
+        mark_page_as_ready_to_publish(self.statistical_article)
+
+        self.call_command()
+
+        executor_stop_and_wait()
+
+        self.assertFalse(PostPublishAction.objects.filter(pk=stale_alias_action.pk).exists())
+        self.assertFalse(PostPublishAction.objects.failed().filter(bundle=self.bundle).exists())
+
+    @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
+    @patch("cms.bundles.utils.notify_slack_of_publication_start")
+    @patch("cms.bundles.utils.notify_slack_of_publish_end")
+    @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
+    @patch("cms.search.signal_handlers.get_publisher")
     def test_publish_bundle_action_error(
         self, mock_get_publisher, mock_notify_post_publish_end, mock_notify_end, mock_notify_start
     ):

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -131,7 +131,11 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
     @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
     @patch("cms.search.signal_handlers.get_publisher")
     def test_publish_bundle_waits_for_action(
-        self, mock_get_publisher, mock_notify_post_publish_end, mock_notify_end, mock_notify_start
+        self,
+        mock_get_publisher,
+        mock_notify_post_publish_end,
+        mock_notify_end,
+        mock_notify_start,
     ):
         BundlePageFactory(parent=self.bundle, page=self.statistical_article)
 
@@ -156,6 +160,45 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         mock_get_publisher.return_value.publish_created_or_updated.assert_called()
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
+
+    @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
+    @patch("cms.bundles.utils.notify_slack_of_publication_start")
+    @patch("cms.bundles.utils.notify_slack_of_publish_end")
+    @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
+    @patch("cms.search.signal_handlers.get_publisher")
+    def test_publish_bundle_runs_actions_for_aliases(
+        self,
+        mock_get_publisher,
+        mock_notify_post_publish_end,  # pylint: disable=unused-argument
+        mock_notify_end,  # pylint: disable=unused-argument
+        mock_notify_start,  # pylint: disable=unused-argument
+    ):
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+        alias = self.statistical_article.create_alias(
+            parent=self.statistical_article.get_parent(), update_slug="aliased-article"
+        )
+
+        mark_page_as_ready_to_publish(self.statistical_article)
+
+        self.call_command()
+
+        executor_stop_and_wait()
+
+        alias.refresh_from_db()
+        self.assertTrue(alias.live)
+
+        alias_actions = PostPublishAction.objects.filter(page=alias)
+        self.assertEqual(alias_actions.count(), 2)
+        for action in alias_actions:
+            self.assertEqual(action.bundle_id, self.bundle.pk)
+            self.assertEqual(action.status, PostPublishActionStatus.SUCCESSFUL)
+
+        published_page_ids = {
+            page_call.args[0].pk
+            for page_call in mock_get_publisher.return_value.publish_created_or_updated.call_args_list
+        }
+
+        self.assertIn(alias.pk, published_page_ids)
 
     @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
     @patch("cms.bundles.utils.notify_slack_of_publication_start")

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -439,11 +439,12 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:  # py
     failed_pages: list[int] = []
     total_pages = bundle.get_bundled_pages().count()
 
+    PostPublishAction.objects.filter(bundle=bundle).delete()
+
     for page in bundle.get_bundled_pages().specific(defer=True).select_related("latest_revision"):
         try:
             # Durable ensures no other savepoint will roll back the publish
             with transaction.atomic(durable=True):
-                PostPublishAction.objects.filter(bundle=bundle, page=page).delete()
                 if workflow_state := page.current_workflow_state:
                     with enqueue_post_publish_actions_for_bundle(bundle):
                         # finish the workflow

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -24,8 +24,7 @@ from cms.bundles.notifications.slack import (
 from cms.core.fields import StreamField
 from cms.post_publish_actions.executor import run_bundle_notification_in_support_executor, run_in_support_executor
 from cms.post_publish_actions.models import PostPublishAction
-from cms.post_publish_actions.signal_handlers import suppress_post_publish_actions_signal
-from cms.post_publish_actions.utils import run_post_publish_actions_for
+from cms.post_publish_actions.signal_handlers import enqueue_post_publish_actions_for_bundle
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.utils import get_translated_string
 
@@ -446,12 +445,9 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:  # py
             with transaction.atomic(durable=True):
                 PostPublishAction.objects.filter(bundle=bundle, page=page).delete()
                 if workflow_state := page.current_workflow_state:
-                    with suppress_post_publish_actions_signal():
+                    with enqueue_post_publish_actions_for_bundle(bundle):
                         # finish the workflow
                         workflow_state.current_task_state.approve()
-
-                        # Run post-publish actions manually to sure the correct bundle is detected.
-                        run_post_publish_actions_for(page, bundle)
 
                     pages_published += 1
                     logger.info(
@@ -459,12 +455,9 @@ def publish_bundle(bundle: Bundle, *, update_status: bool = True) -> bool:  # py
                         extra={"bundle_id": bundle.pk, "page_id": page.pk, "event": "publish_bundle_page"},
                     )
                 elif page.latest_revision:
-                    with suppress_post_publish_actions_signal():
+                    with enqueue_post_publish_actions_for_bundle(bundle):
                         # just run publish
                         page.latest_revision.publish(log_action="wagtail.publish.scheduled")
-
-                        # Run post-publish actions manually to sure the correct bundle is detected.
-                        run_post_publish_actions_for(page, bundle)
 
                     pages_published += 1
                     logger.info(
@@ -639,11 +632,3 @@ def in_active_bundle(item: Model) -> bool:
 def in_bundle_ready_to_be_published(item: Model) -> bool:
     active_bundle: Bundle | None = getattr(item, "active_bundle", None)
     return active_bundle is not None and active_bundle.is_ready_to_be_published
-
-
-def get_active_bundle_for_page(item: Page) -> Bundle | None:
-    from .mixins import BundledPageMixin  # pylint: disable=import-outside-toplevel
-
-    if isinstance(item, BundledPageMixin):
-        return item.active_bundle
-    return None

--- a/cms/post_publish_actions/signal_handlers.py
+++ b/cms/post_publish_actions/signal_handlers.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
-from asgiref.local import Local
 from wagtail.models import Page
 from wagtail.signals import page_published
 
@@ -11,8 +10,6 @@ from .utils import run_post_publish_actions_for
 
 if TYPE_CHECKING:
     from cms.bundles.models import Bundle
-
-_suppress_post_publish_actions_signal = Local()
 
 _publishing_bundle: ContextVar[Bundle | None] = ContextVar("_publishing_bundle", default=None)
 

--- a/cms/post_publish_actions/signal_handlers.py
+++ b/cms/post_publish_actions/signal_handlers.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
 
 from asgiref.local import Local
 from wagtail.models import Page
@@ -8,34 +9,30 @@ from wagtail.signals import page_published
 
 from .utils import run_post_publish_actions_for
 
+if TYPE_CHECKING:
+    from cms.bundles.models import Bundle
+
 _suppress_post_publish_actions_signal = Local()
+
+_publishing_bundle: ContextVar[Bundle | None] = ContextVar("_publishing_bundle", default=None)
 
 
 @contextmanager
-def suppress_post_publish_actions_signal() -> Generator[None]:
-    previous_value = getattr(_suppress_post_publish_actions_signal, "value", None)
+def enqueue_post_publish_actions_for_bundle(bundle: Bundle) -> Generator[None]:
+    """While active, page_published signals will enqueue post-publish actions for the given bundle instead of
+    running synchronously.
+    """
+    context_bundle = _publishing_bundle.set(bundle)
 
     try:
-        _suppress_post_publish_actions_signal.value = True
         yield
     finally:
-        if previous_value is None:
-            del _suppress_post_publish_actions_signal.value
-        else:
-            _suppress_post_publish_actions_signal.value = previous_value
+        _publishing_bundle.reset(context_bundle)
 
 
 def run_post_publish_actions_handler(sender: type[Page], instance: Page, **kwargs: Any) -> None:  # pylint: disable=unused-argument
-    from cms.bundles.utils import get_active_bundle_for_page  # pylint: disable=import-outside-toplevel
-
-    if getattr(_suppress_post_publish_actions_signal, "value", None):
-        return
-
-    # NB: If the bundle is already marked "published", this may return None.
-    bundle = get_active_bundle_for_page(instance)
-
-    run_post_publish_actions_for(instance, bundle)
+    run_post_publish_actions_for(instance, _publishing_bundle.get())
 
 
 def register_signal_handlers() -> None:
-    page_published.connect(run_post_publish_actions_handler)
+    page_published.connect(run_post_publish_actions_handler, dispatch_uid="run_post_publish_actions_handler")

--- a/cms/post_publish_actions/tests/test_signal_handlers.py
+++ b/cms/post_publish_actions/tests/test_signal_handlers.py
@@ -3,36 +3,54 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from cms.post_publish_actions.signal_handlers import (
-    _suppress_post_publish_actions_signal,
+    _publishing_bundle,
+    enqueue_post_publish_actions_for_bundle,
     run_post_publish_actions_handler,
-    suppress_post_publish_actions_signal,
 )
 
 
-class SuppressPostPublishActionsSignalTestCase(SimpleTestCase):
-    def _is_suppressed(self):
-        return getattr(_suppress_post_publish_actions_signal, "value", None)
+class EnqueuePostPublishActionsSignalTestCase(SimpleTestCase):
+    def _current_bundle(self):
+        return _publishing_bundle.get()
 
-    def test_suppresses_and_clears(self):
-        self.assertIsNone(self._is_suppressed())
+    def test_sets_and_clears(self):
+        sentinel_bundle = object()
 
-        with suppress_post_publish_actions_signal():
-            self.assertTrue(self._is_suppressed())
+        self.assertIsNone(self._current_bundle())
 
-        self.assertIsNone(self._is_suppressed())
+        with enqueue_post_publish_actions_for_bundle(sentinel_bundle):
+            self.assertIs(self._current_bundle(), sentinel_bundle)
 
-    def test_nested_inner_exit_does_not_clear_outer(self):
-        with suppress_post_publish_actions_signal():
-            with suppress_post_publish_actions_signal():
-                self.assertTrue(self._is_suppressed())
-            self.assertTrue(self._is_suppressed())
-        self.assertIsNone(self._is_suppressed())
+        self.assertIsNone(self._current_bundle())
+
+    def test_nested_inner_exit_restores_outer(self):
+        outer_bundle = object()
+        inner_bundle = object()
+
+        with enqueue_post_publish_actions_for_bundle(outer_bundle):
+            self.assertIs(self._current_bundle(), outer_bundle)
+
+            with enqueue_post_publish_actions_for_bundle(inner_bundle):
+                self.assertIs(self._current_bundle(), inner_bundle)
+
+            self.assertIs(self._current_bundle(), outer_bundle)
+
+        self.assertIsNone(self._current_bundle())
 
     @patch("cms.post_publish_actions.signal_handlers.run_post_publish_actions_for")
-    def test_handler_is_noop_while_suppressed(self, mock_run_post_publish_actions_for):
+    def test_handler_enqueues_for_context_bundle(self, mock_run_post_publish_actions_for):
         sentinel_page = object()
+        sentinel_bundle = object()
 
-        with suppress_post_publish_actions_signal():
+        with enqueue_post_publish_actions_for_bundle(sentinel_bundle):
             run_post_publish_actions_handler(sender=None, instance=sentinel_page)
 
-        mock_run_post_publish_actions_for.assert_not_called()
+        mock_run_post_publish_actions_for.assert_called_once_with(sentinel_page, sentinel_bundle)
+
+    @patch("cms.post_publish_actions.signal_handlers.run_post_publish_actions_for")
+    def test_handler_runs_without_bundle_outside_context(self, mock_run_post_publish_actions_for):
+        sentinel_page = object()
+
+        run_post_publish_actions_handler(sender=None, instance=sentinel_page)
+
+        mock_run_post_publish_actions_for.assert_called_once_with(sentinel_page, None)

--- a/cms/post_publish_actions/tests/test_utils.py
+++ b/cms/post_publish_actions/tests/test_utils.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 
 from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.bundles.tests.factories import BundleFactory
-from cms.bundles.utils import get_active_bundle_for_page
 from cms.home.models import HomePage
 from cms.post_publish_actions import registry
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
@@ -27,13 +26,6 @@ class RunPostPublishActionsForTestCase(TestCase):
 
         self.handler.assert_called_with(self.page, None)
         self.assertEqual(PostPublishAction.objects.count(), 0)
-
-
-class GetActiveBundleForPageTestCase(TestCase):
-    def test_returns_none_for_a_page_that_cannot_be_bundled(self):
-        home_page = HomePage.objects.first()
-
-        self.assertIsNone(get_active_bundle_for_page(home_page))
 
 
 class PostPublishNotifySlackTestCase(TestCase):

--- a/cms/private_media/signal_handlers.py
+++ b/cms/private_media/signal_handlers.py
@@ -52,6 +52,9 @@ def publish_media_on_publish(instance: Model, **kwargs: Any) -> None:
 
 
 def publish_media_post_publish_action(page: Page, _bundle: Bundle | None) -> None:
+    if page.alias_of_id is not None:
+        # Don't publish media for alias pages, as they don't have their own content.
+        return
     _publish_media(page)
 
 

--- a/cms/private_media/tests/test_signal_handlers.py
+++ b/cms/private_media/tests/test_signal_handlers.py
@@ -174,7 +174,9 @@ class SignalHandlersTestCase(TestCase):
     @patch("cms.private_media.signal_handlers._publish_media")
     def test_signal_early_returns_for_alias(self, mock_publish_media):
         """Tests that the signal handlers early return when the instance is an alias page."""
-        alias_page = self.test_page.create_alias()
-        alias_page.save_revision().publish()
+        self.test_page.create_alias(update_slug="test-information-page-alias")
 
-        mock_publish_media.assert_not_called()
+        self.test_page.save_revision().publish()
+
+        # should only run one time for the original page, not the alias
+        mock_publish_media.assert_called_once_with(self.test_page)

--- a/cms/private_media/tests/test_signal_handlers.py
+++ b/cms/private_media/tests/test_signal_handlers.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import Any
+from unittest.mock import patch
 
 from django.test import TestCase
 from wagtail.models import Site
@@ -162,3 +163,18 @@ class SignalHandlersTestCase(TestCase):
         # because it is still referenced by the original live page
         new_page.unpublish()
         self.assertMediaPrivacy(Privacy.PUBLIC)
+
+    @patch("cms.private_media.signal_handlers._publish_media")
+    def test_signal_runs_for_regular_pages(self, mock_publish_media):
+        """Tests that the signal handlers run for regular page."""
+        self.test_page.save_revision().publish()
+
+        mock_publish_media.assert_called_once_with(self.test_page)
+
+    @patch("cms.private_media.signal_handlers._publish_media")
+    def test_signal_early_returns_for_alias(self, mock_publish_media):
+        """Tests that the signal handlers early return when the instance is an alias page."""
+        alias_page = self.test_page.create_alias(self.home_page)
+        alias_page.save_revision().publish()
+
+        mock_publish_media.assert_not_called()

--- a/cms/private_media/tests/test_signal_handlers.py
+++ b/cms/private_media/tests/test_signal_handlers.py
@@ -174,7 +174,7 @@ class SignalHandlersTestCase(TestCase):
     @patch("cms.private_media.signal_handlers._publish_media")
     def test_signal_early_returns_for_alias(self, mock_publish_media):
         """Tests that the signal handlers early return when the instance is an alias page."""
-        alias_page = self.test_page.create_alias(self.home_page)
+        alias_page = self.test_page.create_alias()
         alias_page.save_revision().publish()
 
         mock_publish_media.assert_not_called()

--- a/cms/search/signal_handlers.py
+++ b/cms/search/signal_handlers.py
@@ -17,27 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 @post_publish_action(PostPublishActionType.SEARCH_UPDATED)
-def update_index_post_publish_action(page: Page, bundle: Bundle | None) -> None:
-    publisher = get_publisher()
+def update_index_post_publish_action(page: Page, _bundle: Bundle | None) -> None:
     if is_indexable_page(page):
-        publisher.publish_created_or_updated(page)
-
-    if bundle is None:
-        # During bundle publishing wagtail's page_published signal is suppressed
-        # outside of bundle publishing it will handle descendants and aliases
-        return
-
-    # mimic update_aliases behaviour to walk alias tree
-    seen_ids: set[int] = set()
-    aliases = list(page.aliases.specific())
-    while aliases:
-        alias = aliases.pop()
-        if alias.id in seen_ids:
-            continue
-        seen_ids.add(alias.id)
-        if is_indexable_page(alias):
-            publisher.publish_created_or_updated(alias)
-        aliases.extend(alias.aliases.specific())
+        get_publisher().publish_created_or_updated(page)
 
 
 @receiver(page_unpublished)

--- a/cms/search/tests/test_signal_handlers.py
+++ b/cms/search/tests/test_signal_handlers.py
@@ -6,12 +6,11 @@ from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move
 
 from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
-from cms.bundles.tests.factories import BundleFactory
 from cms.home.models import HomePage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.release_calendar.models import ReleaseCalendarIndex
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
-from cms.search.signal_handlers import build_old_descendant_path, update_index_post_publish_action
+from cms.search.signal_handlers import build_old_descendant_path
 from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
 from cms.themes.tests.factories import ThemePageFactory
 from cms.topics.tests.factories import TopicPageFactory
@@ -672,33 +671,3 @@ class SearchSignalsTest(TestCase):
                 call(cy_alias, old_url_path=en_before.url_path),
             ]
         )
-
-
-class UpdateIndexPostPublishActionTests(TestCase):
-    @patch("cms.search.signal_handlers.get_publisher")
-    def test_bundle_publish_indexes_aliases(self, mock_get_publisher):
-        page = StatisticalArticlePageFactory()
-        alias = page.create_alias(parent=page.get_parent(), update_slug="aliased_article")
-        bundle = BundleFactory()
-
-        update_index_post_publish_action(page, bundle)
-
-        published_ids = sorted(
-            c.args[0].pk for c in mock_get_publisher.return_value.publish_created_or_updated.call_args_list
-        )
-        self.assertEqual(published_ids, [page.pk, alias.pk])
-
-    @patch("cms.search.signal_handlers.get_publisher")
-    def test_non_bundle_publish_does_not_walk_aliases(self, mock_get_publisher):
-        """Sync publishing indexes aliases via their own page_published signal,
-        so we don't walk the alias tree for non-bundle publishes.
-        """
-        page = StatisticalArticlePageFactory()
-        page.create_alias(parent=page.get_parent(), update_slug="aliased_article")
-
-        update_index_post_publish_action(page, None)
-
-        published_ids = sorted(
-            c.args[0].pk for c in mock_get_publisher.return_value.publish_created_or_updated.call_args_list
-        )
-        self.assertEqual(published_ids, [page.pk])


### PR DESCRIPTION
### What is the context of this PR?

Refactor the signal handling for post-publish actions.

Previously we suppressed signals and executed actions manually, but this has issues with signals not running for aliases. As this may introduce large maintenance burden later if other signals are added to core, we'd like to avoid this.

This PR adds a context variable to track the currently being published bundle to pass into the signal as it enqueues action. Context variables were chosen as in future we may possibly be executing in non-os threads.

This ensures we also have dedicated actions tracked for aliases, and preserves the action registry pattern.

### How to review

Ensure tests run successfully
Check action enqueueing runs correctly

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Add a cleanup card to convert existing usages of thread locals to context variables.
