### PR TITLE
chore(cache): rename frontend cache feature branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main, 'release/v*']
   pull_request:
-    # TODO: Remove 'feature-frontend-cache-invalidation' from the list of branches once the feature branch is merged.
-    branches: [main, 'release/v*', 'feature-frontend-cache-invalidation']
+    # TODO: Remove 'CMS-724-feature-frontend-cache-invalidation' from the list of branches once the feature branch is merged.
+    branches: [main, 'release/v*', 'CMS-724-feature-frontend-cache-invalidation']
 
 concurrency:
   group: '${{ github.head_ref || github.ref }}-${{ github.workflow }}'


### PR DESCRIPTION
### What is the context of this PR?

This PR renames the feature branch name related to the frontend cache functionality in `.github/workflows/ci.yml`.

Related comment: https://github.com/ONSdigital/dis-wagtail/pull/780#pullrequestreview-5016241036

The only reason for this is to merge this change in before rebasing the outstanding PRs #696 #780 #785 

### How to review

Confirm the branch names match

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Rebase the branches as mentioned above.


---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ