### PR TITLE
feat: add cache overpurge for paginated URLs

### DIFF
--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -928,10 +928,9 @@ class StatisticalArticlePage(  # type: ignore[django-manager-missing]
     def get_cached_paths(self) -> Generator[str]:
         yield "/"
         yield "/related-data"  # always include, should a correction remove related datasets
-        if self.datasets:
-            pages = ceil(len(self.datasets) / settings.RELATED_DATASETS_PER_PAGE)
-            # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
-            for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
-                yield f"/related-data?page={page_number}"
+        pages = ceil(len(self.datasets or []) / settings.RELATED_DATASETS_PER_PAGE)
+        # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
+        for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
+            yield f"/related-data?page={page_number}"
 
         yield from self.get_downloadable_block_paths()

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -257,7 +257,8 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         yield "/editions"
         # ensure we always account for ?page=1
         pages = max(1, ceil(self.get_children().live().public().count() / settings.PREVIOUS_RELEASES_PER_PAGE))
-        for page_number in range(1, pages + 1):
+        # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
+        for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
             yield f"/editions?page={page_number}"
 
 
@@ -928,7 +929,9 @@ class StatisticalArticlePage(  # type: ignore[django-manager-missing]
         yield "/"
         yield "/related-data"  # always include, should a correction remove related datasets
         if self.datasets:
-            for page_number in range(1, ceil(len(self.datasets) / settings.RELATED_DATASETS_PER_PAGE) + 1):
+            pages = ceil(len(self.datasets) / settings.RELATED_DATASETS_PER_PAGE)
+            # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
+            for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
                 yield f"/related-data?page={page_number}"
 
         yield from self.get_downloadable_block_paths()

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -583,7 +583,10 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
         self.assertEqual(self.page.analytics_content_type, "articles")
 
     def test_get_cached_paths(self):
-        self.assertEqual(list(self.page.get_cached_paths()), ["/", "/related-data"])
+        self.assertEqual(
+            list(self.page.get_cached_paths()),
+            ["/", "/related-data", "/related-data?page=1", "/related-data?page=2"],
+        )
 
     def test_get_cached_paths__with_related_data_pages(self):
         dataset = DatasetFactory()
@@ -644,7 +647,14 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             list(self.page.get_cached_paths()),
-            ["/", "/related-data", "/download-table/test-table-id", "/download-chart/test-chart-id"],
+            [
+                "/",
+                "/related-data",
+                "/related-data?page=1",
+                "/related-data?page=2",
+                "/download-table/test-table-id",
+                "/download-chart/test-chart-id",
+            ],
         )
 
 

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -592,11 +592,22 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
             stream_data=[("dataset_lookup", dataset)] * 6,
         )
 
-        expected = ["/", "/related-data", "/related-data?page=1"]
-        self.assertEqual(list(self.page.get_cached_paths()), expected)
+        with override_settings(CMS_PAGINATION_OVER_PURGE=2):
+            expected = ["/", "/related-data", "/related-data?page=1", "/related-data?page=2", "/related-data?page=3"]
+            self.assertEqual(list(self.page.get_cached_paths()), expected)
 
-        with override_settings(RELATED_DATASETS_PER_PAGE=3):
-            self.assertEqual(list(self.page.get_cached_paths()), [*expected, "/related-data?page=2"])
+            with override_settings(RELATED_DATASETS_PER_PAGE=3):
+                self.assertEqual(
+                    list(self.page.get_cached_paths()),
+                    [
+                        "/",
+                        "/related-data",
+                        "/related-data?page=1",
+                        "/related-data?page=2",
+                        "/related-data?page=3",
+                        "/related-data?page=4",
+                    ],
+                )
 
     def test_get_cached_paths__with_downloadable_blocks(self):
         self.page.content = [

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -88,6 +88,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             f"{self.series_url}/related-data",
             self.series_edition_url,
             f"{self.series_edition_url}?page=1",
+            f"{self.series_edition_url}?page=2",
+            f"{self.series_edition_url}?page=3",
             self.topic_page_url,
         }
         if with_translation_alias:
@@ -170,13 +172,17 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
         self.statistical_article.save_revision().publish()
 
         expected_urls = self._get_base_expected_statistical_page_urls_to_purge()
-        expected_urls.add(f"{self.article_related_data_url}?page=1")
+        expected_urls |= {
+            f"{self.article_related_data_url}?page=1",
+            f"{self.article_related_data_url}?page=2",
+            f"{self.article_related_data_url}?page=3",
+        }
         patched_purge_urls.assert_called_once_with(expected_urls)
 
         with override_settings(RELATED_DATASETS_PER_PAGE=2):
             self.statistical_article.save_revision().publish()
 
-            expected_urls |= {f"{self.article_related_data_url}?page=2", f"{self.article_related_data_url}?page=3"}
+            expected_urls |= {f"{self.article_related_data_url}?page=4", f"{self.article_related_data_url}?page=5"}
             patched_purge_urls.assert_called_with(expected_urls)
 
     def test_page_publish__statistical_article_featured_in_different_topic(self, patched_purge_urls):
@@ -216,6 +222,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.topic_page_url,
                 self.topic_page_translation_url,
                 # the topic page that features the statistical article's series
@@ -243,6 +251,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
                 f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
+                f"{self.series_edition_url}?page=4",
             }
         )
 
@@ -268,6 +278,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                         f"{self.series_url}/related-data",
                         self.series_edition_url,
                         f"{self.series_edition_url}?page=1",
+                        f"{self.series_edition_url}?page=2",
+                        f"{self.series_edition_url}?page=3",
                     }
                 ),
                 call(
@@ -276,6 +288,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                         f"{series_translation_url}/related-data",
                         f"{series_translation_url}/editions",
                         f"{series_translation_url}/editions?page=1",
+                        f"{series_translation_url}/editions?page=2",
+                        f"{series_translation_url}/editions?page=3",
                     }
                 ),
                 call(
@@ -533,6 +547,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.topic_page_url,
                 self.topic_page_translation_url,
                 # the new series and topic
@@ -540,6 +556,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{another_series_url}/related-data",
                 f"{another_series_url}/editions",
                 f"{another_series_url}/editions?page=1",
+                f"{another_series_url}/editions?page=2",
+                f"{another_series_url}/editions?page=3",
                 self.another_topic_page_url,
                 self.another_topic_page_translation_url,
             }
@@ -561,6 +579,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.article_url,
                 self.article_related_data_url,
                 # the old topic
@@ -780,6 +800,8 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
                 f"{series_url}/related-data/",
                 f"{series_url}/editions/",
                 f"{series_url}/editions/?page=1",
+                f"{series_url}/editions/?page=2",
+                f"{series_url}/editions/?page=3",
             ],
         )
 
@@ -789,5 +811,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article.get_parent()),
-            [series_url, f"{series_url}/related-data", f"{series_url}/editions", f"{series_url}/editions?page=1"],
+            [
+                series_url,
+                f"{series_url}/related-data",
+                f"{series_url}/editions",
+                f"{series_url}/editions?page=1",
+                f"{series_url}/editions?page=2",
+                f"{series_url}/editions?page=3",
+            ],
         )

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -84,6 +84,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
         urls = {
             self.article_url,
             self.article_related_data_url,
+            f"{self.article_related_data_url}?page=1",
+            f"{self.article_related_data_url}?page=2",
             self.series_url,
             f"{self.series_url}/related-data",
             self.series_edition_url,
@@ -218,6 +220,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 # the usual urls
                 new_article_url,
                 f"{new_article_url}/related-data",
+                f"{new_article_url}/related-data?page=1",
+                f"{new_article_url}/related-data?page=2",
                 self.series_url,
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
@@ -296,8 +300,12 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                     {
                         self.article_url,
                         self.article_related_data_url,
+                        f"{self.article_related_data_url}?page=1",
+                        f"{self.article_related_data_url}?page=2",
                         article_translation_url,
                         f"{article_translation_url}/related-data",
+                        f"{article_translation_url}/related-data?page=1",
+                        f"{article_translation_url}/related-data?page=2",
                     }
                 ),
             ]
@@ -389,6 +397,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 self.index_page_url,
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
             }
         )
 
@@ -542,6 +552,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             {
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
                 # the old series and topic
                 self.series_url,
                 f"{self.series_url}/related-data",
@@ -583,6 +595,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{self.series_edition_url}?page=3",
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
                 # the old topic
                 self.topic_page_url,
                 self.topic_page_translation_url,
@@ -707,42 +721,72 @@ class PageViaSnippetFrontEndCacheInvalidationTestCase(TestCase):
         self.contact.save_revision().publish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_unpublish__contact_details(self, mocked_purge_urls):
         self.contact.unpublish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_publish__definition(self, mocked_purge_urls):
         self.definition.save_revision().publish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_unpublish__definition(self, mocked_purge_urls):
         self.definition.unpublish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_delete__contact(self, mocked_purge_urls):
         self.contact.delete()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_delete__definition(self, mocked_purge_urls):
         self.definition.delete()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
 
@@ -776,7 +820,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article),
-            [article_url, f"{article_url}/related-data"],
+            [
+                article_url,
+                f"{article_url}/related-data",
+                f"{article_url}/related-data?page=1",
+                f"{article_url}/related-data?page=2",
+            ],
         )
 
     @override_settings(WAGTAIL_APPEND_SLASH=True)
@@ -785,7 +834,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article),
-            [f"{article_url}/", f"{article_url}/related-data/"],
+            [
+                f"{article_url}/",
+                f"{article_url}/related-data/",
+                f"{article_url}/related-data/?page=1",
+                f"{article_url}/related-data/?page=2",
+            ],
         )
 
     @override_settings(WAGTAIL_APPEND_SLASH=True)

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -894,6 +894,8 @@ RELATED_DATASETS_PER_PAGE = int(env.get("RELATED_DATASETS_PER_PAGE", DEFAULT_PER
 
 # Number of extra trailing pages to purge from the front-end cache beyond the current page count,
 # so that pages orphaned by shrinking pagination (e.g. after a correction removes items) get invalidated too.
+# This is a workaround until Wagtail supports prefix-based cache purging:
+# https://github.com/wagtail/wagtail/pull/13773
 CMS_PAGINATION_OVER_PURGE = int(env.get("CMS_PAGINATION_OVER_PURGE", 2))
 
 # Google Tag Manager ID from env

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -892,6 +892,10 @@ PREVIOUS_RELEASES_PER_PAGE = int(env.get("PREVIOUS_RELEASES_PER_PAGE", 10))
 CMS_RELEASES_INDEX_REDIRECT_ENABLED = env.get("CMS_RELEASES_INDEX_REDIRECT_ENABLED", "true").lower() == "true"
 RELATED_DATASETS_PER_PAGE = int(env.get("RELATED_DATASETS_PER_PAGE", DEFAULT_PER_PAGE))
 
+# Number of extra trailing pages to purge from the front-end cache beyond the current page count,
+# so that pages orphaned by shrinking pagination (e.g. after a correction removes items) get invalidated too.
+CMS_PAGINATION_OVER_PURGE = int(env.get("CMS_PAGINATION_OVER_PURGE", 2))
+
 # Google Tag Manager ID from env
 GOOGLE_TAG_MANAGER_CONTAINER_ID = env.get("GOOGLE_TAG_MANAGER_CONTAINER_ID", "")
 

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -121,6 +121,8 @@ URL_CONFIG_SETTINGS = {
     "WAGTAILADMIN_LOGIN_URL",
 }
 
+CMS_PAGINATION_OVER_PURGE = 2
+
 
 def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: Any) -> None:
     """Resets the url cache if `setting` is any of URL_CONFIG_SETTINGS.


### PR DESCRIPTION
### What is the context of this PR?

This PR build on the work done in #505 and adds cache over-purge functionality for paginated URLs.

The reason for the over purge is to handle trailing pages so pages orphaned by shrinking pagination are invalidated too.

### How to review

Ensure that the code changes make sense.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Merge #505 into main once everything is done.


---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ