### PR TITLE
feat(cache): improve frontend cache implementation

### DIFF
--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -154,12 +154,11 @@ def get_topic_pages_featuring_series(
     return urls
 
 
-def _get_other_language_alias_urls(source_page_ids: set) -> set[str]:
+def _get_alias_urls(source_page_ids: set) -> set[str]:
     urls = set()
-    # Include other language aliases in this too.
-    # Also, since we don't have a request here, get a dummy one for the other language pages.
-    other_locale_ids = Locale.objects.exclude(pk=Locale.get_default().pk).values_list("pk", flat=True)
-    for locale_id in other_locale_ids:
+    # Include aliases in any locale (same-locale copies as well as other-language translations).
+    # Since we don't have a request here, get a dummy one for each locale's site.
+    for locale_id in Locale.objects.values_list("pk", flat=True):
         cache_object = get_dummy_request(site=Site.objects.filter(root_page__locale=locale_id).first())
         if cache_object is None:
             # If no site exists for this locale, skip it
@@ -271,7 +270,7 @@ def purge_series_children_from_cache(page: ArticleSeriesPage) -> None:
         source_page_ids.add(child.pk)
         urls.update(get_page_cached_urls(child))
 
-    urls |= _get_other_language_alias_urls(source_page_ids)
+    urls |= _get_alias_urls(source_page_ids)
 
     if urls:
         purge_urls_from_cache(urls)

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -248,9 +248,8 @@ def purge_old_page_paths_from_cache_after_move(
         for series in page.get_children().live().type(ArticleSeriesPage).specific():
             urls.update(get_related_topic_page_urls(series))
             urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=series.topic_ids))
-            for article in series.get_children().live().type(StatisticalArticlePage).specific():
-                if article.is_latest:
-                    urls.update(get_topic_pages_featuring_series(article, series))
+            if latest := StatisticalArticlePage.objects.child_of(series).live().order_by("-release_date").first():
+                urls.update(get_topic_pages_featuring_series(latest, series))
     elif isinstance(page, MethodologyIndexPage):
         # the index itself moved between topics, taking its methodology pages with it
         for methodology_page in page.get_children().live().type(MethodologyPage).specific():

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -7,8 +7,8 @@ from wagtail.contrib.frontend_cache.utils import purge_urls_from_cache
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Page, ReferenceIndex, Site
 
-from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
-from cms.methodology.models import MethodologyPage
+from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage, StatisticalArticlePage
+from cms.methodology.models import MethodologyIndexPage, MethodologyPage
 from cms.standard_pages.models import InformationPage
 from cms.topics.models import TopicPage
 
@@ -108,7 +108,9 @@ def get_related_topic_page_urls(page: Page, topic_ids: list[str] | None = None) 
         # via their source page, which then accounts for related topics and their aliases.
         return set()
 
-    parent_topic = TopicPage.objects.ancestor_of(page).only("pk", "url_path").first()
+    # inclusive=True so this also works when `page` is itself the TopicPage (e.g. when an index page
+    # moved directly between topics and `page` here is the old/new topic parent)
+    parent_topic = TopicPage.objects.ancestor_of(page, inclusive=True).only("pk", "url_path").first()
     urls = set(get_page_cached_urls(parent_topic))
 
     topic_terms = topic_ids or getattr(page, "topic_ids", [])
@@ -242,6 +244,19 @@ def purge_old_page_paths_from_cache_after_move(
     elif isinstance(page, InformationPage):
         urls.update(get_page_cached_urls(parent_page_before))
         urls.update(get_page_cached_urls(parent_page_after))
+    elif isinstance(page, ArticlesIndexPage):
+        # the index itself moved between topics, taking its series/articles with it
+        for series in page.get_children().live().type(ArticleSeriesPage).specific():
+            urls.update(get_related_topic_page_urls(series))
+            urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=series.topic_ids))
+            for article in series.get_children().live().type(StatisticalArticlePage).specific():
+                if article.is_latest:
+                    urls.update(get_topic_pages_featuring_series(article, series))
+    elif isinstance(page, MethodologyIndexPage):
+        # the index itself moved between topics, taking its methodology pages with it
+        for methodology_page in page.get_children().live().type(MethodologyPage).specific():
+            urls.update(get_related_topic_page_urls(methodology_page))
+            urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=methodology_page.topic_ids))
 
     if urls:
         purge_urls_from_cache(urls)

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -5,10 +5,6 @@ from wagtail.contrib.frontend_cache.signal_handlers import (
     page_published_signal_handler,
     page_unpublished_signal_handler,
 )
-from wagtail.contrib.redirects.signal_handlers import (
-    autocreate_redirects_on_page_move,
-    autocreate_redirects_on_slug_change,
-)
 from wagtail.models import Page, get_page_models
 from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move, published, unpublished
 
@@ -93,12 +89,15 @@ def _get_tracked_page_models() -> set[Page]:
 
 
 def disconnect_signal_handlers() -> None:
-    """Disconnect the core front-end cache signal handlers as we handle them with specific logic."""
+    """Disconnect the core front-end cache signal handlers as we handle them with specific logic.
+
+    Note: wagtail.contrib.redirects connects its autocreate_redirects_on_* handlers without a
+    sender filter, so disconnecting them here with sender=model would be a no-op; they're left
+    connected intentionally so redirects keep being auto-created on slug change/page move.
+    """
     for model in get_page_models():
         page_published.disconnect(page_published_signal_handler, sender=model)
         page_unpublished.disconnect(page_unpublished_signal_handler, sender=model)
-        post_page_move.disconnect(autocreate_redirects_on_page_move, sender=model)
-        page_slug_changed.disconnect(autocreate_redirects_on_slug_change, sender=model)
 
 
 def register_signal_handlers() -> None:

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -701,8 +701,12 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                         f"{self.series_url}/related-data",
                         self.series_edition_url,
                         f"{self.series_edition_url}?page=1",
+                        f"{self.series_edition_url}?page=2",
+                        f"{self.series_edition_url}?page=3",
                         self.article_url,
                         self.article_related_data_url,
+                        f"{self.article_related_data_url}?page=1",
+                        f"{self.article_related_data_url}?page=2",
                         # old and new topics related to the series (both linked to topic_2)
                         self.topic_page_url,
                         self.topic_page_translation_url,

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -4,6 +4,7 @@ from unittest.mock import call, patch
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail.blocks import StreamValue
+from wagtail.contrib.redirects.models import Redirect
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Page, Site
 from wagtail.test.utils import WagtailTestUtils
@@ -507,6 +508,28 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 call({old_index_url, self.information_page_url}),
                 call({old_index_translation_url, information_page_translation_url}),
             ]
+        )
+
+    def test_page_slug_changed__creates_redirect(self, _patched_purge_urls):
+        with self.captureOnCommitCallbacks(execute=True):
+            self.index_page.slug = "new-index-slug"
+            self.index_page.save_revision().publish()
+
+        self.assertTrue(Redirect.objects.filter(redirect_page=self.index_page, automatically_created=True).exists())
+
+    def test_page_move__creates_redirect(self, _patched_purge_urls):
+        self.client.force_login(self.superuser)
+        another_index = IndexPageFactory(title="Another index")
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.information_page.pk, another_index.pk),
+            )
+        )
+
+        self.assertTrue(
+            Redirect.objects.filter(redirect_page=self.information_page, automatically_created=True).exists()
         )
 
     def test_page_move__statistical_article_page(self, patched_purge_urls):

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -642,6 +642,82 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             }
         )
 
+    def test_page_move__articles_index_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        articles_index = ArticlesIndexPage.objects.child_of(self.topic_page).first()
+        # the target topic (and its translation) already has its own auto-created index page which would clash on slug
+        ArticlesIndexPage.objects.child_of(self.another_topic_page).delete()
+        ArticlesIndexPage.objects.child_of(self.another_topic_page_translation).delete()
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(articles_index.pk, self.another_topic_page.pk),
+            )
+        )
+
+        # note: there are two calls as the second call is for the old translation alias
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        # old paths for the index and everything under it
+                        f"{self.topic_page_url}/articles",
+                        self.series_url,
+                        f"{self.series_url}/related-data",
+                        self.series_edition_url,
+                        f"{self.series_edition_url}?page=1",
+                        self.article_url,
+                        self.article_related_data_url,
+                        # old and new topics related to the series (both linked to topic_2)
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                    }
+                ),
+                call({f"{self.topic_page_translation_url}/articles"}),
+            ]
+        )
+
+    def test_page_move__methodology_index_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        methodology_index = MethodologyIndexPage.objects.child_of(self.topic_page).first()
+        # the target topic (and its translation) already has its own auto-created index page which would clash on slug
+        MethodologyIndexPage.objects.child_of(self.another_topic_page).delete()
+        MethodologyIndexPage.objects.child_of(self.another_topic_page_translation).delete()
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(methodology_index.pk, self.another_topic_page.pk),
+            )
+        )
+
+        # note: there are two calls as the second call is for the old translation alias
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        # old paths for the index and the methodology page under it
+                        f"{self.topic_page_url}/methodologies",
+                        self.methodology_page_url,
+                        # old and new topics related to the methodology page (both linked to topic_2)
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                    }
+                ),
+                call(
+                    {
+                        f"{self.topic_page_translation_url}/methodologies",
+                        self.methodology_page_translation_url,
+                    }
+                ),
+            ]
+        )
+
 
 @override_settings(CMS_USE_SUBDOMAIN_LOCALES=False)
 @patch("cms.frontend_cache.cache.purge_urls_from_cache")

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -695,6 +695,7 @@ WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 # default to the list of defined content languages if this is not defined.
 WAGTAILFRONTENDCACHE_LANGUAGES: list[str] = []
 if "FRONTEND_CACHE_CLOUDFLARE_TOKEN" in env or "FRONTEND_CACHE_CLOUDFLARE_BEARER_TOKEN" in env:
+    # Apps need to be installed in this order so that any signal disconnects work as intended
     INSTALLED_APPS += ["wagtail.contrib.frontend_cache", "cms.frontend_cache"]
     WAGTAILFRONTENDCACHE = {
         "default": {


### PR DESCRIPTION
### What is the context of this PR?

This PR addresses comments from #505, particularly:

* Removed the disconnection of signals to retain redirect creation (at the cost of duplicate requests) ([comment](https://github.com/ONSdigital/dis-wagtail/pull/505#discussion_r3415045507))
* Index pages and their children are considered during moves ([comment](https://github.com/ONSdigital/dis-wagtail/pull/505#discussion_r3415301099))
* A comment was added in the settings to indicate the importance of the order of app imports ([comment](https://github.com/ONSdigital/dis-wagtail/pull/505#discussion_r3415693515))
* Add aliases are now considered in the purge ([comment](https://github.com/ONSdigital/dis-wagtail/pull/505#discussion_r3415704960))

### How to review

Ensure that the code changes make sense and all tests pass.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Merge #505 into `main` when ready.


---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ