### PR TITLE
fix(pr-standards): add lowercase `cms` and `dpd` to branch name checks

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -56,7 +56,7 @@ jobs:
             const branchName = context.payload.pull_request?.head?.ref ?? "";
 
             // Extract JIRA issue key
-            const jiraPattern = /\b(CMS|DPD)-(\d+)\b/;
+            const jiraPattern = /\b(CMS|DPD|cms|dpd)-(\d+)\b/;
             const match = branchName.match(jiraPattern);
 
             if (!match) {

--- a/scripts/validate-branch-name.sh
+++ b/scripts/validate-branch-name.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 bypass_label="${BYPASS_LABEL:-no-jira}"
-jira_issue_key_pattern='(^|[^[:alnum:]_])(CMS|DPD)-[0-9]+([^[:alnum:]_]|$)'
+jira_issue_key_pattern='(^|[^[:alnum:]_])(CMS|DPD|cms|dpd)-[0-9]+([^[:alnum:]_]|$)'
 branch_name="${BRANCH_NAME:-$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)}"
 
 if [[ -z "${branch_name}" ]]; then


### PR DESCRIPTION
### What is the context of this PR?

Allow for lowercase `cms` and `dpd` in branch names, not just uppercase.

Lowercase is more consistent with typical branch naming, and if we already have in progress branches it's annoying to swtich.

### How to review

Check scripts.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
