### PR TITLE
fix: update dataset link destinations

### DIFF
--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -618,11 +618,8 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
         self.assertIn(self.page.related_data_display_title, content)
         self.assertIn(lookup_dataset.title, content)
         self.assertIn(lookup_dataset.description, content)
-        # Related data pages link to the dataset series page, not to a specific edition.
-        # We assert on the full href rather than just the path because the series URL
-        # ("/datasets/LOOKUP") is a substring of the edition URL
-        # ("/datasets/LOOKUP/editions/lookup_edition/versions/"), so a looser check would still
-        # pass if this page ever started linking to a specific edition.
+        # The series URL is a prefix of the edition URL, so the full href is asserted to catch a
+        # related data page linking to an edition.
         self.assertIn(f'href="{lookup_dataset.url_path}"', content)
         self.assertIn(manual_dataset["title"], content)
         self.assertIn(manual_dataset["description"], content)

--- a/cms/articles/tests/test_pages.py
+++ b/cms/articles/tests/test_pages.py
@@ -618,7 +618,12 @@ class StatisticalArticlePageTests(TranslationResetMixin, WagtailPageTestCase):
         self.assertIn(self.page.related_data_display_title, content)
         self.assertIn(lookup_dataset.title, content)
         self.assertIn(lookup_dataset.description, content)
-        self.assertIn(lookup_dataset.url_path, content)
+        # Related data pages link to the dataset series page, not to a specific edition.
+        # We assert on the full href rather than just the path because the series URL
+        # ("/datasets/LOOKUP") is a substring of the edition URL
+        # ("/datasets/LOOKUP/editions/lookup_edition/versions/"), so a looser check would still
+        # pass if this page ever started linking to a specific edition.
+        self.assertIn(f'href="{lookup_dataset.url_path}"', content)
         self.assertIn(manual_dataset["title"], content)
         self.assertIn(manual_dataset["description"], content)
         self.assertIn(manual_dataset["url"], content)

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -21,6 +21,15 @@ DatasetChooserBlock = dataset_chooser_viewset.get_block_class(
     name="DatasetChooserBlock", module_path="cms.datasets.blocks"
 )
 
+DUPLICATE_DATASET_ERROR = 'Duplicate datasets are not allowed. Another entry links to "{url_path}".'
+
+# Added for pages whose links resolve to an edition. The chooser lists the dataset version, so an
+# editor who picked two versions of one edition needs telling why that counts as a duplicate.
+LATEST_VERSION_DUPLICATE_HINT = (
+    " Links from this page point to the latest published version of an edition, so the dataset "
+    "version does not affect the destination."
+)
+
 
 class ManualDatasetBlock(StructBlock):
     title = CharBlock(required=True, required_on_save=True)
@@ -77,12 +86,15 @@ class DatasetStoryBlock(StreamBlock):
             url_paths[extract_url_path(url).lower()].add(block_index)
 
         block_errors = {}
-        for block_indices in url_paths.values():
+        for url_path, block_indices in url_paths.items():
             # Add a block error for any index which contains a duplicate URL,
             # so that the validation error messages appear on the actual duplicate entries
             if len(block_indices) > 1:
+                message = DUPLICATE_DATASET_ERROR.format(url_path=url_path)
+                if self.meta.link_to_latest_version:
+                    message += LATEST_VERSION_DUPLICATE_HINT
                 for index in block_indices:
-                    block_errors[index] = ValidationError("Duplicate datasets are not allowed")
+                    block_errors[index] = ValidationError(message)
 
         if block_errors:
             raise StreamBlockValidationError(block_errors=block_errors)

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -71,27 +71,33 @@ class DatasetStoryBlock(StreamBlock):
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
         cleaned_value = super().clean(value)
 
-        # Validate there are no duplicate datasets,
-        # including between manual and looked up datasets referencing the same URL
-
-        # For each dataset URL path, record the indices of the blocks it appears in.
-        # Both kinds of block are normalised the same way, so a URL typed by hand is recognised as
-        # a duplicate of a lookup resolving to the same place, however it was written.
+        # Validate there are no duplicate datasets, including between manual and looked up datasets
+        # resolving to the same place, however each was written.
+        #
+        # url_paths maps a normalised comparison key to the blocks using it. That key is lowercased
+        # and has its trailing slash stripped, so it is not fit to show an editor: destinations
+        # holds the URL each group really links to, preferring a looked up dataset because the CMS
+        # resolves that one itself rather than taking it from whatever somebody typed.
         url_paths = defaultdict(set)
+        destinations: dict[str, str] = {}
         for block_index, block in enumerate(cleaned_value):
+            is_lookup = block.block_type == "dataset_lookup"
             url = (
                 block.value.get_url_path(link_to_latest_version=self.meta.link_to_latest_version)
-                if block.block_type == "dataset_lookup"
+                if is_lookup
                 else block.value["url"]
             )
-            url_paths[extract_url_path(url).lower()].add(block_index)
+            url_path = extract_url_path(url).lower()
+            url_paths[url_path].add(block_index)
+            if is_lookup or url_path not in destinations:
+                destinations[url_path] = url if is_lookup else extract_url_path(url)
 
         block_errors = {}
         for url_path, block_indices in url_paths.items():
             # Add a block error for any index which contains a duplicate URL,
             # so that the validation error messages appear on the actual duplicate entries
             if len(block_indices) > 1:
-                message = DUPLICATE_DATASET_ERROR.format(url_path=url_path)
+                message = DUPLICATE_DATASET_ERROR.format(url_path=destinations[url_path])
                 if self.meta.link_to_latest_version:
                     message += LATEST_VERSION_DUPLICATE_HINT
                 for index in block_indices:

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -51,17 +51,24 @@ class DatasetStoryBlock(StreamBlock):
         label="Manually Linked Dataset",
     )
 
+    class Meta:
+        # Overridden per field: release calendar pages pass True so that looked up datasets link to
+        # the latest published version of the chosen edition rather than the dataset series page.
+        link_to_latest_version = False
+
     def clean(self, value: StreamValue) -> StreamValue:
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets,
         # including between manual and looked up datasets referencing the same URL
 
-        # For each dataset URL path, record the indices of the blocks it appears in
+        # For each dataset URL path, record the indices of the blocks it appears in.
+        # Looked up datasets are compared by the destination they resolve to for this page rather
+        # than by dataset ID, because the same dataset can resolve to different destinations.
         url_paths = defaultdict(set)
         for block_index, block in enumerate(cleaned_value):
             url_path = (
-                block.value.url_path
+                block.value.get_url_path(link_to_latest_version=self.meta.link_to_latest_version)
                 if block.block_type == "dataset_lookup"
                 else extract_url_path(block.value["url"]).lower()
             )

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -23,7 +23,7 @@ DatasetChooserBlock = dataset_chooser_viewset.get_block_class(
 
 DUPLICATE_DATASET_ERROR = 'Duplicate datasets are not allowed. Another entry links to "{url_path}".'
 
-# Added for pages whose links resolve to an edition. The chooser lists the dataset version, so an
+# Appended on pages whose links resolve to an edition. The chooser lists the dataset version, so an
 # editor who picked two versions of one edition needs telling why that counts as a duplicate.
 LATEST_VERSION_DUPLICATE_HINT = (
     " Links from this page point to the latest published version of an edition, so the dataset "

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -69,10 +69,13 @@ class DatasetStoryBlock(StreamBlock):
         link_to_latest_version = False
 
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
+        # pylint: disable=unused-argument
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets, including between manual and looked up datasets
-        # resolving to the same place, however each was written.
+        # that point at the same place, however each was written. Destination resolution only
+        # happens for looked up datasets: a manual link's URL is not resolved, so the version it
+        # names is not dropped from it.
         #
         # url_paths maps a normalised comparison key to the blocks using it. That key is lowercased
         # and has its trailing slash stripped, so it is not fit to show an editor: destinations

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -69,7 +69,6 @@ class DatasetStoryBlock(StreamBlock):
         link_to_latest_version = False
 
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
-        # pylint: disable=unused-argument
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets, including between manual and looked up datasets

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -66,21 +66,14 @@ class DatasetStoryBlock(StreamBlock):
         link_to_latest_version = False
 
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
-        # ignore_required_constraints is passed by BlockField.clean() and must be accepted, or
-        # saving a page with this field raises a TypeError. It is not forwarded to super(), which
-        # matches the behaviour of TimeSeriesPageStoryBlock.clean(). Page form tests that post a
-        # datasets field, such as those in cms/release_calendar/tests/test_forms.py, fail if it is
-        # removed.
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets,
         # including between manual and looked up datasets referencing the same URL
 
         # For each dataset URL path, record the indices of the blocks it appears in.
-        # Looked up datasets are compared by the destination they resolve to for this page rather
-        # than by dataset ID, because the same dataset can resolve to different destinations.
-        # Both kinds of block are then normalised the same way, so that a URL typed by hand is
-        # recognised as a duplicate of a lookup resolving to the same place however it was written.
+        # Both kinds of block are normalised the same way, so a URL typed by hand is recognised as
+        # a duplicate of a lookup resolving to the same place, however it was written.
         url_paths = defaultdict(set)
         for block_index, block in enumerate(cleaned_value):
             url = (

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -61,8 +61,11 @@ class DatasetStoryBlock(StreamBlock):
     )
 
     class Meta:
-        # Overridden per field: release calendar pages pass True so that looked up datasets link to
-        # the latest published version of the chosen edition rather than the dataset series page.
+        # Set per field, and the only place a page declares where its dataset links go. It drives
+        # both the duplicate check below and the URLs format_datasets_as_document_list renders,
+        # which is what stops a page validating against one destination and rendering another.
+        # Release calendar pages set True, so looked up datasets link to the latest published
+        # version of the chosen edition rather than to the dataset series page.
         link_to_latest_version = False
 
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -68,7 +68,7 @@ class DatasetStoryBlock(StreamBlock):
         # version of the chosen edition rather than to the dataset series page.
         link_to_latest_version = False
 
-    def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
+    def clean(self, value: StreamValue) -> StreamValue:
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets, including between manual and looked up datasets

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -65,14 +65,16 @@ class DatasetStoryBlock(StreamBlock):
         # For each dataset URL path, record the indices of the blocks it appears in.
         # Looked up datasets are compared by the destination they resolve to for this page rather
         # than by dataset ID, because the same dataset can resolve to different destinations.
+        # Both kinds of block are then normalised the same way, so that a URL typed by hand is
+        # recognised as a duplicate of a lookup resolving to the same place however it was written.
         url_paths = defaultdict(set)
         for block_index, block in enumerate(cleaned_value):
-            url_path = (
+            url = (
                 block.value.get_url_path(link_to_latest_version=self.meta.link_to_latest_version)
                 if block.block_type == "dataset_lookup"
-                else extract_url_path(block.value["url"]).lower()
+                else block.value["url"]
             )
-            url_paths[url_path].add(block_index)
+            url_paths[extract_url_path(url).lower()].add(block_index)
 
         block_errors = {}
         for block_indices in url_paths.values():

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -68,7 +68,9 @@ class DatasetStoryBlock(StreamBlock):
     def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
         # ignore_required_constraints is passed by BlockField.clean() and must be accepted, or
         # saving a page with this field raises a TypeError. It is not forwarded to super(), which
-        # matches the behaviour of TimeSeriesPageStoryBlock.clean().
+        # matches the behaviour of TimeSeriesPageStoryBlock.clean(). Page form tests that post a
+        # datasets field, such as those in cms/release_calendar/tests/test_forms.py, fail if it is
+        # removed.
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets,

--- a/cms/datasets/blocks.py
+++ b/cms/datasets/blocks.py
@@ -65,7 +65,10 @@ class DatasetStoryBlock(StreamBlock):
         # the latest published version of the chosen edition rather than the dataset series page.
         link_to_latest_version = False
 
-    def clean(self, value: StreamValue) -> StreamValue:
+    def clean(self, value: StreamValue, ignore_required_constraints: bool = False) -> StreamValue:
+        # ignore_required_constraints is passed by BlockField.clean() and must be accepted, or
+        # saving a page with this field raises a TypeError. It is not forwarded to super(), which
+        # matches the behaviour of TimeSeriesPageStoryBlock.clean().
         cleaned_value = super().clean(value)
 
         # Validate there are no duplicate datasets,

--- a/cms/datasets/models.py
+++ b/cms/datasets/models.py
@@ -251,6 +251,29 @@ class Dataset(models.Model):  # type: ignore[django-manager-missing]
         return f"/datasets/{self.namespace}"
 
     @property
+    def latest_version_url_path(self) -> str:
+        """The path to the latest published version of this dataset's edition.
+
+        The path deliberately omits the version. The website resolves it to the latest published
+        version of the edition, so a link built from it follows any correction published for that
+        edition rather than pinning the version that was current when the link was created.
+        """
+        return f"/datasets/{self.namespace}/editions/{self.edition}/versions/"
+
+    def get_url_path(self, *, link_to_latest_version: bool = False) -> str:
+        """Return the public path this dataset should be linked to.
+
+        Which destination is correct depends on the page doing the linking rather than on the
+        dataset. Pages tied to a specific edition, such as release calendar entries, pass True.
+        Pages that are not tied to an edition, such as topic and related data pages, link to the
+        series page so that readers reach the most recent data.
+
+        Both rendering and duplicate validation resolve destinations through here, so that a page
+        cannot validate against one destination and then render another.
+        """
+        return self.latest_version_url_path if link_to_latest_version else self.url_path
+
+    @property
     def compound_id(self) -> str:
         """Return the compound ID for this local Dataset instance.
 

--- a/cms/datasets/models.py
+++ b/cms/datasets/models.py
@@ -256,11 +256,11 @@ class Dataset(models.Model):  # type: ignore[django-manager-missing]
         Which destination is correct depends on the page doing the linking rather than on the
         dataset. Callers read link_to_latest_version off the DatasetStoryBlock the linking page's
         field was built with, so pages tied to a specific edition, such as release calendar
-        entries, get the edition path. That path stops at "versions/", so the destination is not
+        entries, get the edition path. That path stops at "versions", so the destination is not
         pinned to the version recorded here.
         """
         if link_to_latest_version:
-            return f"/datasets/{self.namespace}/editions/{self.edition}/versions/"
+            return f"{self.url_path}/editions/{self.edition}/versions"
         return self.url_path
 
     @property

--- a/cms/datasets/models.py
+++ b/cms/datasets/models.py
@@ -254,9 +254,10 @@ class Dataset(models.Model):  # type: ignore[django-manager-missing]
         """Return the public path this dataset should be linked to.
 
         Which destination is correct depends on the page doing the linking rather than on the
-        dataset: pages tied to a specific edition, such as release calendar entries, pass True.
-        The edition path stops at "versions/", so the destination is not pinned to the version
-        recorded here.
+        dataset. Callers read link_to_latest_version off the DatasetStoryBlock the linking page's
+        field was built with, so pages tied to a specific edition, such as release calendar
+        entries, get the edition path. That path stops at "versions/", so the destination is not
+        pinned to the version recorded here.
         """
         if link_to_latest_version:
             return f"/datasets/{self.namespace}/editions/{self.edition}/versions/"

--- a/cms/datasets/models.py
+++ b/cms/datasets/models.py
@@ -250,28 +250,17 @@ class Dataset(models.Model):  # type: ignore[django-manager-missing]
         """
         return f"/datasets/{self.namespace}"
 
-    @property
-    def latest_version_url_path(self) -> str:
-        """The path to the latest published version of this dataset's edition.
-
-        The path deliberately omits the version. The website resolves it to the latest published
-        version of the edition, so a link built from it follows any correction published for that
-        edition rather than pinning the version that was current when the link was created.
-        """
-        return f"/datasets/{self.namespace}/editions/{self.edition}/versions/"
-
     def get_url_path(self, *, link_to_latest_version: bool = False) -> str:
         """Return the public path this dataset should be linked to.
 
         Which destination is correct depends on the page doing the linking rather than on the
-        dataset. Pages tied to a specific edition, such as release calendar entries, pass True.
-        Pages that are not tied to an edition, such as topic and related data pages, link to the
-        series page so that readers reach the most recent data.
-
-        Both rendering and duplicate validation resolve destinations through here, so that a page
-        cannot validate against one destination and then render another.
+        dataset: pages tied to a specific edition, such as release calendar entries, pass True.
+        The edition path stops at "versions/", so the destination is not pinned to the version
+        recorded here.
         """
-        return self.latest_version_url_path if link_to_latest_version else self.url_path
+        if link_to_latest_version:
+            return f"/datasets/{self.namespace}/editions/{self.edition}/versions/"
+        return self.url_path
 
     @property
     def compound_id(self) -> str:

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -219,8 +219,40 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
         self.assertEqual(len(validation_error.exception.block_errors), 2)
         for error in validation_error.exception.block_errors.values():
-            self.assertIn('"/datasets/ds/editions/march/versions"', error.message)
+            # The destination the entries share, not the normalised key used to spot the collision,
+            # so the trailing slash the page actually links to is present.
+            self.assertIn('"/datasets/ds/editions/march/versions/"', error.message)
             self.assertIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
+
+    @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
+    def test_duplicate_error_message_keeps_the_case_of_the_destination(self):
+        """Comparison is case insensitive, but the reported URL has to match the rendered href.
+
+        The namespace and edition are free text from the Dataset API, so an editor told to look for
+        a lowercased path would be hunting a link the page never produces.
+        """
+        mixed_case = Dataset.objects.create(
+            namespace="LOOKUP",
+            edition="Lookup_Edition",
+            version=1,
+            title="Mixed case namespace and edition",
+            description="test_description",
+        )
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", mixed_case.id),
+                ("manual_link", {"title": "Dataset Title", "url": "/datasets/lookup/editions/lookup_edition/versions"}),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        self.assertEqual(len(validation_error.exception.block_errors), 2)
+        for error in validation_error.exception.block_errors.values():
+            self.assertIn('"/datasets/LOOKUP/editions/Lookup_Edition/versions/"', error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_for_a_manual_link_to_the_resolved_url(self):

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -219,9 +219,9 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
         self.assertEqual(len(validation_error.exception.block_errors), 2)
         for error in validation_error.exception.block_errors.values():
-            # The destination the entries share, not the normalised key used to spot the collision,
-            # so the trailing slash the page actually links to is present.
-            self.assertIn('"/datasets/ds/editions/march/versions/"', error.message)
+            # The destination the entries share, not the normalised key used to spot the
+            # collision, so this is the href an editor can go and look for on the page.
+            self.assertIn('"/datasets/ds/editions/march/versions"', error.message)
             self.assertIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
@@ -252,7 +252,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
         self.assertEqual(len(validation_error.exception.block_errors), 2)
         for error in validation_error.exception.block_errors.values():
-            self.assertIn('"/datasets/LOOKUP/editions/Lookup_Edition/versions/"', error.message)
+            self.assertIn('"/datasets/LOOKUP/editions/Lookup_Edition/versions"', error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_for_a_manual_link_to_the_resolved_url(self):

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -58,11 +58,7 @@ class TestDatasetStoryBlock(TestCase):
                     self.assertIn("Duplicate datasets are not allowed", error.message)
 
     def test_duplicate_error_message_names_the_shared_destination(self):
-        """The message says where the entries point, so the editor can see why they collide.
-
-        On these pages the destination is the series page, so the note about versions that release
-        calendar pages get would not apply and is left out.
-        """
+        """The note about versions belongs only on pages linking to an edition, so not here."""
         block = DatasetStoryBlock()
         value = StreamValue(
             block,
@@ -80,11 +76,7 @@ class TestDatasetStoryBlock(TestCase):
             self.assertNotIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
 
     def test_validation_fails_for_different_editions_of_the_same_dataset(self):
-        """Topic and related data pages link to the dataset series page, which has no edition in
-        its URL. Two different editions of the same dataset therefore both resolve to
-        "/datasets/<dataset-id>", making them duplicates even though the editor picked two
-        different rows in the chooser.
-        """
+        """Both editions resolve to the series page here, so they are duplicates."""
         block = DatasetStoryBlock()
         other_edition = Dataset.objects.create(
             namespace=self.lookup_dataset.namespace,
@@ -167,22 +159,15 @@ class TestDatasetStoryBlock(TestCase):
 
 
 class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
-    """Duplicate validation for pages that link datasets to a specific edition.
+    """Duplicate validation where links resolve to an edition rather than the series page.
 
-    A release is associated with one edition of a dataset, so release calendar pages declare
-    their dataset field as DatasetStoryBlock(link_to_latest_version=True) and their looked up
-    datasets resolve to "/datasets/<dataset-id>/editions/<edition-id>/versions/" instead of the
-    series page. Duplicate validation compares those resolved destinations, so what counts as a
-    duplicate differs from the series page context covered by TestDatasetStoryBlock above.
-
-    Note that the resolved URL has no version in it. The website serves the latest published
-    version of the edition from that path, which is what makes corrections published after the
-    release show up without anyone editing the link.
+    What counts as a duplicate differs from the series page context in TestDatasetStoryBlock,
+    because the resolved URL names the edition but not the version.
     """
 
     def setUp(self):
-        # Three chooser selections for one dataset: two versions of the March edition, and the
-        # April edition. Only the edition affects the resolved URL, not the version.
+        # Only the edition affects the resolved URL, so two versions of one edition collide and
+        # the April edition does not.
         self.march_v1 = Dataset.objects.create(
             namespace="ds",
             edition="march",
@@ -206,10 +191,6 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
         )
 
     def test_validation_passes_for_different_editions_of_the_same_dataset(self):
-        """Two editions of one dataset resolve to different URLs here, so both are allowed.
-
-        A release can legitimately relate to more than one edition of the same dataset.
-        """
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
             block,
@@ -222,36 +203,8 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
         # Expect clean to not raise any errors
         block.clean(value)
 
-    def test_duplicate_error_message_explains_that_the_version_is_not_in_the_link(self):
-        """Two versions of one edition look different in the chooser but link to the same place.
-
-        The chooser lists the version, so an editor who picked version 9 and version 10 has no
-        reason to expect a duplicate. The message therefore names the shared destination, which
-        visibly has no version in it, and spells out why the version makes no difference.
-        """
-        block = DatasetStoryBlock(link_to_latest_version=True)
-        value = StreamValue(
-            block,
-            stream_data=[
-                ("dataset_lookup", self.march_v1.id),
-                ("dataset_lookup", self.march_v2.id),
-            ],
-        )
-
-        with self.assertRaises(ValidationError) as validation_error:
-            block.clean(value)
-
-        for error in validation_error.exception.block_errors.values():
-            self.assertIn('"/datasets/ds/editions/march/versions"', error.message)
-            self.assertIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
-
     def test_validation_fails_for_two_versions_of_the_same_edition(self):
-        """Two versions of one edition resolve to the same URL, so they are duplicates.
-
-        The chooser lists the version, and the CMS records which version was picked, but the
-        version is not part of the resolved URL. Picking March v1 and March v2 on the same page
-        therefore produces two identical links, which the editor is told about here.
-        """
+        """The chooser lists the version, so the message has to explain why these collide."""
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
             block,
@@ -265,16 +218,13 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
             block.clean(value)
 
         self.assertEqual(len(validation_error.exception.block_errors), 2)
+        for error in validation_error.exception.block_errors.values():
+            self.assertIn('"/datasets/ds/editions/march/versions"', error.message)
+            self.assertIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_for_a_manual_link_to_the_resolved_url(self):
-        """A manually typed link is a duplicate of a lookup that resolves to the same place.
-
-        Editors can reach the same dataset either through the chooser or by typing the URL, so
-        both sides of the comparison are normalised first: the host is dropped and the trailing
-        slash is ignored. Each case below is the same destination as the March lookup, written a
-        different way.
-        """
+        """Each case is the March lookup's destination, written a different way."""
         block = DatasetStoryBlock(link_to_latest_version=True)
         manual_url_cases = [
             "/datasets/ds/editions/march/versions/",
@@ -301,12 +251,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_for_manual_links_differing_only_by_a_trailing_slash(self):
-        """Two manually typed URLs that differ only by a trailing slash are duplicates.
-
-        TestDatasetStoryBlock covers this for arbitrary paths. It is repeated here with dataset
-        edition URLs, which end in a slash, since those are the most sensitive to how destinations
-        are normalised.
-        """
+        """Covered for arbitrary paths in TestDatasetStoryBlock, repeated for edition URLs."""
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
             block,
@@ -325,11 +270,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_passes_for_a_manual_link_to_the_series_page(self):
-        """A manual link to the series page is allowed alongside a lookup for the same dataset.
-
-        On this page type the lookup resolves to the edition URL, so the series page is a
-        genuinely different destination.
-        """
+        """Here the lookup resolves to the edition URL, so the series page is a different place."""
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
             block,

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -314,3 +314,18 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
         # Expect clean to not raise any errors
         block.clean(value)
+
+    @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
+    def test_validation_passes_for_a_manual_link_to_one_version_of_the_edition(self):
+        """A single version is a different destination to the edition the lookup resolves to."""
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.march_v1.id),
+                ("manual_link", {"title": "Dataset Title", "url": "/datasets/ds/editions/march/versions/1"}),
+            ],
+        )
+
+        # Expect clean to not raise any errors
+        block.clean(value)

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -223,6 +223,63 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
         self.assertEqual(len(validation_error.exception.block_errors), 2)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
+    def test_validation_fails_for_a_manual_link_to_the_resolved_url(self):
+        """A manually typed link is a duplicate of a lookup that resolves to the same place.
+
+        Editors can reach the same dataset either through the chooser or by typing the URL, so
+        both sides of the comparison are normalised first: the host is dropped and the trailing
+        slash is ignored. Each case below is the same destination as the March lookup, written a
+        different way.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        manual_url_cases = [
+            "/datasets/ds/editions/march/versions/",
+            "/datasets/ds/editions/march/versions",
+            "https://example.com/datasets/ds/editions/march/versions/",
+        ]
+
+        for manual_url in manual_url_cases:
+            with self.subTest(manual_url=manual_url):
+                value = StreamValue(
+                    block,
+                    stream_data=[
+                        ("dataset_lookup", self.march_v1.id),
+                        ("manual_link", {"title": "Dataset Title", "url": manual_url}),
+                    ],
+                )
+
+                with self.assertRaises(ValidationError) as validation_error:
+                    block.clean(value)
+
+                self.assertEqual(len(validation_error.exception.block_errors), 2)
+                for error in validation_error.exception.block_errors.values():
+                    self.assertEqual(error.message, "Duplicate datasets are not allowed")
+
+    @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
+    def test_validation_fails_for_manual_links_differing_only_by_a_trailing_slash(self):
+        """Two manually typed URLs that differ only by a trailing slash are duplicates.
+
+        TestDatasetStoryBlock already covers this for arbitrary paths. It is repeated here with
+        dataset edition URLs because those now end in a slash, which is the case most likely to
+        be broken by a change to how destinations are normalised.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("manual_link", {"title": "Dataset Title", "url": "/datasets/ds/editions/march/versions/"}),
+                ("manual_link", {"title": "Dataset Title", "url": "/datasets/ds/editions/march/versions"}),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        self.assertEqual(len(validation_error.exception.block_errors), 2)
+        for error in validation_error.exception.block_errors.values():
+            self.assertEqual(error.message, "Duplicate datasets are not allowed")
+
+    @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_passes_for_a_manual_link_to_the_series_page(self):
         """A manual link to the series page is allowed alongside a lookup for the same dataset.
 

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -57,6 +57,33 @@ class TestDatasetStoryBlock(TestCase):
                 for error in validation_error.exception.block_errors.values():
                     self.assertEqual(error.message, "Duplicate datasets are not allowed")
 
+    def test_validation_fails_for_different_editions_of_the_same_dataset(self):
+        """Topic and related data pages link to the dataset series page, which has no edition in
+        its URL. Two different editions of the same dataset therefore both resolve to
+        "/datasets/<dataset-id>", making them duplicates even though the editor picked two
+        different rows in the chooser.
+        """
+        block = DatasetStoryBlock()
+        other_edition = Dataset.objects.create(
+            namespace=self.lookup_dataset.namespace,
+            edition="test2_edition",
+            version=1,
+            title="test_title",
+            description="test_description",
+        )
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.lookup_dataset.id),
+                ("dataset_lookup", other_edition.id),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        self.assertEqual(len(validation_error.exception.block_errors), 2)
+
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_successful_validation(self):
         block = DatasetStoryBlock()
@@ -115,3 +142,102 @@ class TestDatasetStoryBlock(TestCase):
 
                 # Expect clean to not raise any errors
                 block.clean(value)
+
+
+class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
+    """Duplicate validation for pages that link datasets to a specific edition.
+
+    A release is associated with one edition of a dataset, so release calendar pages declare
+    their dataset field as DatasetStoryBlock(link_to_latest_version=True) and their looked up
+    datasets resolve to "/datasets/<dataset-id>/editions/<edition-id>/versions/" instead of the
+    series page. Duplicate validation compares those resolved destinations, so what counts as a
+    duplicate differs from the series page context covered by TestDatasetStoryBlock above.
+
+    Note that the resolved URL has no version in it. The website serves the latest published
+    version of the edition from that path, which is what makes corrections published after the
+    release show up without anyone editing the link.
+    """
+
+    def setUp(self):
+        # Three chooser selections for one dataset: two versions of the March edition, and the
+        # April edition. Only the edition affects the resolved URL, not the version.
+        self.march_v1 = Dataset.objects.create(
+            namespace="ds",
+            edition="march",
+            version=1,
+            title="March, version 1",
+            description="test_description",
+        )
+        self.march_v2 = Dataset.objects.create(
+            namespace="ds",
+            edition="march",
+            version=2,
+            title="March, version 2",
+            description="test_description",
+        )
+        self.april_v1 = Dataset.objects.create(
+            namespace="ds",
+            edition="april",
+            version=1,
+            title="April, version 1",
+            description="test_description",
+        )
+
+    def test_validation_passes_for_different_editions_of_the_same_dataset(self):
+        """Two editions of one dataset resolve to different URLs here, so both are allowed.
+
+        This is the main behaviour change: the old validation compared dataset IDs, which made
+        this pair a duplicate.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.march_v1.id),
+                ("dataset_lookup", self.april_v1.id),
+            ],
+        )
+
+        # Expect clean to not raise any errors
+        block.clean(value)
+
+    def test_validation_fails_for_two_versions_of_the_same_edition(self):
+        """Two versions of one edition resolve to the same URL, so they are duplicates.
+
+        The chooser still lists the version, and the CMS still records which version was picked,
+        but the version is not part of the resolved URL. Picking March v1 and March v2 on the
+        same page therefore produces two identical links, which the editor is told about here.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.march_v1.id),
+                ("dataset_lookup", self.march_v2.id),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        self.assertEqual(len(validation_error.exception.block_errors), 2)
+
+    @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
+    def test_validation_passes_for_a_manual_link_to_the_series_page(self):
+        """A manual link to the series page is allowed alongside a lookup for the same dataset.
+
+        On this page type the lookup resolves to the edition URL, so the series page is a
+        genuinely different destination. Under the old dataset ID comparison this pair was
+        rejected.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.march_v1.id),
+                ("manual_link", {"title": "Dataset Title", "url": "/datasets/ds"}),
+            ],
+        )
+
+        # Expect clean to not raise any errors
+        block.clean(value)

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from wagtail.blocks import StreamValue
 
-from cms.datasets.blocks import DatasetStoryBlock
+from cms.datasets.blocks import LATEST_VERSION_DUPLICATE_HINT, DatasetStoryBlock
 from cms.datasets.models import Dataset
 
 
@@ -76,10 +76,8 @@ class TestDatasetStoryBlock(TestCase):
             block.clean(value)
 
         for error in validation_error.exception.block_errors.values():
-            self.assertEqual(
-                error.message,
-                'Duplicate datasets are not allowed. Another entry links to "/datasets/1".',
-            )
+            self.assertIn('"/datasets/1"', error.message)
+            self.assertNotIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
 
     def test_validation_fails_for_different_editions_of_the_same_dataset(self):
         """Topic and related data pages link to the dataset series page, which has no edition in
@@ -244,13 +242,8 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
             block.clean(value)
 
         for error in validation_error.exception.block_errors.values():
-            self.assertEqual(
-                error.message,
-                "Duplicate datasets are not allowed. Another entry links to "
-                '"/datasets/ds/editions/march/versions". Links from this page point to the latest '
-                "published version of an edition, so the dataset version does not affect the "
-                "destination.",
-            )
+            self.assertIn('"/datasets/ds/editions/march/versions"', error.message)
+            self.assertIn(LATEST_VERSION_DUPLICATE_HINT.strip(), error.message)
 
     def test_validation_fails_for_two_versions_of_the_same_edition(self):
         """Two versions of one edition resolve to the same URL, so they are duplicates.

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -16,6 +16,17 @@ class TestDatasetStoryBlock(TestCase):
             description="test_description",
         )
 
+    def test_clean_accepts_wagtails_ignore_required_constraints_argument(self):
+        """Wagtail's BlockField.clean() passes this argument, so clean() has to accept it.
+
+        Without it, saving any page with a datasets field raises a TypeError. Nothing else in the
+        suite calls clean() the way Wagtail does, so the argument otherwise looks unused.
+        """
+        block = DatasetStoryBlock()
+        value = StreamValue(block, stream_data=[("dataset_lookup", self.lookup_dataset.id)])
+
+        block.clean(value, ignore_required_constraints=True)
+
     @override_settings(ONS_WEBSITE_BASE_URL="https://example.com", ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_on_duplicate_datasets(self):
         block = DatasetStoryBlock()

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -210,8 +210,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
     def test_validation_passes_for_different_editions_of_the_same_dataset(self):
         """Two editions of one dataset resolve to different URLs here, so both are allowed.
 
-        This is the main behaviour change: the old validation compared dataset IDs, which made
-        this pair a duplicate.
+        A release can legitimately relate to more than one edition of the same dataset.
         """
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
@@ -256,9 +255,9 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
     def test_validation_fails_for_two_versions_of_the_same_edition(self):
         """Two versions of one edition resolve to the same URL, so they are duplicates.
 
-        The chooser still lists the version, and the CMS still records which version was picked,
-        but the version is not part of the resolved URL. Picking March v1 and March v2 on the
-        same page therefore produces two identical links, which the editor is told about here.
+        The chooser lists the version, and the CMS records which version was picked, but the
+        version is not part of the resolved URL. Picking March v1 and March v2 on the same page
+        therefore produces two identical links, which the editor is told about here.
         """
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
@@ -311,9 +310,9 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
     def test_validation_fails_for_manual_links_differing_only_by_a_trailing_slash(self):
         """Two manually typed URLs that differ only by a trailing slash are duplicates.
 
-        TestDatasetStoryBlock already covers this for arbitrary paths. It is repeated here with
-        dataset edition URLs because those now end in a slash, which is the case most likely to
-        be broken by a change to how destinations are normalised.
+        TestDatasetStoryBlock covers this for arbitrary paths. It is repeated here with dataset
+        edition URLs, which end in a slash, since those are the most sensitive to how destinations
+        are normalised.
         """
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(
@@ -336,8 +335,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
         """A manual link to the series page is allowed alongside a lookup for the same dataset.
 
         On this page type the lookup resolves to the edition URL, so the series page is a
-        genuinely different destination. Under the old dataset ID comparison this pair was
-        rejected.
+        genuinely different destination.
         """
         block = DatasetStoryBlock(link_to_latest_version=True)
         value = StreamValue(

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -16,17 +16,6 @@ class TestDatasetStoryBlock(TestCase):
             description="test_description",
         )
 
-    def test_clean_accepts_wagtails_ignore_required_constraints_argument(self):
-        """Wagtail's BlockField.clean() passes this argument, so clean() has to accept it.
-
-        Without it, saving any page with a datasets field raises a TypeError. Nothing else in the
-        suite calls clean() the way Wagtail does, so the argument otherwise looks unused.
-        """
-        block = DatasetStoryBlock()
-        value = StreamValue(block, stream_data=[("dataset_lookup", self.lookup_dataset.id)])
-
-        block.clean(value, ignore_required_constraints=True)
-
     @override_settings(ONS_WEBSITE_BASE_URL="https://example.com", ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_on_duplicate_datasets(self):
         block = DatasetStoryBlock()

--- a/cms/datasets/tests/test_blocks.py
+++ b/cms/datasets/tests/test_blocks.py
@@ -55,7 +55,31 @@ class TestDatasetStoryBlock(TestCase):
 
                 self.assertEqual(len(validation_error.exception.block_errors), len(stream_data))
                 for error in validation_error.exception.block_errors.values():
-                    self.assertEqual(error.message, "Duplicate datasets are not allowed")
+                    self.assertIn("Duplicate datasets are not allowed", error.message)
+
+    def test_duplicate_error_message_names_the_shared_destination(self):
+        """The message says where the entries point, so the editor can see why they collide.
+
+        On these pages the destination is the series page, so the note about versions that release
+        calendar pages get would not apply and is left out.
+        """
+        block = DatasetStoryBlock()
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.lookup_dataset.id),
+                ("dataset_lookup", self.lookup_dataset.id),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        for error in validation_error.exception.block_errors.values():
+            self.assertEqual(
+                error.message,
+                'Duplicate datasets are not allowed. Another entry links to "/datasets/1".',
+            )
 
     def test_validation_fails_for_different_editions_of_the_same_dataset(self):
         """Topic and related data pages link to the dataset series page, which has no edition in
@@ -201,6 +225,34 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
         # Expect clean to not raise any errors
         block.clean(value)
 
+    def test_duplicate_error_message_explains_that_the_version_is_not_in_the_link(self):
+        """Two versions of one edition look different in the chooser but link to the same place.
+
+        The chooser lists the version, so an editor who picked version 9 and version 10 has no
+        reason to expect a duplicate. The message therefore names the shared destination, which
+        visibly has no version in it, and spells out why the version makes no difference.
+        """
+        block = DatasetStoryBlock(link_to_latest_version=True)
+        value = StreamValue(
+            block,
+            stream_data=[
+                ("dataset_lookup", self.march_v1.id),
+                ("dataset_lookup", self.march_v2.id),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as validation_error:
+            block.clean(value)
+
+        for error in validation_error.exception.block_errors.values():
+            self.assertEqual(
+                error.message,
+                "Duplicate datasets are not allowed. Another entry links to "
+                '"/datasets/ds/editions/march/versions". Links from this page point to the latest '
+                "published version of an edition, so the dataset version does not affect the "
+                "destination.",
+            )
+
     def test_validation_fails_for_two_versions_of_the_same_edition(self):
         """Two versions of one edition resolve to the same URL, so they are duplicates.
 
@@ -253,7 +305,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
                 self.assertEqual(len(validation_error.exception.block_errors), 2)
                 for error in validation_error.exception.block_errors.values():
-                    self.assertEqual(error.message, "Duplicate datasets are not allowed")
+                    self.assertIn("Duplicate datasets are not allowed", error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_fails_for_manual_links_differing_only_by_a_trailing_slash(self):
@@ -277,7 +329,7 @@ class TestDatasetStoryBlockLinkingToLatestVersion(TestCase):
 
         self.assertEqual(len(validation_error.exception.block_errors), 2)
         for error in validation_error.exception.block_errors.values():
-            self.assertEqual(error.message, "Duplicate datasets are not allowed")
+            self.assertIn("Duplicate datasets are not allowed", error.message)
 
     @override_settings(ONS_ALLOWED_LINK_DOMAINS=["example.com"])
     def test_validation_passes_for_a_manual_link_to_the_series_page(self):

--- a/cms/datasets/tests/test_models.py
+++ b/cms/datasets/tests/test_models.py
@@ -6,7 +6,7 @@ import responses
 from django.conf import settings
 from django.test import TestCase, override_settings
 
-from cms.datasets.models import ONSDataset, ONSDatasetApiQuerySet
+from cms.datasets.models import Dataset, ONSDataset, ONSDatasetApiQuerySet
 
 
 class TestONSDatasetApiQuerySet(TestCase):
@@ -541,3 +541,36 @@ class TestONSDataset(TestCase):
         # The unpublished version should be in the 'next' field
         self.assertEqual(dataset.next.title, "Dataset 2 Unpublished")
         self.assertEqual(dataset.next.description, "Description 2 Unpublished")
+
+
+class TestDatasetUrlPaths(TestCase):
+    """The two public destinations a looked up dataset can point at.
+
+    Which one is used depends on the page doing the linking, not on the dataset itself:
+    topic and related data pages use the series page, release calendar pages use the edition.
+    """
+
+    def setUp(self):
+        self.dataset = Dataset.objects.create(
+            namespace="wellbeing-quarterly",
+            edition="september",
+            version=9,
+            title="Quarterly personal well-being estimates",
+            description="Test description",
+        )
+
+    def test_url_path_points_to_the_dataset_series_page(self):
+        """The series page shows the most recent edition, so it needs no edition or version."""
+        self.assertEqual(self.dataset.url_path, "/datasets/wellbeing-quarterly")
+
+    def test_latest_version_url_path_points_to_the_versions_of_the_edition(self):
+        """The edition destination names the edition but deliberately stops at "versions/".
+
+        Note the fixture is version 9 and no version appears in the URL. The website resolves the
+        version-less path to the latest published version of the edition, which is what makes a
+        correction published later show up in an old release calendar entry.
+        """
+        self.assertEqual(
+            self.dataset.latest_version_url_path,
+            "/datasets/wellbeing-quarterly/editions/september/versions/",
+        )

--- a/cms/datasets/tests/test_models.py
+++ b/cms/datasets/tests/test_models.py
@@ -558,9 +558,12 @@ class TestDatasetUrlPaths(TestCase):
     def test_url_path_points_to_the_dataset_series_page(self):
         self.assertEqual(self.dataset.url_path, "/datasets/wellbeing-quarterly")
 
-    def test_latest_version_url_path_points_to_the_versions_of_the_edition(self):
+    def test_get_url_path_defaults_to_the_series_page(self):
+        self.assertEqual(self.dataset.get_url_path(), "/datasets/wellbeing-quarterly")
+
+    def test_get_url_path_linking_to_the_latest_version_names_the_edition(self):
         """The fixture is version 9, and no version appears in the URL."""
         self.assertEqual(
-            self.dataset.latest_version_url_path,
+            self.dataset.get_url_path(link_to_latest_version=True),
             "/datasets/wellbeing-quarterly/editions/september/versions/",
         )

--- a/cms/datasets/tests/test_models.py
+++ b/cms/datasets/tests/test_models.py
@@ -565,5 +565,5 @@ class TestDatasetUrlPaths(TestCase):
         """The fixture is version 9, and no version appears in the URL."""
         self.assertEqual(
             self.dataset.get_url_path(link_to_latest_version=True),
-            "/datasets/wellbeing-quarterly/editions/september/versions/",
+            "/datasets/wellbeing-quarterly/editions/september/versions",
         )

--- a/cms/datasets/tests/test_models.py
+++ b/cms/datasets/tests/test_models.py
@@ -544,11 +544,7 @@ class TestONSDataset(TestCase):
 
 
 class TestDatasetUrlPaths(TestCase):
-    """The two public destinations a looked up dataset can point at.
-
-    Which one is used depends on the page doing the linking, not on the dataset itself:
-    topic and related data pages use the series page, release calendar pages use the edition.
-    """
+    """The two public destinations a looked up dataset can point at."""
 
     def setUp(self):
         self.dataset = Dataset.objects.create(
@@ -560,16 +556,10 @@ class TestDatasetUrlPaths(TestCase):
         )
 
     def test_url_path_points_to_the_dataset_series_page(self):
-        """The series page shows the most recent edition, so it needs no edition or version."""
         self.assertEqual(self.dataset.url_path, "/datasets/wellbeing-quarterly")
 
     def test_latest_version_url_path_points_to_the_versions_of_the_edition(self):
-        """The edition destination names the edition but deliberately stops at "versions/".
-
-        Note the fixture is version 9 and no version appears in the URL. The website resolves the
-        version-less path to the latest published version of the edition, which is what makes a
-        correction published later show up in an old release calendar entry.
-        """
+        """The fixture is version 9, and no version appears in the URL."""
         self.assertEqual(
             self.dataset.latest_version_url_path,
             "/datasets/wellbeing-quarterly/editions/september/versions/",

--- a/cms/datasets/tests/test_utils.py
+++ b/cms/datasets/tests/test_utils.py
@@ -54,11 +54,7 @@ class TestUtils(TestCase):
         )
 
     def test_format_datasets_as_document_list_linking_to_latest_version(self):
-        """Callers linking to a specific edition opt in with link_to_latest_version.
-
-        Release calendar pages pass True here, while topic and related data pages use the default
-        and get the series page (covered by test_format_datasets_as_document_list above).
-        """
+        """The default, which gives the series page, is covered by the test above."""
         lookup_dataset = Dataset.objects.create(
             namespace="LOOKUP",
             edition="lookup_edition",

--- a/cms/datasets/tests/test_utils.py
+++ b/cms/datasets/tests/test_utils.py
@@ -53,6 +53,36 @@ class TestUtils(TestCase):
             },
         )
 
+    def test_format_datasets_as_document_list_linking_to_latest_version(self):
+        """Callers linking to a specific edition opt in with link_to_latest_version.
+
+        Release calendar pages pass True here, while topic and related data pages use the default
+        and get the series page (covered by test_format_datasets_as_document_list above).
+        """
+        lookup_dataset = Dataset.objects.create(
+            namespace="LOOKUP",
+            edition="lookup_edition",
+            version=1,
+            title="test lookup",
+            description="lookup description",
+        )
+        manual_dataset = {"title": "test manual", "description": "manual description", "url": "https://example.com"}
+
+        datasets = StreamValue(
+            DatasetStoryBlock(),
+            stream_data=[
+                ("dataset_lookup", lookup_dataset),
+                ("manual_link", manual_dataset),
+            ],
+        )
+
+        formatted_datasets = format_datasets_as_document_list(datasets, link_to_latest_version=True)
+
+        self.assertEqual(len(formatted_datasets), 2)
+        self.assertEqual(formatted_datasets[0]["title"]["url"], "/datasets/LOOKUP/editions/lookup_edition/versions/")
+        # Manually entered URLs are used as given, whatever the page context
+        self.assertEqual(formatted_datasets[1]["title"]["url"], manual_dataset["url"])
+
     def test_extract_edition_from_dataset_url(self):
         url = "/datasets/wellbeing-quarterly/editions/september/versions/9"
         extracted_edition = extract_edition_from_dataset_url(url)

--- a/cms/datasets/tests/test_utils.py
+++ b/cms/datasets/tests/test_utils.py
@@ -75,7 +75,7 @@ class TestUtils(TestCase):
         formatted_datasets = format_datasets_as_document_list(datasets)
 
         self.assertEqual(len(formatted_datasets), 2)
-        self.assertEqual(formatted_datasets[0]["title"]["url"], "/datasets/LOOKUP/editions/lookup_edition/versions/")
+        self.assertEqual(formatted_datasets[0]["title"]["url"], "/datasets/LOOKUP/editions/lookup_edition/versions")
         # Manually entered URLs are used as given, whatever the page context
         self.assertEqual(formatted_datasets[1]["title"]["url"], manual_dataset["url"])
 

--- a/cms/datasets/tests/test_utils.py
+++ b/cms/datasets/tests/test_utils.py
@@ -65,14 +65,14 @@ class TestUtils(TestCase):
         manual_dataset = {"title": "test manual", "description": "manual description", "url": "https://example.com"}
 
         datasets = StreamValue(
-            DatasetStoryBlock(),
+            DatasetStoryBlock(link_to_latest_version=True),
             stream_data=[
                 ("dataset_lookup", lookup_dataset),
                 ("manual_link", manual_dataset),
             ],
         )
 
-        formatted_datasets = format_datasets_as_document_list(datasets, link_to_latest_version=True)
+        formatted_datasets = format_datasets_as_document_list(datasets)
 
         self.assertEqual(len(formatted_datasets), 2)
         self.assertEqual(formatted_datasets[0]["title"]["url"], "/datasets/LOOKUP/editions/lookup_edition/versions/")

--- a/cms/datasets/utils.py
+++ b/cms/datasets/utils.py
@@ -13,12 +13,22 @@ EDITIONS_PATTERN = re.compile(r"/editions/([^/]+)/")
 COMPOUND_ID_PARTS_COUNT = 4
 
 
-def format_datasets_as_document_list(datasets: StreamValue) -> list[dict[str, Any]]:
+def format_datasets_as_document_list(
+    datasets: StreamValue, *, link_to_latest_version: bool = False
+) -> list[dict[str, Any]]:
     """Takes a StreamValue of dataset blocks (the value of a StreamField of DatasetStoryBlocks).
 
     Returns the datasets in a list of dictionaries in the format required for the ONS Document List design system
     component.
     See: https://service-manual.ons.gov.uk/design-system/components/document-list
+
+    Args:
+        datasets: The value of a StreamField of DatasetStoryBlocks.
+        link_to_latest_version: Link looked up datasets to the latest published version of their
+            edition instead of to the dataset series page. Callers tied to a specific edition, such
+            as release calendar pages, pass True. Topic and related data pages are not tied to an
+            edition, so they use the series page and leave this as False.
+            Manually entered links are unaffected: their URL is always used as given.
     """
     dataset_documents: list = []
     for dataset in datasets:
@@ -33,7 +43,7 @@ def format_datasets_as_document_list(datasets: StreamValue) -> list[dict[str, An
         else:
             dataset_document = format_as_document_list_item(
                 title=block_value.title,
-                url=block_value.url_path,
+                url=block_value.get_url_path(link_to_latest_version=link_to_latest_version),
                 content_type="Dataset",
                 description=dataset.value.description,
             )

--- a/cms/datasets/utils.py
+++ b/cms/datasets/utils.py
@@ -13,23 +13,24 @@ EDITIONS_PATTERN = re.compile(r"/editions/([^/]+)/")
 COMPOUND_ID_PARTS_COUNT = 4
 
 
-def format_datasets_as_document_list(
-    datasets: StreamValue, *, link_to_latest_version: bool = False
-) -> list[dict[str, Any]]:
+def format_datasets_as_document_list(datasets: StreamValue) -> list[dict[str, Any]]:
     """Takes a StreamValue of dataset blocks (the value of a StreamField of DatasetStoryBlocks).
 
     Returns the datasets in a list of dictionaries in the format required for the ONS Document List design system
     component.
     See: https://service-manual.ons.gov.uk/design-system/components/document-list
 
-    Args:
-        datasets: The value of a StreamField of DatasetStoryBlocks.
-        link_to_latest_version: Link looked up datasets to the latest published version of their
-            edition instead of to the dataset series page. Callers tied to a specific edition, such
-            as release calendar pages, pass True. Topic and related data pages are not tied to an
-            edition, so they use the series page and leave this as False.
-            Manually entered links are unaffected: their URL is always used as given.
+    Where looked up datasets link to is declared once, by the DatasetStoryBlock the field was
+    built with, and is read back off the value here. Pages tied to a specific edition, such as
+    release calendar pages, set link_to_latest_version on the block; topic and related data pages
+    are not tied to an edition, so they keep the default and link to the dataset series page.
+    Taking the setting from the block rather than from an argument is what stops a page validating
+    against one destination and rendering another.
+
+    Manually entered links are unaffected: their URL is always used as given.
     """
+    link_to_latest_version = datasets.stream_block.meta.link_to_latest_version
+
     dataset_documents: list = []
     for dataset in datasets:
         block_value = dataset.value

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -244,8 +244,9 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
     @cached_property
     def dataset_document_list(self) -> list[dict[str, Any]]:
         # A release is associated with a specific dataset edition, so its links resolve to the
-        # latest published version of that edition rather than to the dataset series page.
-        return format_datasets_as_document_list(self.datasets, link_to_latest_version=True)
+        # latest published version of that edition rather than to the dataset series page. That
+        # is declared on the datasets field above, and read back off the value when formatting.
+        return format_datasets_as_document_list(self.datasets)
 
     @cached_property
     def table_of_contents(self) -> list[dict[str, Any]]:

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -109,7 +109,7 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
         blank=True,
         help_text=("This is usually through the bundle release process, but can also be manually set."),
     )
-    datasets = StreamField(DatasetStoryBlock(), blank=True, default=list)
+    datasets = StreamField(DatasetStoryBlock(link_to_latest_version=True), blank=True, default=list)
 
     contact_details = models.ForeignKey(
         "core.ContactDetails",

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -243,7 +243,9 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
 
     @cached_property
     def dataset_document_list(self) -> list[dict[str, Any]]:
-        return format_datasets_as_document_list(self.datasets)
+        # A release is associated with a specific dataset edition, so its links resolve to the
+        # latest published version of that edition rather than to the dataset series page.
+        return format_datasets_as_document_list(self.datasets, link_to_latest_version=True)
 
     @cached_property
     def table_of_contents(self) -> list[dict[str, Any]]:

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -701,12 +701,6 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
                 self.assertContains(response, expected_url)
 
     def test_rendered__datasets_link_to_the_latest_version_of_the_edition(self):
-        """The published page links datasets to the edition assigned to the release.
-
-        A release is associated with a specific dataset edition, so its links point at that
-        edition rather than at the series page. Topic and related data pages are not tied to an
-        edition and link to the series page instead.
-        """
         lookup_dataset = Dataset.objects.create(
             namespace="LOOKUP",
             edition="lookup_edition",
@@ -714,10 +708,8 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
             title="test lookup",
             description="lookup description",
         )
-        # Assigned as raw StreamField data rather than as a StreamValue so that the field's own
-        # block definition is used. StreamBlock.to_python() hands a StreamValue straight back, so
-        # assigning StreamValue(DatasetStoryBlock(), ...) would keep that throwaway block and
-        # bypass the configuration this test is checking.
+        # Raw StreamField data, not a StreamValue: StreamBlock.to_python() hands a StreamValue
+        # straight back, which would bypass the field's own block definition.
         self.page.datasets = [{"type": "dataset_lookup", "value": lookup_dataset.pk}]
         self.page.status = ReleaseStatus.PUBLISHED
         self.page.save_revision().publish()
@@ -725,8 +717,7 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
         response = self.client.get(self.page.url)
 
         self.assertContains(response, 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"')
-        # The series page URL is a prefix of the edition URL, so this checks the full href to
-        # confirm the series link is gone rather than merely absent as a substring.
+        # The series URL is a prefix of the edition URL, hence the full href.
         self.assertNotContains(response, 'href="/datasets/LOOKUP"')
 
     def test_rendered__datasets(self):

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -714,7 +714,7 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
 
         response = self.client.get(self.page.url)
 
-        self.assertContains(response, 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"')
+        self.assertContains(response, 'href="/datasets/LOOKUP/editions/lookup_edition/versions"')
         # The series URL is a prefix of the edition URL, hence the full href.
         self.assertNotContains(response, 'href="/datasets/LOOKUP"')
 
@@ -754,7 +754,7 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
                 self.assertEqual(lookup_dataset.title in str(response.content), is_shown)
                 self.assertEqual(lookup_dataset.description in str(response.content), is_shown)
                 # The series URL is a prefix of the edition URL, hence the full href.
-                expected_href = 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"'
+                expected_href = 'href="/datasets/LOOKUP/editions/lookup_edition/versions"'
                 self.assertEqual(expected_href in str(response.content), is_shown)
 
                 self.assertEqual(manual_dataset["title"] in str(response.content), is_shown)

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -703,10 +703,9 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
     def test_rendered__datasets_link_to_the_latest_version_of_the_edition(self):
         """The published page links datasets to the edition assigned to the release.
 
-        A release is associated with a specific dataset edition, so its links point at the latest
-        published version of that edition rather than at the series page. This is what makes the
-        release calendar differ from topic and related data pages, which keep linking to the
-        series page.
+        A release is associated with a specific dataset edition, so its links point at that
+        edition rather than at the series page. Topic and related data pages are not tied to an
+        edition and link to the series page instead.
         """
         lookup_dataset = Dataset.objects.create(
             namespace="LOOKUP",

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -753,8 +753,7 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
 
                 self.assertEqual(lookup_dataset.title in str(response.content), is_shown)
                 self.assertEqual(lookup_dataset.description in str(response.content), is_shown)
-                # The series URL is a prefix of the edition URL, so the full href is asserted to
-                # catch a release calendar page linking to the series page.
+                # The series URL is a prefix of the edition URL, hence the full href.
                 expected_href = 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"'
                 self.assertEqual(expected_href in str(response.content), is_shown)
 

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
-from wagtail.blocks import StreamValue
 from wagtail.locks import BasicLock
 from wagtail.test.utils.form_data import nested_form_data, rich_text, streamfield
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
@@ -15,7 +14,6 @@ from cms.core.custom_date_format import ons_date_format, ons_default_datetime
 from cms.core.models import ContactDetails
 from cms.core.permission_testers import BasePagePermissionTester
 from cms.core.tests.utils import rebuild_internal_search_index
-from cms.datasets.blocks import DatasetStoryBlock
 from cms.datasets.models import Dataset
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.locks import ReleasePageInBundleReadyToBePublishedLock
@@ -737,13 +735,11 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
             (ReleaseStatus.PUBLISHED, True),
             (ReleaseStatus.CANCELLED, False),
         ]
-        self.page.datasets = StreamValue(
-            DatasetStoryBlock(),
-            stream_data=[
-                ("dataset_lookup", lookup_dataset),
-                ("manual_link", manual_dataset),
-            ],
-        )
+        # Raw StreamField data, so the destination comes from the field's own block definition.
+        self.page.datasets = [
+            {"type": "dataset_lookup", "value": lookup_dataset.pk},
+            {"type": "manual_link", "value": manual_dataset},
+        ]
 
         rebuild_internal_search_index()
         for status, is_shown in cases:
@@ -757,7 +753,10 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
 
                 self.assertEqual(lookup_dataset.title in str(response.content), is_shown)
                 self.assertEqual(lookup_dataset.description in str(response.content), is_shown)
-                self.assertEqual(lookup_dataset.url_path in str(response.content), is_shown)
+                # The series URL is a prefix of the edition URL, so the full href is asserted to
+                # catch a release calendar page linking to the series page.
+                expected_href = 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"'
+                self.assertEqual(expected_href in str(response.content), is_shown)
 
                 self.assertEqual(manual_dataset["title"] in str(response.content), is_shown)
                 self.assertEqual(manual_dataset["description"] in str(response.content), is_shown)

--- a/cms/release_calendar/tests/test_models.py
+++ b/cms/release_calendar/tests/test_models.py
@@ -700,6 +700,36 @@ class ReleaseCalendarPageRenderTestCase(TestCase):
 
                 self.assertContains(response, expected_url)
 
+    def test_rendered__datasets_link_to_the_latest_version_of_the_edition(self):
+        """The published page links datasets to the edition assigned to the release.
+
+        A release is associated with a specific dataset edition, so its links point at the latest
+        published version of that edition rather than at the series page. This is what makes the
+        release calendar differ from topic and related data pages, which keep linking to the
+        series page.
+        """
+        lookup_dataset = Dataset.objects.create(
+            namespace="LOOKUP",
+            edition="lookup_edition",
+            version=1,
+            title="test lookup",
+            description="lookup description",
+        )
+        # Assigned as raw StreamField data rather than as a StreamValue so that the field's own
+        # block definition is used. StreamBlock.to_python() hands a StreamValue straight back, so
+        # assigning StreamValue(DatasetStoryBlock(), ...) would keep that throwaway block and
+        # bypass the configuration this test is checking.
+        self.page.datasets = [{"type": "dataset_lookup", "value": lookup_dataset.pk}]
+        self.page.status = ReleaseStatus.PUBLISHED
+        self.page.save_revision().publish()
+
+        response = self.client.get(self.page.url)
+
+        self.assertContains(response, 'href="/datasets/LOOKUP/editions/lookup_edition/versions/"')
+        # The series page URL is a prefix of the edition URL, so this checks the full href to
+        # confirm the series link is gone rather than merely absent as a substring.
+        self.assertNotContains(response, 'href="/datasets/LOOKUP"')
+
     def test_rendered__datasets(self):
         """Check datasets are shown only in a published state."""
         lookup_dataset = Dataset.objects.create(

--- a/cms/topics/tests/test_pages.py
+++ b/cms/topics/tests/test_pages.py
@@ -206,11 +206,8 @@ class TopicPageTests(WagtailPageTestCase):
 
         self.assertContains(response, lookup_dataset.title)
         self.assertContains(response, lookup_dataset.description)
-        # Topic pages link to the dataset series page, not to a specific edition.
-        # We assert on the full href rather than just the path because the series URL
-        # ("/datasets/LOOKUP") is a substring of the edition URL
-        # ("/datasets/LOOKUP/editions/lookup_edition/versions/"), so a looser check would still
-        # pass if this page ever started linking to a specific edition.
+        # The series URL is a prefix of the edition URL, so the full href is asserted to catch a
+        # topic page linking to an edition.
         self.assertContains(response, f'href="{lookup_dataset.url_path}"')
 
         self.assertContains(response, manual_dataset["title"])

--- a/cms/topics/tests/test_pages.py
+++ b/cms/topics/tests/test_pages.py
@@ -206,7 +206,12 @@ class TopicPageTests(WagtailPageTestCase):
 
         self.assertContains(response, lookup_dataset.title)
         self.assertContains(response, lookup_dataset.description)
-        self.assertContains(response, lookup_dataset.url_path)
+        # Topic pages link to the dataset series page, not to a specific edition.
+        # We assert on the full href rather than just the path because the series URL
+        # ("/datasets/LOOKUP") is a substring of the edition URL
+        # ("/datasets/LOOKUP/editions/lookup_edition/versions/"), so a looser check would still
+        # pass if this page ever started linking to a specific edition.
+        self.assertContains(response, f'href="{lookup_dataset.url_path}"')
 
         self.assertContains(response, manual_dataset["title"])
         self.assertContains(response, manual_dataset["description"])

--- a/functional_tests/features/release_page.feature
+++ b/functional_tests/features/release_page.feature
@@ -68,6 +68,16 @@ Feature: CMS users can create, configure, and manage release calendar pages, inc
       | a related link                 |
       | pre-release access information |
 
+# A release is associated with a specific dataset edition, so its dataset links point at that
+# edition rather than at the dataset series page that topic and related data pages link to.
+  Scenario: Datasets on a release calendar page link to the edition assigned to the release
+    Given a sample release calendar page exists
+    When the user edits the release calendar page
+    And  looks up and selects a dataset
+    And  the user opens the preview in a new tab, using the "Published" preview mode
+    Then the selected dataset is displayed on the page
+    And  the looked up dataset links to the latest version of the edition
+
 
 # Checks visibility of release date text field based on page status (Provisional vs. others) in the admin interface.
   Scenario: A CMS user can see release date text field for a provisional release calendar page

--- a/functional_tests/features/statistical_article_page.feature
+++ b/functional_tests/features/statistical_article_page.feature
@@ -111,6 +111,7 @@ Feature: Statistical Article Page components
         And  the user views the statistical article page
         And  the user clicks "View data used in this article" on the article page
         Then the related data page for the article is shown
+        And  the looked up dataset links to the dataset series page
 
     Scenario: The related data page is linked and accessible when there are datasets related to a statistical article in an internal environment
         Given the user is in an internal environment

--- a/functional_tests/features/topic_page.feature
+++ b/functional_tests/features/topic_page.feature
@@ -97,6 +97,7 @@ Feature: CMS users can draft, edit, and publish topic pages
         And the user clicks the "Save draft" button
         And the user views the topic page draft
         Then the selected datasets are displayed on the page
+        And the looked up dataset links to the dataset series page
         And the user sees the 'View all related data' link
 
     Scenario: A CMS user can add a time series section to a topic page

--- a/functional_tests/steps/datasets.py
+++ b/functional_tests/steps/datasets.py
@@ -22,7 +22,10 @@ def look_up_and_select_published_dataset(context: Context) -> None:
     dataset_displayed_fields = {
         "title": mock_dataset["title"],
         "description": mock_dataset["description"],
+        # The two destinations a looked up dataset can resolve to. Which one is correct depends on
+        # the page doing the linking, so scenarios assert it with one of the steps below.
         "url": f"/datasets/{mock_dataset['dataset_id']}",
+        "latest_version_url": (f"/datasets/{mock_dataset['dataset_id']}/editions/{mock_dataset['edition']}/versions/"),
     }
 
     context.selected_datasets = [
@@ -137,6 +140,24 @@ def check_selected_datasets_are_displayed(context: Context) -> None:
     for dataset in context.selected_datasets:
         expect(context.page.get_by_role("link", name=dataset["title"])).to_be_visible()
         expect(context.page.get_by_text(dataset["description"])).to_be_visible()
+
+
+@then("the looked up dataset links to the dataset series page")
+def check_dataset_links_to_series_page(context: Context) -> None:
+    """The series page shows the most recent edition, so no edition appears in the link."""
+    dataset = context.selected_datasets[0]
+    expect(context.page.get_by_role("link", name=dataset["title"])).to_have_attribute("href", dataset["url"])
+
+
+@then("the looked up dataset links to the latest version of the edition")
+def check_dataset_links_to_latest_version_of_edition(context: Context) -> None:
+    """The link names the edition and stops at "versions/", which the website resolves to the
+    latest published version of that edition.
+    """
+    dataset = context.selected_datasets[0]
+    expect(context.page.get_by_role("link", name=dataset["title"])).to_have_attribute(
+        "href", dataset["latest_version_url"]
+    )
 
 
 @then("unpublished datasets are shown by default in the dataset chooser")

--- a/functional_tests/steps/datasets.py
+++ b/functional_tests/steps/datasets.py
@@ -25,7 +25,7 @@ def look_up_and_select_published_dataset(context: Context) -> None:
         # The two destinations a looked up dataset can resolve to. Which one is correct depends on
         # the page doing the linking, so scenarios assert it with one of the steps below.
         "url": f"/datasets/{mock_dataset['dataset_id']}",
-        "latest_version_url": (f"/datasets/{mock_dataset['dataset_id']}/editions/{mock_dataset['edition']}/versions/"),
+        "latest_version_url": (f"/datasets/{mock_dataset['dataset_id']}/editions/{mock_dataset['edition']}/versions"),
     }
 
     context.selected_datasets = [
@@ -151,7 +151,7 @@ def check_dataset_links_to_series_page(context: Context) -> None:
 
 @then("the looked up dataset links to the latest version of the edition")
 def check_dataset_links_to_latest_version_of_edition(context: Context) -> None:
-    """The link names the edition and stops at "versions/", which the website resolves to the
+    """The link names the edition and stops at "versions", which the website resolves to the
     latest published version of that edition.
     """
     dataset = context.selected_datasets[0]


### PR DESCRIPTION
### What is the context of this PR?

[CMS-1334](https://officefornationalstatistics.atlassian.net/browse/CMS-1334)

Dataset links now point to a destination chosen by the page doing the linking, rather than always to the dataset series page.

- **Release calendar entries** link to the edition assigned to the release: `/datasets/<dataset-id>/editions/<edition-id>/versions/`. The version is deliberately omitted, so a correction published to that edition is followed automatically without anyone editing the link.
- **Topic and related data pages** are unchanged and continue to link to the series page, `/datasets/<dataset-id>`, so readers reach the most recent data.

### How to review

(This was pretty tricky to work on given the data api)

Seed a `Dataset` row the way `DatasetChosenView` does.

**Destinations**

1. Put a looked-up dataset on a release calendar entry, publish, and check the link under the Data heading is `/datasets/<id>/editions/<edition>/versions/`.
2. Put the same dataset on a topic page and a related data page, and check both are `/datasets/<id>`.

**Validation**, all on a release calendar page:

3. Two versions of the same edition, save, expect an error quoting the shared URL path and explaining that the version does not affect the destination.
4. Two different editions of the same dataset, save, expect it to succeed.
5. A looked-up dataset plus a hand-typed URL resolving to the same place, for example `https://www.ons.gov.uk/datasets/<Id>/editions/<Edition>/versions` against a lookup for the same edition. Expect an error, despite differing host, case and trailing slash.
6. Two manual URLs differing only by a trailing slash, expect an error.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy




[CMS-1334]: https://officefornationalstatistics.atlassian.net/browse/CMS-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ