### PR TITLE
feat(post-publish-actions): run cache purge for pages as post publish action

### DIFF
--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -16,6 +16,7 @@ from cms.bundles.management.commands.publish_bundles import Command as PublishBu
 from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory, BundlePageFactory
 from cms.core.tests import TransactionTestCase
 from cms.datasets.tests.factories import DatasetFactory
+from cms.frontend_cache.cache import get_page_cached_urls
 from cms.home.models import HomePage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import executor_stop_and_wait, flush_executor
@@ -200,6 +201,38 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         }
 
         self.assertIn(alias.pk, published_page_ids)
+
+    @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    @patch("cms.bundles.utils.notify_slack_of_publication_start")
+    @patch("cms.bundles.utils.notify_slack_of_publish_end")
+    @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
+    @patch("cms.search.signal_handlers.get_publisher")
+    def test_publish_bundle_purges_the_frontend_cache(
+        self,
+        mock_get_publisher,  # pylint: disable=unused-argument
+        mock_notify_post_publish_end,  # pylint: disable=unused-argument
+        mock_notify_end,  # pylint: disable=unused-argument
+        mock_notify_start,  # pylint: disable=unused-argument
+        mock_purge_urls,
+    ):
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+        mark_page_as_ready_to_publish(self.statistical_article)
+
+        self.call_command()
+
+        executor_stop_and_wait()
+
+        action = PostPublishAction.objects.get(
+            page=self.statistical_article, action_type=PostPublishActionType.CACHE_PURGE
+        )
+        self.assertEqual(action.bundle_id, self.bundle.pk)
+        self.assertEqual(action.status, PostPublishActionStatus.SUCCESSFUL)
+
+        self.statistical_article.refresh_from_db()
+        purged_urls = set().union(*(call.args[0] for call in mock_purge_urls.call_args_list))
+
+        self.assertTrue(set(get_page_cached_urls(self.statistical_article)).issubset(purged_urls))
 
     @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
     @patch("cms.bundles.utils.notify_slack_of_publication_start")

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -20,6 +20,7 @@ from cms.home.models import HomePage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import executor_stop_and_wait, flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.workflows.models import ReadyToPublishGroupTask
@@ -188,7 +189,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(alias.live)
 
         alias_actions = PostPublishAction.objects.filter(page=alias)
-        self.assertEqual(alias_actions.count(), 2)
+        self.assertEqual(alias_actions.count(), len(get_post_publish_actions()))
         for action in alias_actions:
             self.assertEqual(action.bundle_id, self.bundle.pk)
             self.assertEqual(action.status, PostPublishActionStatus.SUCCESSFUL)
@@ -259,7 +260,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         failed_action = PostPublishAction.objects.finished().filter(status=PostPublishActionStatus.FAILED).get()
 
@@ -299,7 +300,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 
@@ -338,7 +339,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 

--- a/cms/bundles/tests/test_utils.py
+++ b/cms/bundles/tests/test_utils.py
@@ -29,6 +29,7 @@ from cms.methodology.models import MethodologyPage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.models import ReleaseCalendarPage
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.standard_pages.models import IndexPage, InformationPage
@@ -676,7 +677,10 @@ class PublishBundleFailureTests(TestCase):
         with self.assertRaises(PostPublishAction.DoesNotExist):
             invalid_action.refresh_from_db()
 
-        self.assertEqual(PostPublishAction.objects.filter(bundle=bundle, page=page_will_publish).count(), 2)
+        self.assertEqual(
+            PostPublishAction.objects.filter(bundle=bundle, page=page_will_publish).count(),
+            len(get_post_publish_actions()),
+        )
 
         self.assertTrue(
             PostPublishAction.objects.filter(

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -35,6 +35,7 @@ from cms.datasets.tests.factories import DatasetFactory
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import executor_stop_and_wait, flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.release_calendar.viewsets import FutureReleaseCalendarChooserWidget
@@ -722,7 +723,7 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
         self.bundle.save(update_fields=["status", "publication_date"])
         self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
 
-        expected_action_count = 2
+        expected_action_count = len(get_post_publish_actions())
         deadline = time.monotonic() + 2.5
         while time.monotonic() < deadline and PostPublishAction.objects.finished().count() < expected_action_count:
             time.sleep(0.1)
@@ -752,9 +753,9 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
 
         mock_get_publisher.assert_called()
 
-        self.assertEqual(PostPublishAction.objects.count(), 2)
+        self.assertEqual(PostPublishAction.objects.count(), len(get_post_publish_actions()))
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 
@@ -775,9 +776,9 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
 
         mock_get_publisher.assert_called()
 
-        self.assertEqual(PostPublishAction.objects.count(), 2)
+        self.assertEqual(PostPublishAction.objects.count(), len(get_post_publish_actions()))
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -113,6 +113,9 @@ def register_signal_handlers() -> None:
     )
 
     for model in _get_tracked_page_models():
+        # These were considered for post-publish actions but not implemented for now
+        # They are rare editor actions that are currently more effort than it's worth,
+        # and won't massively benefit from being tracked as post-publish actions in the DB
         page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
         page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
         page_title_changed.connect(purge_descendants_from_frontend_cache, sender=model)

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -13,6 +13,8 @@ from cms.core.models import BasePage, ContactDetails, Definition
 from cms.core.signals import page_title_changed
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage
+from cms.post_publish_actions.models import PostPublishActionType
+from cms.post_publish_actions.registry import PostPublishActionPriority, register_post_publish_action
 from cms.release_calendar.models import ReleaseCalendarIndex
 
 from .cache import (
@@ -26,12 +28,15 @@ from .cache import (
 if TYPE_CHECKING:
     from django.db.models import Model
 
+    from cms.bundles.models import Bundle
+
 
 EXCLUDED_PAGE_TYPES = frozenset({ArticlesIndexPage, HomePage, MethodologyIndexPage, ReleaseCalendarIndex})
 
 
-def purge_published_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
-    purge_page_from_frontend_cache(instance)
+def purge_published_page_from_frontend_cache(page: Page, _bundle: Bundle | None) -> None:
+    if type(page) in _get_tracked_page_models():
+        purge_page_from_frontend_cache(page)
 
 
 def purge_unpublished_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
@@ -101,8 +106,13 @@ def disconnect_signal_handlers() -> None:
 
 
 def register_signal_handlers() -> None:
+    register_post_publish_action(
+        PostPublishActionType.CACHE_PURGE,
+        purge_published_page_from_frontend_cache,
+        priority=PostPublishActionPriority.MEDIUM,
+    )
+
     for model in _get_tracked_page_models():
-        page_published.connect(purge_published_page_from_frontend_cache, sender=model)
         page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
         page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
         page_title_changed.connect(purge_descendants_from_frontend_cache, sender=model)

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -82,7 +82,7 @@ def purge_pages_containing_the_deleted_snippet_from_frontend_cache(
     purge_page_containing_snippet_from_cache(instance)
 
 
-def _get_tracked_page_models() -> set[Page]:
+def _get_tracked_page_models() -> set[type[Page]]:
     """Returns a list of page models that are included in the front-end cache purging.
 
     We're excluding the following page types:

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -1040,7 +1040,7 @@ class PublishPurgeRunsAsPostPublishActionTestCase(WagtailTestUtils, TestCase):
         cls.index_page = IndexPageFactory()
         cls.information_page = InformationPageFactory(parent=cls.index_page, title="Info page")
 
-    def test_registered_ast_the_frontend_cache_action(self):
+    def test_registered_as_the_frontend_cache_action(self):
         self.assertIs(
             get_post_publish_actions()[PostPublishActionType.CACHE_PURGE], purge_published_page_from_frontend_cache
         )

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -17,10 +17,13 @@ from cms.datasets.blocks import DatasetStoryBlock
 from cms.datasets.tests.factories import DatasetFactory
 from cms.datavis.tests.factories import TableDataFactory, make_table_block_value
 from cms.frontend_cache.cache import get_page_cached_urls
-from cms.frontend_cache.signal_handlers import _get_tracked_page_models
+from cms.frontend_cache.signal_handlers import _get_tracked_page_models, purge_published_page_from_frontend_cache
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage, MethodologyPage
 from cms.methodology.tests.factories import MethodologyPageFactory
+from cms.post_publish_actions import registry
+from cms.post_publish_actions.models import PostPublishActionType
+from cms.post_publish_actions.registry import PostPublishActionPriority, get_post_publish_actions
 from cms.release_calendar.models import ReleaseCalendarPage
 from cms.standard_pages.models import CookiesPage, IndexPage, InformationPage
 from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
@@ -1029,3 +1032,40 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
                 f"{series_url}/editions?page=3",
             ],
         )
+
+
+class PublishPurgeRunsAsPostPublishActionTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.index_page = IndexPageFactory()
+        cls.information_page = InformationPageFactory(parent=cls.index_page, title="Info page")
+
+    def test_registered_ast_the_frontend_cache_action(self):
+        self.assertIs(
+            get_post_publish_actions()[PostPublishActionType.CACHE_PURGE], purge_published_page_from_frontend_cache
+        )
+
+    def test_registered_with_medium_priority(self):
+        registered = registry._registry[PostPublishActionType.CACHE_PURGE]  # pylint: disable=protected-access
+        self.assertEqual(registered.priority, PostPublishActionPriority.MEDIUM)
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_publish_does_not_purge_outside_registry(self, patched_purge_urls):
+        with patch.dict(registry._registry, {}, clear=True):  # pylint: disable=protected-access
+            self.information_page.save_revision().publish()
+
+        patched_purge_urls.assert_not_called()
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_running_the_action_directly_purges_page(self, patched_purge_urls):
+        purge_published_page_from_frontend_cache(self.information_page, None)
+
+        patched_purge_urls.assert_called_once_with(
+            {self.information_page.get_full_url(get_dummy_request()), self.index_page.get_full_url(get_dummy_request())}
+        )
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_running_action_skips_untracked_page_types(self, patched_purge_urls):
+        purge_published_page_from_frontend_cache(HomePage.objects.first(), None)
+
+        patched_purge_urls.assert_not_called()

--- a/cms/post_publish_actions/models.py
+++ b/cms/post_publish_actions/models.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 class PostPublishActionType(models.TextChoices):
+    CACHE_PURGE = "CACHE_PURGE", "Frontend cache purge"
     S3_ACL = "S3_ACL", "Private Media ACLs"
     SEARCH_UPDATED = "SEARCH_UPDATED", "Search updated"
 

--- a/cms/post_publish_actions/models.py
+++ b/cms/post_publish_actions/models.py
@@ -24,10 +24,14 @@ class PostPublishActionStatus(models.TextChoices):
 
 class PostPublishActionQuerySet(models.QuerySet):
     def active(self) -> Self:
-        """Exclude stale action types.
-        These may be from previous deployments with different types.
+        """Exclude action types with no registered handler.
+
+        May be deprecated action types from previous versions, or handlers that are not currently
+        registered with the current configuration (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`).
         """
-        return self.filter(action_type__in=PostPublishActionType.values)
+        from .registry import get_registered_action_types  # pylint: disable=import-outside-toplevel
+
+        return self.filter(action_type__in=get_registered_action_types())
 
     def finished(self) -> Self:
         return self.exclude(finished_at=None)

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -63,3 +63,12 @@ def get_post_publish_actions() -> dict[PostPublishActionType, ActionHandler]:
 
 def get_post_publish_action_for_type(action_type: PostPublishActionType) -> ActionHandler:
     return _registry[action_type].handler
+
+
+def get_registered_action_types() -> list[PostPublishActionType]:
+    """Returns a list of all registered post-publish action types.
+
+    Handlers can be conditionaly registered (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`)
+    so this may only be a subset of all action types defined in `PostPublishActionType`.
+    """
+    return list(_registry)

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -33,6 +33,8 @@ _registry: dict[PostPublishActionType, RegisteredPostPublishAction] = {}
 
 
 def register_post_publish_action(
+    action_type: PostPublishActionType, action_handler: ActionHandler, *, priority: int = PostPublishActionPriority.MEDIUM
+) -> None:
     action_type: PostPublishActionType, action_handler: ActionHandler, priority: int = PostPublishActionPriority.MEDIUM
 ) -> None:
     if action_type in _registry:

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -33,9 +33,10 @@ _registry: dict[PostPublishActionType, RegisteredPostPublishAction] = {}
 
 
 def register_post_publish_action(
-    action_type: PostPublishActionType, action_handler: ActionHandler, *, priority: int = PostPublishActionPriority.MEDIUM
-) -> None:
-    action_type: PostPublishActionType, action_handler: ActionHandler, priority: int = PostPublishActionPriority.MEDIUM
+    action_type: PostPublishActionType,
+    action_handler: ActionHandler,
+    *,
+    priority: int = PostPublishActionPriority.MEDIUM,
 ) -> None:
     if action_type in _registry:
         raise ImproperlyConfigured(f"{action_type} is already configured: {_registry[action_type].handler}")

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -68,7 +68,7 @@ def get_post_publish_action_for_type(action_type: PostPublishActionType) -> Acti
 def get_registered_action_types() -> list[PostPublishActionType]:
     """Returns a list of all registered post-publish action types.
 
-    Handlers can be conditionaly registered (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`)
+    Handlers can be conditionally registered (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`)
     so this may only be a subset of all action types defined in `PostPublishActionType`.
     """
     return list(_registry)

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ImproperlyConfigured
@@ -12,27 +14,49 @@ if TYPE_CHECKING:
 
 ActionHandler = Callable[[Page, "Bundle | None"], None]
 
-_registry: dict[PostPublishActionType, ActionHandler] = {}
+
+class PostPublishActionPriority(IntEnum):
+    """Defines the priority of a post-publish action. Lower numbers are higher priority."""
+
+    HIGH = 1
+    MEDIUM = 2
+    LOW = 3
 
 
-def register_post_publish_action(action_type: PostPublishActionType, action_handler: ActionHandler) -> None:
+@dataclass(frozen=True)
+class RegisteredPostPublishAction:
+    handler: ActionHandler
+    priority: int = PostPublishActionPriority.MEDIUM
+
+
+_registry: dict[PostPublishActionType, RegisteredPostPublishAction] = {}
+
+
+def register_post_publish_action(
+    action_type: PostPublishActionType, action_handler: ActionHandler, priority: int = PostPublishActionPriority.MEDIUM
+) -> None:
     if action_type in _registry:
-        raise ImproperlyConfigured(f"{action_type} is already configured: {_registry[action_type]}")
+        raise ImproperlyConfigured(f"{action_type} is already configured: {_registry[action_type].handler}")
 
-    _registry[action_type] = action_handler
+    _registry[action_type] = RegisteredPostPublishAction(handler=action_handler, priority=priority)
 
 
-def post_publish_action(action_type: PostPublishActionType) -> Callable[[ActionHandler], ActionHandler]:
+def post_publish_action(
+    action_type: PostPublishActionType, priority: int = PostPublishActionPriority.MEDIUM
+) -> Callable[[ActionHandler], ActionHandler]:
     def decorator(action_handler: ActionHandler) -> ActionHandler:
-        register_post_publish_action(action_type, action_handler)
+        register_post_publish_action(action_type, action_handler, priority=priority)
         return action_handler
 
     return decorator
 
 
 def get_post_publish_actions() -> dict[PostPublishActionType, ActionHandler]:
-    return _registry
+    return {
+        action_type: registered.handler
+        for action_type, registered in sorted(_registry.items(), key=lambda item: item[1].priority)
+    }
 
 
 def get_post_publish_action_for_type(action_type: PostPublishActionType) -> ActionHandler:
-    return _registry[action_type]
+    return _registry[action_type].handler

--- a/cms/post_publish_actions/tests/test_management_commands.py
+++ b/cms/post_publish_actions/tests/test_management_commands.py
@@ -175,7 +175,11 @@ class RetryPostPublishActionsTestCase(TransactionTestCase):
     def test_republishing_restores_retry_budget(self):
         action = self._create_stalled_action(retry_count=2, status=PostPublishActionStatus.FAILED)
 
-        with patch.dict(registry._registry, {PostPublishActionType.SEARCH_UPDATED: MagicMock()}, clear=True):  # pylint: disable=protected-access
+        with patch.dict(
+            registry._registry,  # pylint: disable=protected-access
+            {PostPublishActionType.SEARCH_UPDATED: registry.RegisteredPostPublishAction(handler=MagicMock())},
+            clear=True,
+        ):
             run_post_publish_actions_for(self.page, self.bundle)
 
         action.refresh_from_db()

--- a/cms/post_publish_actions/tests/test_models.py
+++ b/cms/post_publish_actions/tests/test_models.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
 from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.bundles.tests.factories import BundleFactory
+from cms.post_publish_actions import registry
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
 
 
@@ -54,3 +56,14 @@ class PostPublishActionTestCase(TestCase):
 
         self.assertIn(action, PostPublishAction.objects.active())
         self.assertNotIn(invalid_action, PostPublishAction.objects.active())
+
+    def test_active_excludes_action_types_without_a_registered_handler(self):
+        action = PostPublishAction.objects.create(
+            bundle=self.bundle, page=self.page, action_type=PostPublishActionType.CACHE_PURGE
+        )
+
+        with patch.dict(registry._registry) as patched_registry:  # pylint: disable=protected-access
+            del patched_registry[PostPublishActionType.CACHE_PURGE]
+            self.assertNotIn(action, PostPublishAction.objects.active())
+
+        self.assertIn(action, PostPublishAction.objects.active())

--- a/cms/post_publish_actions/tests/test_registry.py
+++ b/cms/post_publish_actions/tests/test_registry.py
@@ -1,8 +1,12 @@
+from unittest.mock import patch
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
+from cms.post_publish_actions import registry
 from cms.post_publish_actions.models import PostPublishActionType
 from cms.post_publish_actions.registry import (
+    PostPublishActionPriority,
     get_post_publish_action_for_type,
     get_post_publish_actions,
     register_post_publish_action,
@@ -30,3 +34,64 @@ class RegistryTestCase(SimpleTestCase):
             register_post_publish_action(PostPublishActionType.SEARCH_UPDATED, _noop_handler)
 
         self.assertIsNot(get_post_publish_action_for_type(PostPublishActionType.SEARCH_UPDATED), _noop_handler)
+
+
+class RegistryPriorityTestCase(SimpleTestCase):
+    def setUp(self):
+        patcher = patch.dict(registry._registry, {}, clear=True)  # pylint: disable=protected-access
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_actions_are_returned_highest_priority_first(self):
+        """Test that actions are returned in order of priority."""
+        register_post_publish_action(
+            PostPublishActionType.SEARCH_UPDATED, _noop_handler, priority=PostPublishActionPriority.LOW
+        )
+        register_post_publish_action(
+            PostPublishActionType.S3_ACL, _noop_handler, priority=PostPublishActionPriority.HIGH
+        )
+        register_post_publish_action(
+            PostPublishActionType.CACHE_PURGE, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+
+        actions = get_post_publish_actions()
+
+        self.assertEqual(
+            list(actions.keys()),
+            [
+                PostPublishActionType.S3_ACL,
+                PostPublishActionType.CACHE_PURGE,
+                PostPublishActionType.SEARCH_UPDATED,
+            ],
+        )
+
+    def test_equal_priorities_keep_their_registration_order(self):
+        register_post_publish_action(
+            PostPublishActionType.SEARCH_UPDATED, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+        register_post_publish_action(
+            PostPublishActionType.S3_ACL, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+
+        self.assertEqual(
+            list(get_post_publish_actions().keys()),
+            [PostPublishActionType.SEARCH_UPDATED, PostPublishActionType.S3_ACL],
+        )
+
+    def test_registration_defaults_to_medium_priority(self):
+        register_post_publish_action(PostPublishActionType.SEARCH_UPDATED, _noop_handler)
+
+        self.assertEqual(
+            registry._registry[PostPublishActionType.SEARCH_UPDATED],  # pylint: disable=protected-access
+            registry.RegisteredPostPublishAction(handler=_noop_handler, priority=PostPublishActionPriority.MEDIUM),
+        )
+
+    def test_decorator_passes_priority_to_registration(self):
+        @registry.post_publish_action(PostPublishActionType.SEARCH_UPDATED, priority=PostPublishActionPriority.HIGH)
+        def handler(page, bundle):  # pylint: disable=unused-argument
+            pass
+
+        self.assertEqual(
+            registry._registry[PostPublishActionType.SEARCH_UPDATED],  # pylint: disable=protected-access
+            registry.RegisteredPostPublishAction(handler=handler, priority=PostPublishActionPriority.HIGH),
+        )

--- a/cms/post_publish_actions/tests/test_utils.py
+++ b/cms/post_publish_actions/tests/test_utils.py
@@ -21,7 +21,11 @@ class RunPostPublishActionsForTestCase(TestCase):
 
     def test_without_bundle_runs_handlers_synchronously(self):
         """Test that pages published without a bundle publish synchronously for now."""
-        with patch.dict(registry._registry, {PostPublishActionType.S3_ACL: self.handler}, clear=True):
+        with patch.dict(
+            registry._registry,
+            {PostPublishActionType.S3_ACL: registry.RegisteredPostPublishAction(handler=self.handler)},
+            clear=True,
+        ):
             run_post_publish_actions_for(self.page, None)
 
         self.handler.assert_called_with(self.page, None)

--- a/cms/post_publish_actions/utils.py
+++ b/cms/post_publish_actions/utils.py
@@ -90,6 +90,8 @@ def post_publish_notify_slack(start_time: datetime, bundle: Bundle, *, publish_f
 
 
 def run_post_publish_actions_for(page: Page, bundle: Bundle | None) -> None:
+    # Gets actions in ascending priority
+    # Guarantees order of execution for individual pages, and order of enequeuing for pages in bundles
     registry = get_post_publish_actions()
 
     # TODO: Handle pages not in bundle.

--- a/cms/post_publish_actions/utils.py
+++ b/cms/post_publish_actions/utils.py
@@ -90,8 +90,9 @@ def post_publish_notify_slack(start_time: datetime, bundle: Bundle, *, publish_f
 
 
 def run_post_publish_actions_for(page: Page, bundle: Bundle | None) -> None:
-    # Gets actions in ascending priority
-    # Guarantees order of execution for individual pages, and order of enqueuing for pages in bundles
+    # Actions are returned in ascending priority order.
+    # Sync path (no bundle): runs strictly in priority order.
+    # Bundle path: enqueued in priority order, but execution order is not guaranteed (thread pool).
     registry = get_post_publish_actions()
 
     # TODO: Handle pages not in bundle.

--- a/cms/post_publish_actions/utils.py
+++ b/cms/post_publish_actions/utils.py
@@ -91,7 +91,7 @@ def post_publish_notify_slack(start_time: datetime, bundle: Bundle, *, publish_f
 
 def run_post_publish_actions_for(page: Page, bundle: Bundle | None) -> None:
     # Gets actions in ascending priority
-    # Guarantees order of execution for individual pages, and order of enequeuing for pages in bundles
+    # Guarantees order of execution for individual pages, and order of enqueuing for pages in bundles
     registry = get_post_publish_actions()
 
     # TODO: Handle pages not in bundle.

--- a/cms/private_media/signal_handlers.py
+++ b/cms/private_media/signal_handlers.py
@@ -137,5 +137,5 @@ def register_signal_handlers() -> None:
     unpublished.connect(unpublish_media_on_unpublish, dispatch_uid="unpublish_media")
 
     register_post_publish_action(
-        PostPublishActionType.S3_ACL, publish_media_post_publish_action, PostPublishActionPriority.HIGH
+        PostPublishActionType.S3_ACL, publish_media_post_publish_action, priority=PostPublishActionPriority.HIGH
     )

--- a/cms/private_media/signal_handlers.py
+++ b/cms/private_media/signal_handlers.py
@@ -9,7 +9,7 @@ from wagtail.signals import published, unpublished
 
 from cms.bundles.models import Bundle
 from cms.post_publish_actions.models import PostPublishActionType
-from cms.post_publish_actions.registry import register_post_publish_action
+from cms.post_publish_actions.registry import PostPublishActionPriority, register_post_publish_action
 from cms.private_media.constants import Privacy
 from cms.private_media.models import PrivateImageMixin
 from cms.private_media.utils import get_private_media_models
@@ -136,4 +136,6 @@ def register_signal_handlers() -> None:
     published.connect(publish_media_on_publish, dispatch_uid="publish_media")
     unpublished.connect(unpublish_media_on_unpublish, dispatch_uid="unpublish_media")
 
-    register_post_publish_action(PostPublishActionType.S3_ACL, publish_media_post_publish_action)
+    register_post_publish_action(
+        PostPublishActionType.S3_ACL, publish_media_post_publish_action, PostPublishActionPriority.HIGH
+    )

--- a/cms/search/signal_handlers.py
+++ b/cms/search/signal_handlers.py
@@ -9,14 +9,14 @@ from wagtail.signals import page_slug_changed, page_unpublished, post_page_move
 
 from cms.bundles.models import Bundle
 from cms.post_publish_actions.models import PostPublishActionType
-from cms.post_publish_actions.registry import post_publish_action
+from cms.post_publish_actions.registry import PostPublishActionPriority, post_publish_action
 from cms.search.publishers import get_publisher
 from cms.search.utils import get_model_by_name, is_indexable_page
 
 logger = logging.getLogger(__name__)
 
 
-@post_publish_action(PostPublishActionType.SEARCH_UPDATED)
+@post_publish_action(PostPublishActionType.SEARCH_UPDATED, PostPublishActionPriority.LOW)
 def update_index_post_publish_action(page: Page, _bundle: Bundle | None) -> None:
     if is_indexable_page(page):
         get_publisher().publish_created_or_updated(page)

--- a/docs/custom-features/post-publish-actions.md
+++ b/docs/custom-features/post-publish-actions.md
@@ -14,7 +14,7 @@ When a bundle is published, each page triggers registered post-publish actions. 
 Actions are registered via a decorator or function call:
 
 - **`S3_ACL`** — updates S3 object ACLs for private media associated with the page (see `cms/private_media/signal_handlers.py`).
-- **`CACHE_PURGE`** -- purges urls specified for the page from the Cloudflare cache (see `cms/frontend_cache/signal_handlers.py`). Only registered when `cms.frontend_cache` app installed.
+- **`CACHE_PURGE`** — purges urls specified for the page from the Cloudflare cache (see `cms/frontend_cache/signal_handlers.py`). Only registered when `cms.frontend_cache` app installed.
 - **`SEARCH_UPDATED`** — notifies the search service that a page has been created or updated (see `cms/search/signal_handlers.py`).
 
 New action types can be added by defining a handler that accepts `(page: Page, bundle: Bundle | None)` and registering it with `@post_publish_action(PostPublishActionType.MY_TYPE)` or `register_post_publish_action(...)`.

--- a/docs/custom-features/post-publish-actions.md
+++ b/docs/custom-features/post-publish-actions.md
@@ -1,5 +1,3 @@
-from post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.registry import register_post_publish_action
-
 # Post-publish Actions
 
 Post-publish actions are tasks that run asynchronously after pages are published as part of a bundle. They allow side effects such as updating search indexes or changing S3 ACLs to happen in parallel, without blocking the publishing process.

--- a/docs/custom-features/post-publish-actions.md
+++ b/docs/custom-features/post-publish-actions.md
@@ -1,3 +1,5 @@
+from post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.registry import PostPublishActionPriorityfrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.models import PostPublishActionTypefrom post_publish_actions.registry import register_post_publish_action
+
 # Post-publish Actions
 
 Post-publish actions are tasks that run asynchronously after pages are published as part of a bundle. They allow side effects such as updating search indexes or changing S3 ACLs to happen in parallel, without blocking the publishing process.
@@ -13,10 +15,13 @@ When a bundle is published, each page triggers registered post-publish actions. 
 
 Actions are registered via a decorator or function call:
 
-- **`SEARCH_UPDATED`** — notifies the search service that a page has been created or updated (see `cms/search/signal_handlers.py`).
 - **`S3_ACL`** — updates S3 object ACLs for private media associated with the page (see `cms/private_media/signal_handlers.py`).
+- **`CACHE_PURGE`** -- purges urls specified for the page from the Cloudflare cache (see `cms/frontend_cache/signal_handlers.py`). Only registered when `cms.frontend_cache` app installed.
+- **`SEARCH_UPDATED`** — notifies the search service that a page has been created or updated (see `cms/search/signal_handlers.py`).
 
 New action types can be added by defining a handler that accepts `(page: Page, bundle: Bundle | None)` and registering it with `@post_publish_action(PostPublishActionType.MY_TYPE)` or `register_post_publish_action(...)`.
+
+Registration is conditional on the owning app being installed, so the set of registered actions can be smaller than the total list of action types defined here. `PostPublishAction.objects.active()` returns only actions for which a handler is registered, so they will be ignored by completion polling and retries.
 
 ## Architecture
 
@@ -42,6 +47,41 @@ publish_bundles command / manual publish in wagtail admin
 ### Registry
 
 `cms/post_publish_actions/registry.py` maintains a mapping of `PostPublishActionType` → handler callable. Handlers receive `(page, bundle)` and perform the side effect. Registration happens at app startup (in `signal_handlers.py` / `apps.py`).
+
+#### Priority
+
+Each handler is registered with a priority, `PostPublishActionPriority`.
+
+```python
+class PostPublishActionPriority(IntEnum):
+    HIGH = 1
+    MEDIUM = 2
+    LOW = 3
+```
+
+This determines the order in which actions are executed (sync path) or enqueued (thread pooling). Lower priority integer values run first, and equal numbers are run in registration order.
+
+```python
+register_post_publish_action(
+    PostPublishActionType.CACHE_PURGE,
+    purge_published_page_from_frontend_cache,
+    priority=PostPublishActionPriority.MEDIUM,
+)
+
+
+@post_publish_action(PostPublishActionType.SEARCH_UPDATED, PostPublishActionPriority.LOW)
+def update_index_post_publish_action(page: Page, bundle: Bundle | None) -> None: ...
+```
+
+Alternatively an integer can be passed directly as the priority, which may enable extra high or low values to guarantee a particular action runs first/last.
+
+For now the actions are registered in the following order
+
+| Action Type      | Priority |
+| ---------------- | -------- |
+| `S3_ACL`         | `HIGH`   |
+| `CACHE_PURGE`    | `MEDIUM` |
+| `SEARCH_UPDATED` | `LOW`    |
 
 ### Model
 
@@ -187,6 +227,7 @@ If a bundle is re-published, any actions are deleted and re-created so we don't 
 | `cms/post_publish_actions/signal_handlers.py`                                | Wagtail signal integration and bundle context manager |
 | `cms/post_publish_actions/utils.py`                                          | Completion polling, Slack notification orchestration  |
 | `cms/post_publish_actions/management/commands/retry_post_publish_actions.py` | Retry management command                              |
+| `cms/frontend_cache/signal_handlers.py`                                      | `CACHE_PURGE` action handler                          |
 | `cms/bundles/management/commands/publish_bundles.py`                         | Bundle publishing orchestration                       |
 | `cms/bundles/utils.py`                                                       |                                                       |
 | `cms/search/signal_handlers.py`                                              | `SEARCH_UPDATED` action handler                       |
@@ -200,5 +241,3 @@ Bundles were the first use case for concurrent post-publish actions, but in futu
 
 - Individual page publishes (outside of bundles)
 - Page unpublishes (both inside and outside of bundles)
-
-This will also include new registry actions for custom cache purging (in development on feature branch `feature-frontend-cache-invalidation`).


### PR DESCRIPTION
### What is the context of this PR?

Updates the frontend cache purging logic to run from the post-publish actions registry when the `frontend_cache` app is installed.

This also ads a small change to the registry to allow for action prioritisation. This will guarantee that in the synchronous (e.g. single page publish) case, the actions will complete in priority order. In the non-synchronous case it guarantees the order in which the actions are enqueued. This will not necessarily guarantee the order in which they complete within the thread pool.

Currently the intended order for single pages is

ACL update
Cache purge
Search index update

### How to review

Review tests to ensure they cover all relevant test cases.
Ensure the purge runs correctly, with correct URLs when a page is published.
Ensure when running a bundle publish that the count of post publish actions is correct, and we can see a cache purge was attempted.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.


---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ