### PR TITLE
fix: add workflow/page status to release calendar chooser

### DIFF
--- a/cms/bundles/panels.py
+++ b/cms/bundles/panels.py
@@ -194,7 +194,9 @@ class CustomReleaseCalendarPageChooser(FutureReleaseCalendarChooserWidget):
 
 
 class ReleaseChooserWithDetailsPanel(BundleFieldPanel):
-    """A custom page chooser panel that includes the release calendar page title, status and release date."""
+    """A custom page chooser panel that includes the release calendar page title, release status, release date
+    and page status.
+    """
 
     def get_form_options(self) -> dict[str, list | dict]:
         opts: dict[str, list | dict] = super().get_form_options()

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -393,6 +393,12 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseMixin, TestCase):
         response = self.client.get(self.edit_url)
         self.assertContains(response, f"{page_title} (Ready to publish)")
 
+        self.statistical_article_page.save_revision().publish()
+        self.statistical_article_page.title = "The updated article"
+        self.statistical_article_page.save_revision()
+        response = self.client.get(self.edit_url)
+        self.assertContains(response, f"{self.statistical_article_page.get_admin_display_title()} (Live + Draft)")
+
     @mock.patch("cms.bundles.viewsets.bundle.notify_slack_of_status_change")
     def test_bundle_approval__cannot__approve_if_pages_are_not_ready_to_publish(self, mock_notify_slack):
         """Test bundle approval workflow."""

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -129,10 +129,6 @@ class BundleViewSetTestCaseMixin(WagtailTestUtils):
 
         return nested_form_data(data)
 
-    @staticmethod
-    def chooser_panel_display(page) -> str:
-        return f"{page.title} ({page.get_status_display()}, {page.release_date_value})"
-
     def _create_release_calendar_page(self, title, status):
         """Assigns a release calendar page to the bundle."""
         release_date = timezone.now() + timedelta(days=1)
@@ -344,7 +340,7 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseMixin, TestCase):
         self.post_with_action_and_test("action-return-to-draft", BundleStatus.DRAFT, self.edit_url)
 
     def test_bundle_edit_view__shows_release_calendar_page_details(self):
-        """Release calendar page's title, status and release date are displayed when selected in bundles."""
+        """Release calendar page's title, release status, release date and page status are displayed."""
         for title, status, expected_text in self.RELEASE_CALENDAR_PAGE_CASES:
             with self.subTest(title=title, status=status):
                 release_calendar_page = self._create_release_calendar_page(title=title, status=status)
@@ -352,7 +348,7 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseMixin, TestCase):
                 # test for cancelled pages should fail
                 self._assign_release_calendar_page_to_bundle(release_calendar_page=release_calendar_page)
                 response = self.client.get(self.edit_url)
-                expected_display_panel = f"{expected_text} {release_calendar_page.release_date_value})"
+                expected_display_panel = f"{expected_text} {release_calendar_page.release_date_value}) (Live)"
                 self.assertContains(response, expected_display_panel)
 
     def test_bundle_edit_view__shows_updated_release_calendar_page_details(self):
@@ -363,7 +359,10 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseMixin, TestCase):
             title="Future Release calendar Page", status=ReleaseStatus.PROVISIONAL
         )
         self._assign_release_calendar_page_to_bundle(release_calendar_page=release_calendar_page)
-        original_text = self.chooser_panel_display(release_calendar_page)
+        original_text = (
+            f"{release_calendar_page.title} ({release_calendar_page.get_status_display()}, "
+            f"{release_calendar_page.release_date_value}) (Live)"
+        )
 
         for title, status, expected_text in self.RELEASE_CALENDAR_PAGE_CASES:
             with self.subTest(title=title, status=status):
@@ -374,7 +373,7 @@ class BundleViewSetEditTestCase(BundleViewSetTestCaseMixin, TestCase):
                 self.bundle.save()
 
                 response = self.client.get(self.edit_url)
-                expected_display_panel = f"{expected_text} {release_calendar_page.release_date_value})"
+                expected_display_panel = f"{expected_text} {release_calendar_page.release_date_value}) (Live)"
 
                 self.assertContains(response, expected_display_panel)
                 self.assertNotContains(response, original_text)

--- a/cms/bundles/utils.py
+++ b/cms/bundles/utils.py
@@ -22,6 +22,7 @@ from cms.bundles.notifications.slack import (
     notify_slack_of_publish_end,
 )
 from cms.core.fields import StreamField
+from cms.core.formatting_utils import get_page_display_status
 from cms.post_publish_actions.executor import run_bundle_notification_in_support_executor, run_in_support_executor
 from cms.post_publish_actions.models import PostPublishAction
 from cms.post_publish_actions.signal_handlers import enqueue_post_publish_actions_for_bundle
@@ -374,11 +375,8 @@ def _normalise_date(value: str | datetime | None) -> str | None:
 
 def get_page_title_with_workflow_status(page: Page) -> str:
     title: str = page.specific_deferred.get_admin_display_title()
-
-    if workflow_state := page.current_workflow_state:
-        return f"{title} ({workflow_state.current_task_state.task.name})"
-
-    return f"{title} (Draft)"
+    page_status = get_page_display_status(page)
+    return f"{title} ({page_status})"
 
 
 def get_language_code_from_page(page: Page) -> str:

--- a/cms/core/formatting_utils.py
+++ b/cms/core/formatting_utils.py
@@ -28,6 +28,20 @@ class DocumentListItem(TypedDict):
 PageDataCollection = Iterable[Union["ArticleDict", "MethodologyDict"]]
 
 
+def get_page_display_status(page: Page) -> str:
+    """Returns display text for a page's current workflow or publication state.
+
+    When the page is in workflow, this returns the current workflow task name.
+    Otherwise it returns a derived status based on whether the page is live and
+    whether it has unpublished changes.
+    """
+    if workflow_state := page.current_workflow_state:
+        return workflow_state.current_task_state.task.name  # type: ignore[no-any-return]
+    if page.live:
+        return "Live + Draft" if page.has_unpublished_changes else "Live"
+    return "Draft"
+
+
 def format_as_document_list_item(
     title: str, url: str, content_type: StrOrPromise | None, description: str, release_date: date | None = None
 ) -> DocumentListItem:

--- a/cms/core/tests/test_formatting_utils.py
+++ b/cms/core/tests/test_formatting_utils.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from datetime import timezone as tz
 from types import SimpleNamespace
+from typing import Any
 
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
@@ -45,11 +47,11 @@ class DummyPageWithNoReleaseDate(DummyPage):
         abstract = True
 
 
+@dataclass
 class DummyStatusPage:
-    def __init__(self, *, current_workflow_state=None, live=False, has_unpublished_changes=True):
-        self.current_workflow_state = current_workflow_state
-        self.live = live
-        self.has_unpublished_changes = has_unpublished_changes
+    current_workflow_state: Any | None = None
+    live: bool = False
+    has_unpublished_changes: bool = True
 
 
 class GetFormattedPagesListTests(TestCase):

--- a/cms/core/tests/test_formatting_utils.py
+++ b/cms/core/tests/test_formatting_utils.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
 from datetime import timezone as tz
+from types import SimpleNamespace
 
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
@@ -10,6 +11,7 @@ from cms.core.formatting_utils import (
     format_as_document_list_item,
     get_document_metadata,
     get_formatted_pages_list,
+    get_page_display_status,
     to_rfc3339_datetime,
 )
 from cms.core.models.base import BasePage
@@ -41,6 +43,13 @@ class DummyPageWithNoReleaseDate(DummyPage):
 
     class Meta:
         abstract = True
+
+
+class DummyStatusPage:
+    def __init__(self, *, current_workflow_state=None, live=False, has_unpublished_changes=True):
+        self.current_workflow_state = current_workflow_state
+        self.live = live
+        self.has_unpublished_changes = has_unpublished_changes
 
 
 class GetFormattedPagesListTests(TestCase):
@@ -274,3 +283,29 @@ class TestToRFC3339Datetime(SimpleTestCase):
 
     def test_returns_none_for_none_input(self):
         self.assertIsNone(to_rfc3339_datetime(None))
+
+
+class GetPageDisplayStatusTestCase(TestCase):
+    def test_returns_current_workflow_task_name_when_in_workflow(self):
+        page = DummyStatusPage(
+            current_workflow_state=SimpleNamespace(
+                current_task_state=SimpleNamespace(task=SimpleNamespace(name="In Preview"))
+            ),
+        )
+
+        self.assertEqual(get_page_display_status(page), "In Preview")
+
+    def test_returns_live_when_live_without_unpublished_changes(self):
+        page = DummyStatusPage(live=True, has_unpublished_changes=False)
+
+        self.assertEqual(get_page_display_status(page), "Live")
+
+    def test_returns_draft_when_not_live_and_not_in_workflow(self):
+        page = DummyStatusPage(live=False, has_unpublished_changes=True)
+
+        self.assertEqual(get_page_display_status(page), "Draft")
+
+    def test_returns_live_and_draft_for_live_page_with_unpublished_changes(self):
+        page = DummyStatusPage(live=True, has_unpublished_changes=True)
+
+        self.assertEqual(get_page_display_status(page), "Live + Draft")

--- a/cms/release_calendar/tests/test_utils.py
+++ b/cms/release_calendar/tests/test_utils.py
@@ -9,11 +9,9 @@ from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.release_calendar.utils import (
     get_release_calendar_page_details,
-    get_release_calendar_page_status,
     get_translated_string,
     parse_month_year,
 )
-from cms.workflows.tests.utils import mark_page_as_ready_for_review
 
 
 class ParseMonthYearTestCase(TestCase):
@@ -130,35 +128,6 @@ class GetTranslatedStringTestCase(TranslationResetMixin, TestCase):
         result = get_translated_string(test_string, "cy")
         # Should still return a string even when i18n is disabled
         self.assertEqual(result, "Hello world")
-
-
-class GetReleaseCalendarPageStatusTestCase(TestCase):
-    def test_returns_current_workflow_task_name_when_in_workflow(self):
-        page = ReleaseCalendarPageFactory(title="Workflow page")
-        mark_page_as_ready_for_review(page)
-
-        self.assertEqual(get_release_calendar_page_status(page), "In Preview")
-
-    def test_returns_live_when_live_without_unpublished_changes(self):
-        page = ReleaseCalendarPageFactory(title="Live page")
-        page.live = True
-        page.has_unpublished_changes = False
-
-        self.assertEqual(get_release_calendar_page_status(page), "Live")
-
-    def test_returns_draft_when_not_live_and_not_in_workflow(self):
-        page = ReleaseCalendarPageFactory(title="Draft page")
-        page.live = False
-        page.has_unpublished_changes = True
-
-        self.assertEqual(get_release_calendar_page_status(page), "Draft")
-
-    def test_returns_draft_for_live_page_with_unpublished_changes(self):
-        page = ReleaseCalendarPageFactory(title="Live draft page")
-        page.live = True
-        page.has_unpublished_changes = True
-
-        self.assertEqual(get_release_calendar_page_status(page), "Draft")
 
 
 class GetReleaseCalendarPageDetailsTestCase(TestCase):

--- a/cms/release_calendar/tests/test_utils.py
+++ b/cms/release_calendar/tests/test_utils.py
@@ -1,10 +1,19 @@
-from datetime import date
+from datetime import date, timedelta
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from django.utils.translation import gettext
 
 from cms.core.tests.utils import TranslationResetMixin
-from cms.release_calendar.utils import get_translated_string, parse_month_year
+from cms.release_calendar.enums import ReleaseStatus
+from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
+from cms.release_calendar.utils import (
+    get_release_calendar_page_details,
+    get_release_calendar_page_status,
+    get_translated_string,
+    parse_month_year,
+)
+from cms.workflows.tests.utils import mark_page_as_ready_for_review
 
 
 class ParseMonthYearTestCase(TestCase):
@@ -121,3 +130,48 @@ class GetTranslatedStringTestCase(TranslationResetMixin, TestCase):
         result = get_translated_string(test_string, "cy")
         # Should still return a string even when i18n is disabled
         self.assertEqual(result, "Hello world")
+
+
+class GetReleaseCalendarPageStatusTestCase(TestCase):
+    def test_returns_current_workflow_task_name_when_in_workflow(self):
+        page = ReleaseCalendarPageFactory(title="Workflow page")
+        mark_page_as_ready_for_review(page)
+
+        self.assertEqual(get_release_calendar_page_status(page), "In Preview")
+
+    def test_returns_live_when_live_without_unpublished_changes(self):
+        page = ReleaseCalendarPageFactory(title="Live page")
+        page.live = True
+        page.has_unpublished_changes = False
+
+        self.assertEqual(get_release_calendar_page_status(page), "Live")
+
+    def test_returns_draft_when_not_live_and_not_in_workflow(self):
+        page = ReleaseCalendarPageFactory(title="Draft page")
+        page.live = False
+        page.has_unpublished_changes = True
+
+        self.assertEqual(get_release_calendar_page_status(page), "Draft")
+
+    def test_returns_draft_for_live_page_with_unpublished_changes(self):
+        page = ReleaseCalendarPageFactory(title="Live draft page")
+        page.live = True
+        page.has_unpublished_changes = True
+
+        self.assertEqual(get_release_calendar_page_status(page), "Draft")
+
+
+class GetReleaseCalendarPageDetailsTestCase(TestCase):
+    def test_returns_release_status_release_date_and_page_status(self):
+        release_calendar_page = ReleaseCalendarPageFactory(
+            title="Future release",
+            status=ReleaseStatus.PROVISIONAL,
+            release_date=timezone.now() + timedelta(days=3),
+        )
+        release_calendar_page.live = True
+        release_calendar_page.has_unpublished_changes = False
+
+        self.assertEqual(
+            get_release_calendar_page_details(release_calendar_page),
+            f"Future release (Provisional, {release_calendar_page.release_date_value}) (Live)",
+        )

--- a/cms/release_calendar/utils.py
+++ b/cms/release_calendar/utils.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext, override
 
+from cms.core.formatting_utils import get_page_display_status
+
 if TYPE_CHECKING:
     from .models import ReleaseCalendarPage
 FULL_ENGLISH_MONTHS = [
@@ -96,25 +98,12 @@ def get_translated_string(string_to_translate: str, language_code: str) -> str:
     return translated_string
 
 
-def get_release_calendar_page_status(release_calendar_page: ReleaseCalendarPage) -> str:
-    """Returns the page status shown for a release calendar page in the chooser panel.
-
-    When the page is in workflow, this returns the current workflow task name.
-    Otherwise it returns the page status based on whether the page is live without unpublished changes or still a draft.
-    """
-    if workflow_state := release_calendar_page.current_workflow_state:
-        return workflow_state.current_task_state.task.name  # type: ignore[no-any-return]
-    if release_calendar_page.live and not release_calendar_page.has_unpublished_changes:
-        return "Live"
-    return "Draft"
-
-
 def get_release_calendar_page_details(
     release_calendar_page: ReleaseCalendarPage,
 ) -> str:
     """Returns the release page title, release status, release date and page status."""
     release_status = release_calendar_page.specific_deferred.get_status_display()
-    page_status = get_release_calendar_page_status(release_calendar_page)
+    page_status = get_page_display_status(release_calendar_page)
     return (
         f"{release_calendar_page.title} "
         f"({release_status}, "

--- a/cms/release_calendar/utils.py
+++ b/cms/release_calendar/utils.py
@@ -96,12 +96,28 @@ def get_translated_string(string_to_translate: str, language_code: str) -> str:
     return translated_string
 
 
+def get_release_calendar_page_status(release_calendar_page: ReleaseCalendarPage) -> str:
+    """Returns the page status shown for a release calendar page in the chooser panel.
+
+    When the page is in workflow, this returns the current workflow task name.
+    Otherwise it returns the page status based on whether the page is live without unpublished changes or still a draft.
+    """
+    if workflow_state := release_calendar_page.current_workflow_state:
+        return workflow_state.current_task_state.task.name
+    if release_calendar_page.live and not release_calendar_page.has_unpublished_changes:
+        return "Live"
+    return "Draft"
+
+
 def get_release_calendar_page_details(
     release_calendar_page: ReleaseCalendarPage,
 ) -> str:
-    """Returns the release page title, status and release date."""
+    """Returns the release page title, release status, release date and page status."""
+    release_status = release_calendar_page.specific_deferred.get_status_display()
+    page_status = get_release_calendar_page_status(release_calendar_page)
     return (
         f"{release_calendar_page.title} "
-        f"({release_calendar_page.specific_deferred.get_status_display()}, "
-        f"{release_calendar_page.specific_deferred.release_date_value})"
+        f"({release_status}, "
+        f"{release_calendar_page.specific_deferred.release_date_value}) "
+        f"({page_status})"
     )

--- a/cms/release_calendar/utils.py
+++ b/cms/release_calendar/utils.py
@@ -103,7 +103,7 @@ def get_release_calendar_page_status(release_calendar_page: ReleaseCalendarPage)
     Otherwise it returns the page status based on whether the page is live without unpublished changes or still a draft.
     """
     if workflow_state := release_calendar_page.current_workflow_state:
-        return workflow_state.current_task_state.task.name
+        return workflow_state.current_task_state.task.name  # type: ignore[no-any-return]
     if release_calendar_page.live and not release_calendar_page.has_unpublished_changes:
         return "Live"
     return "Draft"

--- a/functional_tests/features/bundle.feature
+++ b/functional_tests/features/bundle.feature
@@ -14,14 +14,14 @@ Feature: CMS users can manage bundles
         And the user opens the release calendar page chooser
         Then the locale column is displayed in the chooser
 
-    Scenario Outline: A content editor can see the release calendar page title, status and release date when it has been selected under scheduling
+    Scenario Outline: A content editor can see the release calendar page title, release status, release date and page status when it has been selected under scheduling
         Given a release calendar page with a "<Release Status>" status and future release date exists
         When the user navigates to the bundle creation page
         And the user enters a bundle title
         And the user opens the release calendar page chooser
         And the user selects the existing release calendar page
         And the user saves the bundle as draft
-        Then the user sees the release calendar page title, status and release date
+        Then the user sees the release calendar page title, release status, release date and page status
 
         Examples:
             | Release Status |
@@ -44,7 +44,7 @@ Feature: CMS users can manage bundles
         And  the user saves the bundle as draft
         And  the user updates the selected release calendar page's title, release date and sets the status to "<New Status>"
         And  returns to the bundle edit page
-        Then the user sees the updated release calendar page's title, release date and the status "<New Status>"
+        Then the user sees the updated release calendar page's title, release date and release status "<New Status>"
 
         Examples:
             | New Status  |

--- a/functional_tests/steps/bundles.py
+++ b/functional_tests/steps/bundles.py
@@ -187,14 +187,16 @@ def user_creates_bundle_with_future_release_calendar_page(context: Context) -> N
     context.page.get_by_text(title).click()
 
 
-@step("the user sees the release calendar page title, status and release date")
-def user_sees_release_calendar_page_title_status_release_date(
+@step("the user sees the release calendar page title, release status, release date and page status")
+def user_sees_release_calendar_page_title_release_status_date_page_status(
     context: Context,
 ) -> None:
+    # The page is non-live and only saved as a revision, so its status is Draft.
+    expected_page_status = "Draft"
     expect(
         context.page.get_by_text(
             f"{context.release_calendar_page.title} ({context.release_calendar_page.status},"
-            f" {context.release_calendar_page.release_date_value})"
+            f" {context.release_calendar_page.release_date_value}) ({expected_page_status})"
         )
     ).to_be_visible()
 
@@ -250,15 +252,20 @@ def returns_to_bundle_edit_page(
     context.page = bundle_admin_view.value
 
 
-@then('the user sees the updated release calendar page\'s title, release date and the status "{status}"')
+@then('the user sees the updated release calendar page\'s title, release date and release status "{status}"')
 def user_sees_updated_release_calendar_page_title_release_date_status(context: Context, status: str) -> None:
+    # The page remains non-live here, so its displayed status is still Draft.
+    expected_page_status = "Draft"
     expect(
         context.page.get_by_text(
-            f"New title ({status}, {context.saved_release_calendar_page_details['release_date_value']})"
+            f"New title ({status}, {context.saved_release_calendar_page_details['release_date_value']}) "
+            f"({expected_page_status})"
         )
     ).to_be_visible()
     expect(
-        context.page.get_by_text(f"{context.original_title} ({context.original_status}, {context.original_date})")
+        context.page.get_by_text(
+            f"{context.original_title} ({context.original_status}, {context.original_date}) ({expected_page_status})"
+        )
     ).not_to_be_visible()
 
 


### PR DESCRIPTION
### What is the context of this PR?

Adds the Release Calendar workflow/page status to the Release Calendar details on the chooser panel. This should match the way that the workflow/page status is displayed for the bundled pages chooser panel.
<img width="1572" height="412" alt="image" src="https://github.com/user-attachments/assets/331d4427-d874-4da8-9452-8232f46180f8" />


### How to review

1. Create/edit a bundle in the admin
2. Using the release calendar chooser panel, select a release calendar
3. Ensure that the status of the release calendar page is displayed correctly on the release calendar chooser panel
4. Update the status of the release calendar and ensure the status displayed on the chooser panel in the bundle is updated

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions
N/A


---
Ticket: [DPD-5228](https://officefornationalstatistics.atlassian.net/browse/DPD-5228) (relates to the last AC)

[DPD-5228]: https://officefornationalstatistics.atlassian.net/browse/DPD-5228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ