### PR TITLE
chore(taxonomy): add make target to delete topics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ load-design-system-templates:  ## Load the design system templates
 load-topics:  ## Load our fixture of taxonomy topics
 	poetry run python ./manage.py loaddata cms/taxonomy/fixtures/topics.json
 
+.PHONY: delete-topics
+delete-topics: ## Delete all topics from the database (root is preserved via the model manager)
+	poetry run python ./manage.py shell -c "from cms.taxonomy.models import Topic; Topic.objects.all().delete(); Topic.fix_tree()"
+
 .PHONY: test-data-create
 test-data-create:  ## Seed test data
 	poetry run python ./manage.py create_test_data \


### PR DESCRIPTION
### What is the context of this PR?

Adds a `delete-topics` Make target for removing all taxonomy topics from the database.

### How to review

Does it make sense, is it useful?. Try run `make delete-topics` then try load topics/sync topics to ensure no regression.

Will be used more often when being able to sync topics from diff envs.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
