### PR TITLE
chore: remove C90 suppression and set maximum complexity

### DIFF
--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -314,7 +314,7 @@ def add_media_summary_item(request: HttpRequest, items: list[SummaryItem]) -> No
 
 
 @hooks.register("register_log_actions")
-def register_bundle_log_actions(actions: LogActionRegistry) -> None:
+def register_bundle_log_standard_actions(actions: LogActionRegistry) -> None:
     """Registers custom logging actions.
 
     @see https://docs.wagtail.org/en/stable/extending/audit_log.html
@@ -383,35 +383,19 @@ def register_bundle_log_actions(actions: LogActionRegistry) -> None:
             except KeyError:
                 return "Attempted to preview an item."
 
-    @actions.register_action("bundles.teams_changed")
-    class ChangeBundleTeams(LogFormatter):  # pylint: disable=unused-variable
-        """LogFormatter class for preview team changes to bundles."""
+    @actions.register_action("bundles.inspect")
+    class InspectBundle(LogFormatter):  # pylint: disable=unused-variable
+        """LogFormatter class for viewing the bundle inspect page."""
 
-        label = "Change preview teams"
-
-        def format_message(self, log_entry: ModelLogEntry) -> Any:
-            return format_added_removed_message(
-                log_entry,
-                added_key="added_teams",
-                removed_key="removed_teams",
-                context="Changed preview teams for bundle",
-            )
-
-    @actions.register_action("bundles.pages_changed")
-    class ChangeBundlePages(LogFormatter):  # pylint: disable=unused-variable
-        """LogFormatter class for page changes to bundles."""
-
-        label = "Change pages in bundle"
+        label = "View bundle details"
 
         def format_message(self, log_entry: ModelLogEntry) -> Any:
             """Returns the formatted log message."""
-            return format_added_removed_message(
-                log_entry,
-                added_key="added_pages",
-                removed_key="removed_pages",
-                context="Changed pages in bundle",
-            )
+            return "Viewed bundle inspect page"
 
+
+@hooks.register("register_log_actions")
+def register_bundle_log_change_actions(actions: LogActionRegistry) -> None:
     @actions.register_action("bundles.datasets_changed")
     class ChangeBundleDatasets(LogFormatter):  # pylint: disable=unused-variable
         """LogFormatter class for dataset changes to bundles."""
@@ -427,27 +411,46 @@ def register_bundle_log_actions(actions: LogActionRegistry) -> None:
                 context="Changed datasets in bundle",
             )
 
-    @actions.register_action("bundles.schedule_changed")
-    class ChangeBundleSchedule(LogFormatter):  # pylint: disable=unused-variable
-        """LogFormatter class for bundle publication date changes."""
+        @actions.register_action("bundles.schedule_changed")
+        class ChangeBundleSchedule(LogFormatter):
+            """LogFormatter class for bundle publication date changes."""
 
-        label = "Change bundle schedule"
+            label = "Change bundle schedule"
+
+            def format_message(self, log_entry: ModelLogEntry) -> Any:
+                """Returns the formatted log message."""
+                try:
+                    old = log_entry.data.get("old") or "Not set"
+                    new = log_entry.data.get("new") or "Not set"
+                    return f"Changed publication date from '{old}' to '{new}'"
+                except KeyError:
+                    return "Changed publication date"
+
+    @actions.register_action("bundles.teams_changed")
+    class ChangeBundleTeams(LogFormatter):  # pylint: disable=unused-variable
+        """LogFormatter class for preview team changes to bundles."""
+
+        label = "Change preview teams"
 
         def format_message(self, log_entry: ModelLogEntry) -> Any:
-            """Returns the formatted log message."""
-            try:
-                old = log_entry.data.get("old") or "Not set"
-                new = log_entry.data.get("new") or "Not set"
-                return f"Changed publication date from '{old}' to '{new}'"
-            except KeyError:
-                return "Changed publication date"
+            return format_added_removed_message(
+                log_entry,
+                added_key="added_teams",
+                removed_key="removed_teams",
+                context="Changed preview teams for bundle",
+            )
 
-    @actions.register_action("bundles.inspect")
-    class InspectBundle(LogFormatter):  # pylint: disable=unused-variable
-        """LogFormatter class for viewing the bundle inspect page."""
+        @actions.register_action("bundles.pages_changed")
+        class ChangeBundlePages(LogFormatter):
+            """LogFormatter class for page changes to bundles."""
 
-        label = "View bundle details"
+            label = "Change pages in bundle"
 
-        def format_message(self, log_entry: ModelLogEntry) -> Any:
-            """Returns the formatted log message."""
-            return "Viewed bundle inspect page"
+            def format_message(self, log_entry: ModelLogEntry) -> Any:
+                """Returns the formatted log message."""
+                return format_added_removed_message(
+                    log_entry,
+                    added_key="added_pages",
+                    removed_key="removed_pages",
+                    context="Changed pages in bundle",
+                )

--- a/cms/bundles/wagtail_hooks.py
+++ b/cms/bundles/wagtail_hooks.py
@@ -411,20 +411,20 @@ def register_bundle_log_change_actions(actions: LogActionRegistry) -> None:
                 context="Changed datasets in bundle",
             )
 
-        @actions.register_action("bundles.schedule_changed")
-        class ChangeBundleSchedule(LogFormatter):
-            """LogFormatter class for bundle publication date changes."""
+    @actions.register_action("bundles.schedule_changed")
+    class ChangeBundleSchedule(LogFormatter):  # pylint: disable=unused-variable
+        """LogFormatter class for bundle publication date changes."""
 
-            label = "Change bundle schedule"
+        label = "Change bundle schedule"
 
-            def format_message(self, log_entry: ModelLogEntry) -> Any:
-                """Returns the formatted log message."""
-                try:
-                    old = log_entry.data.get("old") or "Not set"
-                    new = log_entry.data.get("new") or "Not set"
-                    return f"Changed publication date from '{old}' to '{new}'"
-                except KeyError:
-                    return "Changed publication date"
+        def format_message(self, log_entry: ModelLogEntry) -> Any:
+            """Returns the formatted log message."""
+            try:
+                old = log_entry.data.get("old") or "Not set"
+                new = log_entry.data.get("new") or "Not set"
+                return f"Changed publication date from '{old}' to '{new}'"
+            except KeyError:
+                return "Changed publication date"
 
     @actions.register_action("bundles.teams_changed")
     class ChangeBundleTeams(LogFormatter):  # pylint: disable=unused-variable
@@ -440,17 +440,17 @@ def register_bundle_log_change_actions(actions: LogActionRegistry) -> None:
                 context="Changed preview teams for bundle",
             )
 
-        @actions.register_action("bundles.pages_changed")
-        class ChangeBundlePages(LogFormatter):
-            """LogFormatter class for page changes to bundles."""
+    @actions.register_action("bundles.pages_changed")
+    class ChangeBundlePages(LogFormatter):  # pylint: disable=unused-variable
+        """LogFormatter class for page changes to bundles."""
 
-            label = "Change pages in bundle"
+        label = "Change pages in bundle"
 
-            def format_message(self, log_entry: ModelLogEntry) -> Any:
-                """Returns the formatted log message."""
-                return format_added_removed_message(
-                    log_entry,
-                    added_key="added_pages",
-                    removed_key="removed_pages",
-                    context="Changed pages in bundle",
-                )
+        def format_message(self, log_entry: ModelLogEntry) -> Any:
+            """Returns the formatted log message."""
+            return format_added_removed_message(
+                log_entry,
+                added_key="added_pages",
+                removed_key="removed_pages",
+                context="Changed pages in bundle",
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,13 +123,14 @@ ignore = [
     "W191",
     # Prefer explicit type rather than union (|) shorthand
     "UP007",
-    # Allow complex functions
-    "C901",
     # Allow non-top-level imports
     "PLC0415",
     # contextlib.suppress is slower
     "SIM105"
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ select = [
     "C4",     # flake8-comprehensions
     "S",      # flake8-bandit
     "D",      # pydocstyle - Enforce existing docstrings only
-    "C90",    # mccabe
     "RUF",    # Ruff specific rules
 
     # PL - Pylint is only partially supported, we also use the pylint tool to catch all the rules.
@@ -123,8 +122,6 @@ ignore = [
     "W191",
     # Prefer explicit type rather than union (|) shorthand
     "UP007",
-    # Allow complex functions
-    "C901",
     # Allow non-top-level imports
     "PLC0415",
     # contextlib.suppress is slower

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ select = [
     "C4",     # flake8-comprehensions
     "S",      # flake8-bandit
     "D",      # pydocstyle - Enforce existing docstrings only
+    "C90",    # mccabe
     "RUF",    # Ruff specific rules
 
     # PL - Pylint is only partially supported, we also use the pylint tool to catch all the rules.
@@ -122,6 +123,8 @@ ignore = [
     "W191",
     # Prefer explicit type rather than union (|) shorthand
     "UP007",
+    # Allow complex functions
+    "C901",
     # Allow non-top-level imports
     "PLC0415",
     # contextlib.suppress is slower


### PR DESCRIPTION
### What is the context of this PR?

~This PR removes `C90` from rules, because the only rule that provides is `C901`, which we ignore explicitly.~

This PR removes the suppression of rule `C901`, sets `max-complexity` to 15 and splits `register_bundle_log_actions` to reduce the complexity.

Reference: https://docs.astral.sh/ruff/rules/#mccabe-c90

### How to review

1. Review the reference link above
2. Confirm that "complex functions" are not flagged by ruff

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A
