### PR TITLE
feat: frontend cache invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main, 'release/v*']
   pull_request:
-    branches: [main, 'release/v*']
+    # TODO: Remove 'feature-frontend-cache-invalidation' from the list of branches once the feature branch is merged.
+    branches: [main, 'release/v*', 'feature-frontend-cache-invalidation']
 
 concurrency:
   group: '${{ github.head_ref || github.ref }}-${{ github.workflow }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main, 'release/v*']
   pull_request:
-    # TODO: Remove 'feature-frontend-cache-invalidation' from the list of branches once the feature branch is merged.
-    branches: [main, 'release/v*', 'feature-frontend-cache-invalidation']
+    # TODO: Remove 'CMS-724-feature-frontend-cache-invalidation' from the list of branches once the feature branch is merged.
+    branches: [main, 'release/v*', 'CMS-724-feature-frontend-cache-invalidation']
 
 concurrency:
   group: '${{ github.head_ref || github.ref }}-${{ github.workflow }}'

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -258,7 +258,8 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         yield "/editions"
         # ensure we always account for ?page=1
         pages = max(1, ceil(self.get_children().live().public().count() / settings.PREVIOUS_RELEASES_PER_PAGE))
-        for page_number in range(1, pages + 1):
+        # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
+        for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
             yield f"/editions?page={page_number}"
 
 
@@ -949,8 +950,9 @@ class StatisticalArticlePage(  # type: ignore[django-manager-missing]
     def get_cached_paths(self) -> Generator[str]:
         yield "/"
         yield "/related-data"  # always include, should a correction remove related datasets
-        if self.datasets:
-            for page_number in range(1, ceil(len(self.datasets) / settings.RELATED_DATASETS_PER_PAGE) + 1):
-                yield f"/related-data?page={page_number}"
+        pages = ceil(len(self.datasets or []) / settings.RELATED_DATASETS_PER_PAGE)
+        # over-purge trailing pages so pages orphaned by shrinking pagination are invalidated too
+        for page_number in range(1, pages + settings.CMS_PAGINATION_OVER_PURGE + 1):
+            yield f"/related-data?page={page_number}"
 
         yield from self.get_downloadable_block_paths()

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import models, transaction
+from django.db import models
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
@@ -24,7 +24,6 @@ from wagtail.templatetags.wagtailcore_tags import richtext
 from cms.articles.enums import SortingChoices
 from cms.articles.forms import StatisticalArticlePageAdminForm
 from cms.articles.panels import HeadlineFiguresFieldPanel
-from cms.articles.signals import series_title_changed
 from cms.articles.utils import serialize_correction_or_notice
 from cms.bundles.mixins import BundledPageMixin
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, bool_to_yes_no, format_date_for_gtm
@@ -49,8 +48,6 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.template.response import TemplateResponse
     from wagtail.admin.panels import Panel
-
-    from cms.users.models import User
 
 
 logger = logging.getLogger(__name__)
@@ -126,31 +123,6 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         """Returns the summary of the latest article in the series."""
         # TODO: update to include drafts when looking at previews holistically.
         return latest.summary if (latest := self.get_latest()) else ""
-
-    @transaction.atomic
-    def save(  # type: ignore[override]
-        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
-    ) -> ArticleSeriesPage | None:
-        # typing ignored as we need TypedDict but mypy struggles with it
-        original_values = None  # typing: ignore[var-annotated]
-        if self.pk:
-            original_values = ArticleSeriesPage.objects.values("title", "slug").filter(pk=self.pk).first()
-
-        instance: ArticleSeriesPage | None = super().save(  # type: ignore[call-arg]
-            clean=clean, user=user, log_action=log_action, **kwargs
-        )
-
-        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
-            # The title has changed, but not the slug.
-            # The slug change is already handled by the `page_slug_changed` signal.
-            transaction.on_commit(
-                lambda: series_title_changed.send(
-                    sender=self.__class__,
-                    instance=self,
-                )
-            )
-
-        return instance
 
     def get_latest(self) -> StatisticalArticlePage | None:
         latest: StatisticalArticlePage | None = (

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -1,11 +1,13 @@
 import logging
+from collections.abc import Generator
+from math import ceil
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import models
+from django.db import models, transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
@@ -22,6 +24,7 @@ from wagtail.templatetags.wagtailcore_tags import richtext
 from cms.articles.enums import SortingChoices
 from cms.articles.forms import StatisticalArticlePageAdminForm
 from cms.articles.panels import HeadlineFiguresFieldPanel
+from cms.articles.signals import series_title_changed
 from cms.articles.utils import serialize_correction_or_notice
 from cms.bundles.mixins import BundledPageMixin
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, bool_to_yes_no, format_date_for_gtm
@@ -46,6 +49,8 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.template.response import TemplateResponse
     from wagtail.admin.panels import Panel
+
+    from cms.users.models import User
 
 
 logger = logging.getLogger(__name__)
@@ -121,6 +126,31 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
         """Returns the summary of the latest article in the series."""
         # TODO: update to include drafts when looking at previews holistically.
         return latest.summary if (latest := self.get_latest()) else ""
+
+    @transaction.atomic
+    def save(  # type: ignore[override]
+        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
+    ) -> ArticleSeriesPage | None:
+        # typing ignored as we need TypedDict but mypy struggles with it
+        original_values = None  # typing: ignore[var-annotated]
+        if self.pk:
+            original_values = ArticleSeriesPage.objects.values("title", "slug").filter(pk=self.pk).first()
+
+        instance: ArticleSeriesPage | None = super().save(  # type: ignore[call-arg]
+            clean=clean, user=user, log_action=log_action, **kwargs
+        )
+
+        if original_values and self.title != original_values["title"] and self.slug == original_values["slug"]:
+            # The title has changed, but not the slug.
+            # The slug change is already handled by the `page_slug_changed` signal.
+            transaction.on_commit(
+                lambda: series_title_changed.send(
+                    sender=self.__class__,
+                    instance=self,
+                )
+            )
+
+        return instance
 
     def get_latest(self) -> StatisticalArticlePage | None:
         latest: StatisticalArticlePage | None = (
@@ -221,6 +251,15 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
     def download_table_with_version(self, request: HttpRequest, slug: str, version: int, table_id: str) -> HttpResponse:
         response: HttpResponse = self.release(request, slug, version=version, table_id=table_id)
         return response
+
+    def get_cached_paths(self) -> Generator[str]:
+        yield "/"
+        yield "/related-data"
+        yield "/editions"
+        # ensure we always account for ?page=1
+        pages = max(1, ceil(self.get_children().live().public().count() / settings.PREVIOUS_RELEASES_PER_PAGE))
+        for page_number in range(1, pages + 1):
+            yield f"/editions?page={page_number}"
 
 
 # pylint: disable=too-many-public-methods
@@ -906,3 +945,12 @@ class StatisticalArticlePage(  # type: ignore[django-manager-missing]
         summary_word_count = len(strip_tags(self.summary).split())
 
         return title_word_count + summary_word_count + content_word_count
+
+    def get_cached_paths(self) -> Generator[str]:
+        yield "/"
+        yield "/related-data"  # always include, should a correction remove related datasets
+        if self.datasets:
+            for page_number in range(1, ceil(len(self.datasets) / settings.RELATED_DATASETS_PER_PAGE) + 1):
+                yield f"/related-data?page={page_number}"
+
+        yield from self.get_downloadable_block_paths()

--- a/cms/articles/signals.py
+++ b/cms/articles/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+series_title_changed = Signal()

--- a/cms/articles/signals.py
+++ b/cms/articles/signals.py
@@ -1,3 +1,0 @@
-from django.dispatch import Signal
-
-series_title_changed = Signal()

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -626,7 +626,10 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
         self.assertEqual(self.page.analytics_content_type, "articles")
 
     def test_get_cached_paths(self):
-        self.assertEqual(list(self.page.get_cached_paths()), ["/", "/related-data"])
+        self.assertEqual(
+            list(self.page.get_cached_paths()),
+            ["/", "/related-data", "/related-data?page=1", "/related-data?page=2"],
+        )
 
     def test_get_cached_paths__with_related_data_pages(self):
         dataset = DatasetFactory()
@@ -635,11 +638,22 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
             stream_data=[("dataset_lookup", dataset)] * 6,
         )
 
-        expected = ["/", "/related-data", "/related-data?page=1"]
-        self.assertEqual(list(self.page.get_cached_paths()), expected)
+        with override_settings(CMS_PAGINATION_OVER_PURGE=2):
+            expected = ["/", "/related-data", "/related-data?page=1", "/related-data?page=2", "/related-data?page=3"]
+            self.assertEqual(list(self.page.get_cached_paths()), expected)
 
-        with override_settings(RELATED_DATASETS_PER_PAGE=3):
-            self.assertEqual(list(self.page.get_cached_paths()), [*expected, "/related-data?page=2"])
+            with override_settings(RELATED_DATASETS_PER_PAGE=3):
+                self.assertEqual(
+                    list(self.page.get_cached_paths()),
+                    [
+                        "/",
+                        "/related-data",
+                        "/related-data?page=1",
+                        "/related-data?page=2",
+                        "/related-data?page=3",
+                        "/related-data?page=4",
+                    ],
+                )
 
     def test_get_cached_paths__with_downloadable_blocks(self):
         self.page.content = [
@@ -676,7 +690,14 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             list(self.page.get_cached_paths()),
-            ["/", "/related-data", "/download-table/test-table-id", "/download-chart/test-chart-id"],
+            [
+                "/",
+                "/related-data",
+                "/related-data?page=1",
+                "/related-data?page=2",
+                "/download-table/test-table-id",
+                "/download-chart/test-chart-id",
+            ],
         )
 
 

--- a/cms/articles/tests/test_article_models.py
+++ b/cms/articles/tests/test_article_models.py
@@ -625,6 +625,60 @@ class StatisticalArticlePageTestCase(WagtailTestUtils, TestCase):
         """Test that the GTM content type is 'articles'."""
         self.assertEqual(self.page.analytics_content_type, "articles")
 
+    def test_get_cached_paths(self):
+        self.assertEqual(list(self.page.get_cached_paths()), ["/", "/related-data"])
+
+    def test_get_cached_paths__with_related_data_pages(self):
+        dataset = DatasetFactory()
+        self.page.datasets = StreamValue(
+            DatasetStoryBlock(),
+            stream_data=[("dataset_lookup", dataset)] * 6,
+        )
+
+        expected = ["/", "/related-data", "/related-data?page=1"]
+        self.assertEqual(list(self.page.get_cached_paths()), expected)
+
+        with override_settings(RELATED_DATASETS_PER_PAGE=3):
+            self.assertEqual(list(self.page.get_cached_paths()), [*expected, "/related-data?page=2"])
+
+    def test_get_cached_paths__with_downloadable_blocks(self):
+        self.page.content = [
+            {
+                "type": "section",
+                "value": {
+                    "title": "Content",
+                    "content": [
+                        {
+                            "id": "test-table-id",
+                            "type": "table",
+                            "value": make_table_block_value(
+                                title="Test Table 1",
+                                caption="Table caption 1",
+                                source="Test Source",
+                                headers=[["Header 1"]],
+                                rows=[["Row 1 Col 1"]],
+                            ),
+                        },
+                        {
+                            "id": "test-chart-id",
+                            "type": "line_chart",
+                            "value": {
+                                "title": "Test Chart",
+                                "subtitle": "Chart subtitle",
+                                "theme": "primary",
+                                "tabletable": TableDataFactory(table_data=[["", "Series 0"], ["2004", "100"]]),
+                            },
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertEqual(
+            list(self.page.get_cached_paths()),
+            ["/", "/related-data", "/download-table/test-table-id", "/download-chart/test-chart-id"],
+        )
+
 
 class StatisticalArticlePageRenderTestCase(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/cms/bundles/tests/test_management_commands.py
+++ b/cms/bundles/tests/test_management_commands.py
@@ -16,10 +16,12 @@ from cms.bundles.management.commands.publish_bundles import Command as PublishBu
 from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory, BundlePageFactory
 from cms.core.tests import TransactionTestCase
 from cms.datasets.tests.factories import DatasetFactory
+from cms.frontend_cache.cache import get_page_cached_urls
 from cms.home.models import HomePage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import executor_stop_and_wait, flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.workflows.models import ReadyToPublishGroupTask
@@ -188,7 +190,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(alias.live)
 
         alias_actions = PostPublishAction.objects.filter(page=alias)
-        self.assertEqual(alias_actions.count(), 2)
+        self.assertEqual(alias_actions.count(), len(get_post_publish_actions()))
         for action in alias_actions:
             self.assertEqual(action.bundle_id, self.bundle.pk)
             self.assertEqual(action.status, PostPublishActionStatus.SUCCESSFUL)
@@ -199,6 +201,38 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         }
 
         self.assertIn(alias.pk, published_page_ids)
+
+    @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    @patch("cms.bundles.utils.notify_slack_of_publication_start")
+    @patch("cms.bundles.utils.notify_slack_of_publish_end")
+    @patch("cms.post_publish_actions.utils.notify_slack_of_post_publish_end")
+    @patch("cms.search.signal_handlers.get_publisher")
+    def test_publish_bundle_purges_the_frontend_cache(
+        self,
+        mock_get_publisher,  # pylint: disable=unused-argument
+        mock_notify_post_publish_end,  # pylint: disable=unused-argument
+        mock_notify_end,  # pylint: disable=unused-argument
+        mock_notify_start,  # pylint: disable=unused-argument
+        mock_purge_urls,
+    ):
+        BundlePageFactory(parent=self.bundle, page=self.statistical_article)
+        mark_page_as_ready_to_publish(self.statistical_article)
+
+        self.call_command()
+
+        executor_stop_and_wait()
+
+        action = PostPublishAction.objects.get(
+            page=self.statistical_article, action_type=PostPublishActionType.CACHE_PURGE
+        )
+        self.assertEqual(action.bundle_id, self.bundle.pk)
+        self.assertEqual(action.status, PostPublishActionStatus.SUCCESSFUL)
+
+        self.statistical_article.refresh_from_db()
+        purged_urls = set().union(*(call.args[0] for call in mock_purge_urls.call_args_list))
+
+        self.assertTrue(set(get_page_cached_urls(self.statistical_article)).issubset(purged_urls))
 
     @override_settings(SLACK_NOTIFICATIONS_WEBHOOK_URL="https://slack.example.com")
     @patch("cms.bundles.utils.notify_slack_of_publication_start")
@@ -259,7 +293,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         failed_action = PostPublishAction.objects.finished().filter(status=PostPublishActionStatus.FAILED).get()
 
@@ -299,7 +333,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 
@@ -338,7 +372,7 @@ class PublishBundlesCommandTestCase(TransactionTestCase):
         self.assertTrue(mock_notify_post_publish_end.called)
 
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 

--- a/cms/bundles/tests/test_utils.py
+++ b/cms/bundles/tests/test_utils.py
@@ -29,6 +29,7 @@ from cms.methodology.models import MethodologyPage
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.models import ReleaseCalendarPage
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.standard_pages.models import IndexPage, InformationPage
@@ -676,7 +677,10 @@ class PublishBundleFailureTests(TestCase):
         with self.assertRaises(PostPublishAction.DoesNotExist):
             invalid_action.refresh_from_db()
 
-        self.assertEqual(PostPublishAction.objects.filter(bundle=bundle, page=page_will_publish).count(), 2)
+        self.assertEqual(
+            PostPublishAction.objects.filter(bundle=bundle, page=page_will_publish).count(),
+            len(get_post_publish_actions()),
+        )
 
         self.assertTrue(
             PostPublishAction.objects.filter(

--- a/cms/bundles/tests/test_viewsets.py
+++ b/cms/bundles/tests/test_viewsets.py
@@ -35,6 +35,7 @@ from cms.datasets.tests.factories import DatasetFactory
 from cms.methodology.tests.factories import MethodologyPageFactory
 from cms.post_publish_actions.executor import executor_stop_and_wait, flush_executor
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
+from cms.post_publish_actions.registry import get_post_publish_actions
 from cms.release_calendar.enums import ReleaseStatus
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.release_calendar.viewsets import FutureReleaseCalendarChooserWidget
@@ -722,7 +723,7 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
         self.bundle.save(update_fields=["status", "publication_date"])
         self.post_with_action_and_test("action-publish", BundleStatus.PUBLISHED, self.bundle_index_url)
 
-        expected_action_count = 2
+        expected_action_count = len(get_post_publish_actions())
         deadline = time.monotonic() + 2.5
         while time.monotonic() < deadline and PostPublishAction.objects.finished().count() < expected_action_count:
             time.sleep(0.1)
@@ -752,9 +753,9 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
 
         mock_get_publisher.assert_called()
 
-        self.assertEqual(PostPublishAction.objects.count(), 2)
+        self.assertEqual(PostPublishAction.objects.count(), len(get_post_publish_actions()))
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 
@@ -775,9 +776,9 @@ class BundleViewSetPublishTestCase(BundleViewSetTestCaseMixin, TransactionTestCa
 
         mock_get_publisher.assert_called()
 
-        self.assertEqual(PostPublishAction.objects.count(), 2)
+        self.assertEqual(PostPublishAction.objects.count(), len(get_post_publish_actions()))
         self.assertEqual(PostPublishAction.objects.unfinished().count(), 0)
-        self.assertEqual(PostPublishAction.objects.finished().count(), 2)
+        self.assertEqual(PostPublishAction.objects.finished().count(), len(get_post_publish_actions()))
 
         action = PostPublishAction.objects.get(action_type=PostPublishActionType.SEARCH_UPDATED)
 

--- a/cms/core/blocks/markup.py
+++ b/cms/core/blocks/markup.py
@@ -297,15 +297,21 @@ class ONSTableBlock(TinyTableBlock):
         return self._build_table_download_url(page, block_id, parent_context.get("superseded_version"))
 
     @staticmethod
-    def _build_table_download_url(page: Any, block_id: str, superseded_version: int | None = None) -> str:
-        """Build table download URL for published pages."""
-        base_url = page.url.rstrip("/")
+    def _build_download_path_fragment(block_id: str, superseded_version: int | None = None) -> str:
+        """Build the table download URL path portion for published pages."""
         version_part = f"/versions/{superseded_version}" if superseded_version is not None else ""
-        return f"{base_url}{version_part}/download-table/{block_id}"
+        return f"{version_part}/download-table/{block_id}"
+
+    @staticmethod
+    def _build_table_download_url(page: Any, block_id: str, superseded_version: int | None = None) -> str:
+        """Build the table download URL for published pages."""
+        base_url = page.url.rstrip("/")
+        download_fragment = ONSTableBlock._build_download_path_fragment(block_id, superseded_version)
+        return f"{base_url}{download_fragment}"
 
     @staticmethod
     def _build_preview_table_download_url(page: Any, block_id: str, request: Any = None) -> str:
-        """Build table download URL for preview mode."""
+        """Build the table download URL for preview mode."""
         revision_id = None
         if request and hasattr(request, "resolver_match") and request.resolver_match:
             revision_id = request.resolver_match.kwargs.get("revision_id")

--- a/cms/core/cache.py
+++ b/cms/core/cache.py
@@ -9,10 +9,10 @@ from django.core.cache import InvalidCacheBackendError, caches
 from django.core.exceptions import ImproperlyConfigured
 from django.views.decorators.cache import cache_control
 from django_redis.cache import RedisCache
-from wagtail.contrib.frontend_cache.utils import purge_url_from_cache
-from wagtail.models import Site
 
 logger = logging.getLogger(__name__)
+
+memory_cache = partial(cache_memoize, cache_alias="memory")
 
 
 class InvalidateReplayRedisCache(RedisCache):
@@ -46,15 +46,6 @@ class InvalidateReplayRedisCache(RedisCache):
         super().delete_many(keys, version)
 
 
-def purge_cache_on_all_sites(path: str) -> None:
-    """Purge the given path on all defined sites."""
-    if settings.DEBUG:
-        return
-
-    for site in Site.objects.all():
-        purge_url_from_cache(site.root_url.rstrip("/") + path)
-
-
 def get_default_cache_control_kwargs() -> dict[str, int | bool]:
     """Get cache control parameters used by the cache control decorators
     used by default on most pages. These parameters are meant to be
@@ -76,6 +67,3 @@ def get_default_cache_control_decorator() -> Callable:
     """
     cache_control_kwargs = get_default_cache_control_kwargs()
     return cache_control(**cache_control_kwargs)
-
-
-memory_cache = partial(cache_memoize, cache_alias="memory")

--- a/cms/core/models/base.py
+++ b/cms/core/models/base.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import transaction
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -20,6 +21,7 @@ from cms.core.cache import get_default_cache_control_decorator
 from cms.core.forms import DeduplicateTopicsAdminForm, ONSCopyForm
 from cms.core.permission_testers import BasePagePermissionTester
 from cms.core.query import order_by_pk_position
+from cms.core.signals import page_title_changed
 from cms.locale.utils import get_mapped_site_root_paths
 from cms.taxonomy.mixins import ExclusiveTaxonomyMixin
 
@@ -114,6 +116,29 @@ class BasePage(PageLDMixin, ListingFieldsMixin, SocialFieldsMixin, Page):  # typ
     def permissions_for_user(self, user: User) -> BasePagePermissionTester:
         """Override the permission tester class to use for our page models."""
         return BasePagePermissionTester(user, self)
+
+    @transaction.atomic
+    def save(  # type: ignore[override]
+        self, clean: bool = True, user: User | None = None, log_action: bool = False, **kwargs: Any
+    ) -> Self | None:
+        update_fields = kwargs.get("update_fields")
+        # Determine if the title field is being updated and fetch the original title if it exists.
+        # If update_fields is None, no field restrictions are applied, so the title could be updated.
+        title_is_persisted = update_fields is None or "title" in update_fields
+        original_title = (
+            type(self).objects.values_list("title", flat=True).filter(pk=self.pk).first()
+            if self.pk and title_is_persisted
+            else None
+        )
+
+        instance: Self | None = super().save(  # type: ignore[call-arg]
+            clean=clean, user=user, log_action=log_action, **kwargs
+        )
+
+        if original_title is not None and self.title != original_title:
+            transaction.on_commit(lambda: page_title_changed.send(sender=type(self), instance=self))
+
+        return instance
 
     @cached_property
     def related_pages(self) -> PageQuerySet:

--- a/cms/core/signals.py
+++ b/cms/core/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+# Sent when a persisted page title changes.
+page_title_changed = Signal()

--- a/cms/data_downloads/mixins.py
+++ b/cms/data_downloads/mixins.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from django.http import Http404, HttpResponse
 from wagtail.contrib.routable_page.models import path
 
+from cms.core.blocks import ONSTableBlock
 from cms.core.blocks.constants import CHART_BLOCK_TYPES, TABLE_BLOCK_TYPES
 from cms.data_downloads.utils import (
     create_data_csv_download_response_from_data,
@@ -13,6 +14,7 @@ from cms.data_downloads.utils import (
     get_csv_download_filename,
     get_table_csv_download_title,
 )
+from cms.datavis.blocks.base import BaseChartBlock
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -62,6 +64,33 @@ class DataDownloadMixin:
             ):
                 return dict(content_block.value)
         return {}
+
+    def _get_downloadable_blocks(self) -> list[tuple[str, str]]:
+        blocks: list[tuple[str, str]] = []
+
+        for content_block in self._iter_content_blocks():
+            if content_block.id is not None and (
+                content_block.block_type in TABLE_BLOCK_TYPES or content_block.block_type in CHART_BLOCK_TYPES
+            ):
+                block_type: str = content_block.block_type
+                block_id: str = content_block.id
+                blocks.append((block_type, block_id))
+
+        return blocks
+
+    def get_downloadable_block_paths(self) -> list[str]:
+        paths: list[str] = []
+
+        for block_type, block_id in self._get_downloadable_blocks():
+            block_path = ""
+            if block_type in TABLE_BLOCK_TYPES:
+                block_path = ONSTableBlock._build_download_path_fragment(block_id)  # pylint: disable=protected-access
+            elif block_type in CHART_BLOCK_TYPES:
+                block_path = BaseChartBlock._build_download_path_fragment(block_id)  # pylint: disable=protected-access
+            if block_path:
+                paths.append(block_path)
+
+        return paths
 
     def get_table(self, table_id: str) -> dict[str, Any]:
         """Finds a table block by its unique block ID in content.

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -400,6 +400,12 @@ class BaseChartBlock(BaseVisualisationBlock):
         }
 
     @staticmethod
+    def _build_download_path_fragment(block_id: str, superseded_version: int | None = None) -> str:
+        """Build the chart download URL path portion for published pages."""
+        version_part = f"/versions/{superseded_version}" if superseded_version is not None else ""
+        return f"{version_part}/download-chart/{block_id}"
+
+    @staticmethod
     def _build_chart_download_url(page: BasePage, block_id: str, superseded_version: int | None = None) -> str:
         """Build the chart download URL, handling versioned pages.
 
@@ -412,12 +418,8 @@ class BaseChartBlock(BaseVisualisationBlock):
             The URL to download the chart data as CSV.
         """
         base_url = page.url.rstrip("/")
-        version_part = ""
-
-        if superseded_version is not None:
-            version_part = f"/versions/{superseded_version}"
-
-        return f"{base_url}{version_part}/download-chart/{block_id}"
+        download_fragment = BaseChartBlock._build_download_path_fragment(block_id, superseded_version)
+        return f"{base_url}{download_fragment}"
 
     @staticmethod
     def _build_preview_chart_download_url(page: BasePage, block_id: str, request: HttpRequest | None = None) -> str:

--- a/cms/frontend_cache/apps.py
+++ b/cms/frontend_cache/apps.py
@@ -1,0 +1,16 @@
+from django.apps import AppConfig
+
+
+class FrontendCacheAppConfig(AppConfig):
+    name = "cms.frontend_cache"
+
+    def ready(self) -> None:
+        from .signal_handlers import (  # pylint: disable=import-outside-toplevel
+            disconnect_signal_handlers,
+            register_signal_handlers,
+        )
+
+        # Disconnect the core front-end cache signal handlers as we handle them with specific logic
+        disconnect_signal_handlers()
+        # And connect our handlers
+        register_signal_handlers()

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -1,0 +1,267 @@
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+from django.db.models import IntegerField, Q
+from django.db.models.functions import Cast
+from wagtail.contrib.frontend_cache.utils import purge_urls_from_cache
+from wagtail.coreutils import get_dummy_request
+from wagtail.models import Locale, Page, ReferenceIndex, Site
+
+from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
+from cms.methodology.models import MethodologyPage
+from cms.standard_pages.models import InformationPage
+from cms.topics.models import TopicPage
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+    from wagtail.query import PageQuerySet
+
+
+def _normalise_trailing_slash(url: str) -> str:
+    """Add or strip the trailing slash on a URL's path according to WAGTAIL_APPEND_SLASH."""
+    path, separator, query = url.partition("?")
+    path = (path if path.endswith("/") else f"{path}/") if settings.WAGTAIL_APPEND_SLASH else path.rstrip("/")
+    return f"{path}{separator}{query}"
+
+
+def get_page_cached_urls(page: Page, cache_object: Any | None = None) -> list[str]:
+    """This is a modified version of core's get_page_cached_urls that honours the WAGTAIL_APPEND_SLASH setting.
+
+    See https://github.com/wagtail/wagtail/issues/13920
+    """
+    if (page_url := page.get_full_url(request=cache_object)) is None:
+        # nothing to be done if the page has no routable URL
+        return []
+
+    base_url = page_url.rstrip("/")
+    return [
+        _normalise_trailing_slash(f"{base_url}/{path.lstrip('/')}")
+        for path in page.specific_deferred.get_cached_paths()
+    ]
+
+
+def purge_cache_on_all_sites(path: str) -> None:
+    """Purge the given path on all defined sites."""
+    if settings.DEBUG:
+        return
+
+    urls = [site.root_url.rstrip("/") + path for site in Site.objects.all()]
+    purge_urls_from_cache(urls)
+
+
+def get_urls_featuring_object(obj: Model) -> set[str]:
+    """For a single model instance, return a set of URLs that make use of the instance in some way.
+
+    This includes URLs for:
+    -   Pages that directly reference the object (e.g. via relationship fields
+        or StreamField blocks)
+
+    NOTE: To find urls for featuring multiple objects of the same type, use `get_urls_featuring_objects` instead.
+    """
+    return get_urls_featuring_objects([obj])
+
+
+def get_urls_featuring_objects(objects: list[Model]) -> set[str]:
+    """For multiple instances of the same model, return a set of URLs that make use of them in some way.
+
+    This includes URLs for:
+    -   Pages that directly reference the objects (e.g. via relationship fields
+        or StreamField blocks)
+    """
+    urls: set[str] = set()
+
+    if not objects:
+        return urls
+
+    object_ids = [int(obj.pk) for obj in objects]
+
+    if isinstance(objects[0], Page):
+        to_content_type_model = "page"
+        to_content_type_app_label = "wagtailcore"
+    else:
+        to_content_type_model = objects[0]._meta.model_name.lower()  # type: ignore[union-attr]
+        to_content_type_app_label = objects[0]._meta.app_label.lower()
+
+    page_ids = (
+        ReferenceIndex.objects.filter(
+            base_content_type__model="page",
+            base_content_type__app_label="wagtailcore",
+            to_content_type__model=to_content_type_model,
+            to_content_type__app_label=to_content_type_app_label,
+            to_object_id__in=object_ids,
+        )
+        .annotate(page_id=Cast("object_id", output_field=IntegerField()))
+        .values_list("page_id", flat=True)
+    )
+
+    for page in (
+        Page.objects.filter(Q(id__in=page_ids) | Q(alias_of__in=page_ids)).specific(defer=True).live().iterator()
+    ):
+        urls.update(get_page_cached_urls(page))
+
+    return urls
+
+
+def get_related_topic_page_urls(page: Page, topic_ids: list[str] | None = None) -> set[str]:
+    if page.alias_of_id is not None:
+        # skip if the given page is an alias. Aliases are not published directly, but
+        # via their source page, which then accounts for related topics and their aliases.
+        return set()
+
+    parent_topic = TopicPage.objects.ancestor_of(page).only("pk", "url_path").first()
+    urls = set(get_page_cached_urls(parent_topic))
+
+    topic_terms = topic_ids or getattr(page, "topic_ids", [])
+    related_topic_pages = (
+        TopicPage.objects.filter(topic__in=topic_terms).exclude(pk=parent_topic.pk).live().only("pk", "url_path")
+    )
+
+    # include parent topic translation aliases
+    aliases = parent_topic.get_translations().filter(alias_of__isnull=False).specific().only("pk", "url_path")
+    for parent_topic_alias in aliases:
+        urls.update(get_page_cached_urls(parent_topic_alias))
+        related_topic_pages = related_topic_pages.exclude(pk=parent_topic_alias.pk)
+
+    for topic_page in related_topic_pages:
+        urls.update(get_page_cached_urls(topic_page))
+
+    return urls
+
+
+def get_topic_pages_featuring_series(
+    statistical_article: StatisticalArticlePage, article_series: ArticleSeriesPage
+) -> set[str]:
+    """Returns the list of topic page URLs that feature the given statistical article series."""
+    urls: set[str] = set()
+
+    if not statistical_article.is_latest:
+        return urls
+
+    topic_page_ids = []
+    # Get the series topic path and exclude it as we handle the parent topic separately.
+    # url_path is in the form: /home/topic/articles/series/ so this becomes /home/topic/
+    parent_topic_path = "/".join(article_series.url_path.rstrip("/").split("/")[:-2]) + "/"
+    featured_on_topics_qs: PageQuerySet = article_series.featured_on_topic.exclude(url_path=parent_topic_path)
+    for topic_page in featured_on_topics_qs.live().only("pk", "url_path"):
+        urls.update(get_page_cached_urls(topic_page))
+        topic_page_ids.append(topic_page.pk)
+
+    for topic_page_alias in TopicPage.objects.filter(alias_of__in=topic_page_ids).only("pk", "url_path"):
+        urls.update(get_page_cached_urls(topic_page_alias))
+
+    return urls
+
+
+def _get_other_language_alias_urls(source_page_ids: set) -> set[str]:
+    urls = set()
+    # Include other language aliases in this too.
+    # Also, since we don't have a request here, get a dummy one for the other language pages.
+    other_locale_ids = Locale.objects.exclude(pk=Locale.get_default().pk).values_list("pk", flat=True)
+    for locale_id in other_locale_ids:
+        cache_object = get_dummy_request(site=Site.objects.filter(root_page__locale=locale_id).first())
+        if cache_object is None:
+            # If no site exists for this locale, skip it
+            continue
+        for alias in Page.objects.filter(locale=locale_id, alias_of__in=source_page_ids).specific().iterator():
+            urls.update(get_page_cached_urls(alias, cache_object=cache_object))
+
+    return urls
+
+
+def get_old_page_slugs(page: Page, page_old: Page) -> set[str]:
+    urls: set = set()
+    if page.url_path == page_old.url_path:
+        return urls
+
+    url_path_length = len(page.url_path)
+
+    # include the old page URL
+    urls = set(get_page_cached_urls(page_old))
+    source_page_ids = {page_old.pk}
+
+    for descendant in page.get_descendants().live().defer_streamfields().specific().iterator():
+        source_page_ids.add(descendant.pk)
+        descendant.url_path = page_old.url_path + descendant.url_path[url_path_length:]
+
+        urls.update(get_page_cached_urls(descendant))
+
+    return urls
+
+
+def purge_page_from_frontend_cache(page: Page) -> None:
+    # get the page urls
+    urls = set(get_page_cached_urls(page))
+
+    # expand to custom logic
+    if isinstance(page, StatisticalArticlePage):
+        series_page = page.get_parent().specific_deferred
+        urls.update(get_page_cached_urls(series_page))
+        urls.update(get_related_topic_page_urls(series_page))
+        urls.update(get_topic_pages_featuring_series(page, series_page))
+    elif isinstance(page, MethodologyPage):
+        urls.update(get_related_topic_page_urls(page))
+    elif isinstance(page, InformationPage):
+        urls.update(get_page_cached_urls(page.get_parent().specific_deferred))
+
+    urls.update(get_urls_featuring_object(page))
+    purge_urls_from_cache(urls)
+
+
+def purge_old_page_slugs_from_frontend_cache(page: Page, page_old: Page) -> None:
+    if urls := get_old_page_slugs(page, page_old):
+        purge_urls_from_cache(urls)
+
+
+def purge_old_page_paths_from_cache_after_move(
+    page: Page, parent_page_before: Page, parent_page_after: Page, url_path_before: str
+) -> None:
+    if page.url_path == url_path_before:
+        # This is a page 'reorder' within the same parent. No need for further processing
+        return
+
+    # Simulate an 'old_page' by copying the specific instance and resetting
+    # the in-memory `url_path` value to what it was before the move
+    old_page = type(page)()
+    old_page.__dict__.update(page.__dict__)
+    old_page.url_path = url_path_before
+
+    urls = get_old_page_slugs(page, old_page)
+    if isinstance(page, StatisticalArticlePage):
+        urls.update(get_page_cached_urls(parent_page_before))  # old series
+        urls.update(get_related_topic_page_urls(parent_page_before))  # old topic
+
+        urls.update(get_page_cached_urls(parent_page_after))  # new series
+        urls.update(get_related_topic_page_urls(parent_page_after))  # new topic
+    elif isinstance(page, ArticleSeriesPage):
+        urls.update(get_related_topic_page_urls(page))
+        # the parent is the article index so doesn't have any topic IDs.
+        urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=page.topic_ids))
+    elif isinstance(page, MethodologyPage):
+        urls.update(get_related_topic_page_urls(page))
+        urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=page.topic_ids))
+    elif isinstance(page, InformationPage):
+        urls.update(get_page_cached_urls(parent_page_before))
+        urls.update(get_page_cached_urls(parent_page_after))
+
+    if urls:
+        purge_urls_from_cache(urls)
+
+
+def purge_series_children_from_cache(page: ArticleSeriesPage) -> None:
+    # when an article series title changes, we want to purge all child articles too
+    # so they get the updated title
+    urls = set()
+    source_page_ids = set()
+    for child in page.get_descendants().live().specific(defer=True).iterator():
+        source_page_ids.add(child.pk)
+        urls.update(get_page_cached_urls(child))
+
+    urls |= _get_other_language_alias_urls(source_page_ids)
+
+    if urls:
+        purge_urls_from_cache(urls)
+
+
+def purge_page_containing_snippet_from_cache(obj: Model) -> None:
+    if urls := get_urls_featuring_object(obj):
+        purge_urls_from_cache(urls)

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -260,9 +260,10 @@ def purge_old_page_paths_from_cache_after_move(
         purge_urls_from_cache(urls)
 
 
-def purge_series_children_from_cache(page: ArticleSeriesPage) -> None:
-    # when an article series title changes, we want to purge all child articles too
-    # so they get the updated title
+def purge_descendants_from_cache(page: Page) -> None:
+    # when a page's title changes, we want to purge all descendant pages too, as they
+    # display the title in their breadcrumbs (e.g. an article series title on its editions,
+    # or a topic title on the articles and methodologies beneath it)
     urls = set()
     source_page_ids = set()
     for child in page.get_descendants().live().specific(defer=True).iterator():

--- a/cms/frontend_cache/cache.py
+++ b/cms/frontend_cache/cache.py
@@ -7,8 +7,8 @@ from wagtail.contrib.frontend_cache.utils import purge_urls_from_cache
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Page, ReferenceIndex, Site
 
-from cms.articles.models import ArticleSeriesPage, StatisticalArticlePage
-from cms.methodology.models import MethodologyPage
+from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage, StatisticalArticlePage
+from cms.methodology.models import MethodologyIndexPage, MethodologyPage
 from cms.standard_pages.models import InformationPage
 from cms.topics.models import TopicPage
 
@@ -108,7 +108,9 @@ def get_related_topic_page_urls(page: Page, topic_ids: list[str] | None = None) 
         # via their source page, which then accounts for related topics and their aliases.
         return set()
 
-    parent_topic = TopicPage.objects.ancestor_of(page).only("pk", "url_path").first()
+    # inclusive=True so this also works when `page` is itself the TopicPage (e.g. when an index page
+    # moved directly between topics and `page` here is the old/new topic parent)
+    parent_topic = TopicPage.objects.ancestor_of(page, inclusive=True).only("pk", "url_path").first()
     urls = set(get_page_cached_urls(parent_topic))
 
     topic_terms = topic_ids or getattr(page, "topic_ids", [])
@@ -152,12 +154,11 @@ def get_topic_pages_featuring_series(
     return urls
 
 
-def _get_other_language_alias_urls(source_page_ids: set) -> set[str]:
+def _get_alias_urls(source_page_ids: set) -> set[str]:
     urls = set()
-    # Include other language aliases in this too.
-    # Also, since we don't have a request here, get a dummy one for the other language pages.
-    other_locale_ids = Locale.objects.exclude(pk=Locale.get_default().pk).values_list("pk", flat=True)
-    for locale_id in other_locale_ids:
+    # Include aliases in any locale (same-locale copies as well as other-language translations).
+    # Since we don't have a request here, get a dummy one for each locale's site.
+    for locale_id in Locale.objects.values_list("pk", flat=True):
         cache_object = get_dummy_request(site=Site.objects.filter(root_page__locale=locale_id).first())
         if cache_object is None:
             # If no site exists for this locale, skip it
@@ -242,6 +243,18 @@ def purge_old_page_paths_from_cache_after_move(
     elif isinstance(page, InformationPage):
         urls.update(get_page_cached_urls(parent_page_before))
         urls.update(get_page_cached_urls(parent_page_after))
+    elif isinstance(page, ArticlesIndexPage):
+        # the index itself moved between topics, taking its series/articles with it
+        for series in page.get_children().live().type(ArticleSeriesPage).specific():
+            urls.update(get_related_topic_page_urls(series))
+            urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=series.topic_ids))
+            if latest := StatisticalArticlePage.objects.child_of(series).live().order_by("-release_date").first():
+                urls.update(get_topic_pages_featuring_series(latest, series))
+    elif isinstance(page, MethodologyIndexPage):
+        # the index itself moved between topics, taking its methodology pages with it
+        for methodology_page in page.get_children().live().type(MethodologyPage).specific():
+            urls.update(get_related_topic_page_urls(methodology_page))
+            urls.update(get_related_topic_page_urls(parent_page_before, topic_ids=methodology_page.topic_ids))
 
     if urls:
         purge_urls_from_cache(urls)
@@ -256,7 +269,7 @@ def purge_series_children_from_cache(page: ArticleSeriesPage) -> None:
         source_page_ids.add(child.pk)
         urls.update(get_page_cached_urls(child))
 
-    urls |= _get_other_language_alias_urls(source_page_ids)
+    urls |= _get_alias_urls(source_page_ids)
 
     if urls:
         purge_urls_from_cache(urls)

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -1,0 +1,121 @@
+from typing import TYPE_CHECKING, Any
+
+from django.db.models.signals import post_delete
+from wagtail.contrib.frontend_cache.signal_handlers import (
+    page_published_signal_handler,
+    page_unpublished_signal_handler,
+)
+from wagtail.contrib.redirects.signal_handlers import (
+    autocreate_redirects_on_page_move,
+    autocreate_redirects_on_slug_change,
+)
+from wagtail.models import Page, get_page_models
+from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move, published, unpublished
+
+from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage
+from cms.articles.signals import series_title_changed
+from cms.core.models import BasePage, ContactDetails, Definition
+from cms.home.models import HomePage
+from cms.methodology.models import MethodologyIndexPage
+from cms.release_calendar.models import ReleaseCalendarIndex
+
+from .cache import (
+    purge_old_page_paths_from_cache_after_move,
+    purge_old_page_slugs_from_frontend_cache,
+    purge_page_containing_snippet_from_cache,
+    purge_page_from_frontend_cache,
+    purge_series_children_from_cache,
+)
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+
+
+EXCLUDED_PAGE_TYPES = frozenset({ArticlesIndexPage, HomePage, MethodologyIndexPage, ReleaseCalendarIndex})
+
+
+def purge_published_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
+    purge_page_from_frontend_cache(instance)
+
+
+def purge_unpublished_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
+    # note: this also covers page deletion
+    # https://github.com/wagtail/wagtail/blob/228058b56775b126a91ecc4e4338366869513ea8/wagtail/signal_handlers.py#L31
+    purge_page_from_frontend_cache(instance)
+
+
+def purge_page_from_frontend_cache_after_slug_change(instance: Page, instance_before: Page, **kwargs: Any) -> None:
+    purge_old_page_slugs_from_frontend_cache(instance, instance_before)
+
+
+def purge_page_from_frontend_cache_after_move(
+    instance: Page,
+    parent_page_before: Page,
+    parent_page_after: Page,
+    url_path_before: str,
+    url_path_after: str,  # pylint: disable=unused-argument
+    **kwargs: Any,
+) -> None:
+    purge_old_page_paths_from_cache_after_move(
+        instance.specific, parent_page_before.specific_deferred, parent_page_after.specific_deferred, url_path_before
+    )
+
+
+def purges_series_children_from_frontend_cache(instance: ArticleSeriesPage, **kwargs: Any) -> None:
+    purge_series_children_from_cache(instance)
+
+
+def purge_pages_containing_the_published_snippet_from_frontend_cache(instance: Model, **kwargs: Any) -> None:
+    purge_page_containing_snippet_from_cache(instance)
+
+
+def purge_pages_containing_the_unpublished_snippet_from_frontend_cache(instance: Model, **kwargs: Any) -> None:
+    purge_page_containing_snippet_from_cache(instance)
+
+
+def purge_pages_containing_the_deleted_snippet_from_frontend_cache(
+    sender: Model,  # pylint: disable=unused-argument
+    instance: Model,
+    **kwargs: Any,
+) -> None:
+    purge_page_containing_snippet_from_cache(instance)
+
+
+def _get_tracked_page_models() -> set[Page]:
+    """Returns a list of page models that are included in the front-end cache purging.
+
+    We're excluding the following page types:
+    - HomePage as it is not served by from Wagtail. TODO: remove when switching to do that
+    - the Release Calendar, articles and methodology indexes are served by the Search service and has a short TTL
+    - the generic Page model to ensure we fully account for our exclusions.
+    """
+    return {model for model in get_page_models() if issubclass(model, BasePage) and model not in EXCLUDED_PAGE_TYPES}
+
+
+def disconnect_signal_handlers() -> None:
+    """Disconnect the core front-end cache signal handlers as we handle them with specific logic."""
+    for model in get_page_models():
+        page_published.disconnect(page_published_signal_handler, sender=model)
+        page_unpublished.disconnect(page_unpublished_signal_handler, sender=model)
+        post_page_move.disconnect(autocreate_redirects_on_page_move, sender=model)
+        page_slug_changed.disconnect(autocreate_redirects_on_slug_change, sender=model)
+
+
+def register_signal_handlers() -> None:
+    for model in _get_tracked_page_models():
+        page_published.connect(purge_published_page_from_frontend_cache, sender=model)
+        page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
+        page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
+
+    series_title_changed.connect(purges_series_children_from_frontend_cache, sender=ArticleSeriesPage)
+    post_page_move.connect(purge_page_from_frontend_cache_after_move)
+
+    for model in [ContactDetails, Definition]:
+        published.connect(purge_pages_containing_the_published_snippet_from_frontend_cache, sender=model)
+        unpublished.connect(purge_pages_containing_the_unpublished_snippet_from_frontend_cache, sender=model)
+        post_delete.connect(purge_pages_containing_the_deleted_snippet_from_frontend_cache, sender=model)
+
+    # FIXME when allowing to edit navigation
+    # - Main Menu on publish, if in nav
+    # - Footer menu on publish, if in nav
+    # - Nav save, if there are changes

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -8,19 +8,19 @@ from wagtail.contrib.frontend_cache.signal_handlers import (
 from wagtail.models import Page, get_page_models
 from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move, published, unpublished
 
-from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage
-from cms.articles.signals import series_title_changed
+from cms.articles.models import ArticlesIndexPage
 from cms.core.models import BasePage, ContactDetails, Definition
+from cms.core.signals import page_title_changed
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage
 from cms.release_calendar.models import ReleaseCalendarIndex
 
 from .cache import (
+    purge_descendants_from_cache,
     purge_old_page_paths_from_cache_after_move,
     purge_old_page_slugs_from_frontend_cache,
     purge_page_containing_snippet_from_cache,
     purge_page_from_frontend_cache,
-    purge_series_children_from_cache,
 )
 
 if TYPE_CHECKING:
@@ -57,8 +57,8 @@ def purge_page_from_frontend_cache_after_move(
     )
 
 
-def purges_series_children_from_frontend_cache(instance: ArticleSeriesPage, **kwargs: Any) -> None:
-    purge_series_children_from_cache(instance)
+def purge_descendants_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
+    purge_descendants_from_cache(instance)
 
 
 def purge_pages_containing_the_published_snippet_from_frontend_cache(instance: Model, **kwargs: Any) -> None:
@@ -105,8 +105,8 @@ def register_signal_handlers() -> None:
         page_published.connect(purge_published_page_from_frontend_cache, sender=model)
         page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
         page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
+        page_title_changed.connect(purge_descendants_from_frontend_cache, sender=model)
 
-    series_title_changed.connect(purges_series_children_from_frontend_cache, sender=ArticleSeriesPage)
     post_page_move.connect(purge_page_from_frontend_cache_after_move)
 
     for model in [ContactDetails, Definition]:

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -5,10 +5,6 @@ from wagtail.contrib.frontend_cache.signal_handlers import (
     page_published_signal_handler,
     page_unpublished_signal_handler,
 )
-from wagtail.contrib.redirects.signal_handlers import (
-    autocreate_redirects_on_page_move,
-    autocreate_redirects_on_slug_change,
-)
 from wagtail.models import Page, get_page_models
 from wagtail.signals import page_published, page_slug_changed, page_unpublished, post_page_move, published, unpublished
 
@@ -93,12 +89,15 @@ def _get_tracked_page_models() -> set[Page]:
 
 
 def disconnect_signal_handlers() -> None:
-    """Disconnect the core front-end cache signal handlers as we handle them with specific logic."""
+    """Disconnect the core front-end cache signal handlers as we handle them with specific logic.
+
+    Note: wagtail.contrib.redirects connects its autocreate_redirects_on_* handlers without a
+    sender filter, so disconnecting them here with sender=model would be a no-op; they're left
+    connected intentionally so redirects keep being auto-created on slug change/page move.
+    """
     for model in get_page_models():
         page_published.disconnect(page_published_signal_handler, sender=model)
         page_unpublished.disconnect(page_unpublished_signal_handler, sender=model)
-        post_page_move.disconnect(autocreate_redirects_on_page_move, sender=model)
-        page_slug_changed.disconnect(autocreate_redirects_on_slug_change, sender=model)
 
 
 def register_signal_handlers() -> None:

--- a/cms/frontend_cache/signal_handlers.py
+++ b/cms/frontend_cache/signal_handlers.py
@@ -13,6 +13,8 @@ from cms.core.models import BasePage, ContactDetails, Definition
 from cms.core.signals import page_title_changed
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage
+from cms.post_publish_actions.models import PostPublishActionType
+from cms.post_publish_actions.registry import PostPublishActionPriority, register_post_publish_action
 from cms.release_calendar.models import ReleaseCalendarIndex
 
 from .cache import (
@@ -26,12 +28,15 @@ from .cache import (
 if TYPE_CHECKING:
     from django.db.models import Model
 
+    from cms.bundles.models import Bundle
+
 
 EXCLUDED_PAGE_TYPES = frozenset({ArticlesIndexPage, HomePage, MethodologyIndexPage, ReleaseCalendarIndex})
 
 
-def purge_published_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
-    purge_page_from_frontend_cache(instance)
+def purge_published_page_from_frontend_cache(page: Page, _bundle: Bundle | None) -> None:
+    if type(page) in _get_tracked_page_models():
+        purge_page_from_frontend_cache(page)
 
 
 def purge_unpublished_page_from_frontend_cache(instance: Page, **kwargs: Any) -> None:
@@ -77,7 +82,7 @@ def purge_pages_containing_the_deleted_snippet_from_frontend_cache(
     purge_page_containing_snippet_from_cache(instance)
 
 
-def _get_tracked_page_models() -> set[Page]:
+def _get_tracked_page_models() -> set[type[Page]]:
     """Returns a list of page models that are included in the front-end cache purging.
 
     We're excluding the following page types:
@@ -101,8 +106,16 @@ def disconnect_signal_handlers() -> None:
 
 
 def register_signal_handlers() -> None:
+    register_post_publish_action(
+        PostPublishActionType.CACHE_PURGE,
+        purge_published_page_from_frontend_cache,
+        priority=PostPublishActionPriority.MEDIUM,
+    )
+
     for model in _get_tracked_page_models():
-        page_published.connect(purge_published_page_from_frontend_cache, sender=model)
+        # These were considered for post-publish actions but not implemented for now
+        # They are rare editor actions that are currently more effort than it's worth,
+        # and won't massively benefit from being tracked as post-publish actions in the DB
         page_unpublished.connect(purge_unpublished_page_from_frontend_cache, sender=model)
         page_slug_changed.connect(purge_page_from_frontend_cache_after_slug_change, sender=model)
         page_title_changed.connect(purge_descendants_from_frontend_cache, sender=model)

--- a/cms/frontend_cache/tests/backends.py
+++ b/cms/frontend_cache/tests/backends.py
@@ -1,0 +1,10 @@
+import logging
+
+from wagtail.contrib.frontend_cache.backends import BaseBackend
+
+logger = logging.getLogger(__name__)
+
+
+class DummyFrontEndCacheBackend(BaseBackend):
+    def purge(self, url: str) -> None:
+        logger.info("Purging %s", url)

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -1,0 +1,793 @@
+from datetime import timedelta
+from unittest.mock import call, patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from wagtail.blocks import StreamValue
+from wagtail.coreutils import get_dummy_request
+from wagtail.models import Locale, Page, Site
+from wagtail.test.utils import WagtailTestUtils
+
+from cms.articles.models import ArticleSeriesPage, ArticlesIndexPage, StatisticalArticlePage
+from cms.articles.tests.factories import ArticleSeriesPageFactory, StatisticalArticlePageFactory
+from cms.core.models import ContactDetails, Definition
+from cms.datasets.blocks import DatasetStoryBlock
+from cms.datasets.tests.factories import DatasetFactory
+from cms.datavis.tests.factories import TableDataFactory, make_table_block_value
+from cms.frontend_cache.cache import get_page_cached_urls
+from cms.frontend_cache.signal_handlers import _get_tracked_page_models
+from cms.home.models import HomePage
+from cms.methodology.models import MethodologyIndexPage, MethodologyPage
+from cms.methodology.tests.factories import MethodologyPageFactory
+from cms.release_calendar.models import ReleaseCalendarPage
+from cms.standard_pages.models import CookiesPage, IndexPage, InformationPage
+from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
+from cms.taxonomy.models import GenericPageToTaxonomyTopic
+from cms.taxonomy.tests.factories import TopicFactory
+from cms.themes.models import ThemeIndexPage, ThemePage
+from cms.topics.models import TopicPage
+from cms.topics.tests.factories import TopicPageFactory
+
+
+@patch("cms.frontend_cache.cache.purge_urls_from_cache")
+class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.home_page = HomePage.objects.first()
+        cls.welsh_locale = Locale.objects.get(language_code="cy")
+
+        cls.topic_1 = TopicFactory()
+        cls.topic_2 = TopicFactory()
+
+        cls.topic_page = TopicPageFactory(title="The topic page", topic=cls.topic_1)
+        cls.topic_page.save_revision().publish()
+        cls.topic_page_translation = cls.topic_page.get_translations().first()
+
+        cls.another_topic_page = TopicPageFactory(title="Another topic page", live=False, topic=cls.topic_2)
+        cls.another_topic_page_translation = cls.another_topic_page.get_translations().first()
+
+        cls.statistical_article = StatisticalArticlePageFactory(
+            parent__parent__parent=cls.topic_page, parent__title="Article series", title="The article"
+        )
+        cls.series_page = cls.statistical_article.get_parent().specific
+        GenericPageToTaxonomyTopic.objects.create(page=cls.series_page, topic=cls.topic_2)
+
+        cls.methodology_page = MethodologyPageFactory(parent__parent=cls.topic_page, title="Methodology")
+        GenericPageToTaxonomyTopic.objects.create(page=cls.methodology_page, topic=cls.topic_2)
+
+        cls.methodology_page_translation = cls.methodology_page.copy_for_translation(
+            locale=cls.welsh_locale, copy_parents=True, alias=True
+        )
+
+        cls.index_page = IndexPageFactory(title="Index page")
+        cls.information_page = InformationPageFactory(parent=cls.index_page, title="Info page")
+
+        cls.request = get_dummy_request()
+
+        cls.series_url = cls.series_page.get_full_url(cls.request)
+        cls.series_edition_url = f"{cls.series_url}/editions"
+        cls.article_url = cls.statistical_article.get_full_url(cls.request)
+        cls.article_related_data_url = f"{cls.article_url}/related-data"
+        cls.topic_page_url = cls.topic_page.get_full_url(cls.request)
+        cls.topic_page_translation_url = cls.topic_page_translation.get_full_url(cls.request)
+        cls.another_topic_page_url = cls.another_topic_page.get_full_url(cls.request)
+        cls.another_topic_page_translation_url = cls.another_topic_page_translation.get_full_url(cls.request)
+
+        cls.methodology_page_url = cls.methodology_page.get_full_url(cls.request)
+        cls.methodology_page_translation_url = cls.methodology_page_translation.get_full_url(cls.request)
+        cls.index_page_url = cls.index_page.get_full_url(cls.request)
+        cls.information_page_url = cls.information_page.get_full_url(cls.request)
+
+        cls.superuser = cls.create_superuser(username="admin")
+
+    def _get_base_expected_statistical_page_urls_to_purge(self, with_translation_alias=True):
+        urls = {
+            self.article_url,
+            self.article_related_data_url,
+            self.series_url,
+            f"{self.series_url}/related-data",
+            self.series_edition_url,
+            f"{self.series_edition_url}?page=1",
+            self.topic_page_url,
+        }
+        if with_translation_alias:
+            urls.add(self.topic_page_translation_url)
+
+        return urls
+
+    def test_excluded_page_types(self, _patched_purge_urls):
+        self.assertEqual(
+            _get_tracked_page_models(),
+            {
+                CookiesPage,
+                IndexPage,
+                InformationPage,
+                ArticleSeriesPage,
+                StatisticalArticlePage,
+                MethodologyPage,
+                ReleaseCalendarPage,
+                TopicPage,
+                ThemePage,
+                ThemeIndexPage,
+            },
+        )
+
+    @patch("cms.frontend_cache.signal_handlers.purge_page_from_frontend_cache")
+    def test_excluded_page_types__dont_react(self, patched_purge_page, patched_purge_urls):
+        self.home_page.save_revision().publish()
+
+        patched_purge_page.assert_not_called()
+        patched_purge_urls.assert_not_called()
+
+    def test_page_publish__statistical_article(self, patched_purge_urls):
+        self.statistical_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_once_with(self._get_base_expected_statistical_page_urls_to_purge())
+
+    def test_page_publish__statistical_article__with_linked_topics(self, patched_purge_urls):
+        # Add more topics (in addition to the original two):
+        # 1. a draft topic page with a topic term that the series has -> not counted
+        # 2. a published topic with a topic term that the series has -> counted
+        topic_term_for_draft = TopicFactory()
+        TopicPageFactory(title="Draft topic page", topic=topic_term_for_draft, live=False)
+        GenericPageToTaxonomyTopic.objects.create(page=self.series_page, topic=topic_term_for_draft)
+
+        another_related_topic = TopicFactory()
+        related_topic_page = TopicPageFactory(title="Related topic page", topic=another_related_topic)
+        GenericPageToTaxonomyTopic.objects.create(page=self.series_page, topic=another_related_topic)
+
+        # now publish the two relevant topic, then our page.
+        self.another_topic_page.save_revision().publish()
+        related_topic_page.save_revision().publish()
+        patched_purge_urls.reset_mock()
+
+        self.statistical_article.save_revision().publish()
+
+        expected_urls = self._get_base_expected_statistical_page_urls_to_purge() | {
+            self.another_topic_page_url,
+            self.another_topic_page_translation_url,
+            related_topic_page.get_full_url(request=self.request),
+            related_topic_page.get_translations().first().get_full_url(request=self.request),
+        }
+        patched_purge_urls.assert_called_once_with(expected_urls)
+
+    def test_page_publish__statistical_article__and_parent_topic_with_proper_translation(self, patched_purge_urls):
+        self.topic_page_translation.alias_of = None
+        self.topic_page_translation.save_revision().publish()
+
+        self.statistical_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_with(
+            self._get_base_expected_statistical_page_urls_to_purge(with_translation_alias=False)
+        )
+
+    def test_page_publish__statistical_article_with_related_data(self, patched_purge_urls):
+        dataset = DatasetFactory()
+        self.statistical_article.datasets = StreamValue(
+            DatasetStoryBlock(),
+            stream_data=[("dataset_lookup", dataset)] * 6,
+        )
+        self.statistical_article.save_revision().publish()
+
+        expected_urls = self._get_base_expected_statistical_page_urls_to_purge()
+        expected_urls.add(f"{self.article_related_data_url}?page=1")
+        patched_purge_urls.assert_called_once_with(expected_urls)
+
+        with override_settings(RELATED_DATASETS_PER_PAGE=2):
+            self.statistical_article.save_revision().publish()
+
+            expected_urls |= {f"{self.article_related_data_url}?page=2", f"{self.article_related_data_url}?page=3"}
+            patched_purge_urls.assert_called_with(expected_urls)
+
+    def test_page_publish__statistical_article_featured_in_different_topic(self, patched_purge_urls):
+        # set up:
+        # the second topic page features the main series page, and they do not share common topics
+        self.series_page.topics.all().delete()
+        self.another_topic_page.featured_series = self.series_page
+        self.another_topic_page.save_revision().publish()
+        patched_purge_urls.reset_mock()
+
+        self.statistical_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_with(
+            # the usual urls
+            self._get_base_expected_statistical_page_urls_to_purge()
+            |
+            # the topic page that features the statistical article's series
+            {self.another_topic_page_url, self.another_topic_page_translation_url}
+        )
+
+        # now with a new article in the series
+        patched_purge_urls.reset_mock()
+        new_article = StatisticalArticlePageFactory(
+            parent=self.series_page,
+            title="New article",
+            release_date=self.statistical_article.release_date + timedelta(days=1),
+        )
+        new_article_url = new_article.get_full_url(request=self.request)
+        new_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_with(
+            {
+                # the usual urls
+                new_article_url,
+                f"{new_article_url}/related-data",
+                self.series_url,
+                f"{self.series_url}/related-data",
+                self.series_edition_url,
+                f"{self.series_edition_url}?page=1",
+                self.topic_page_url,
+                self.topic_page_translation_url,
+                # the topic page that features the statistical article's series
+                self.another_topic_page_url,
+                self.another_topic_page_translation_url,
+            }
+        )
+
+        # finally, republish the old statistical article - it should not touch the topic that features the series
+        patched_purge_urls.reset_mock()
+        self.statistical_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_with(self._get_base_expected_statistical_page_urls_to_purge())
+
+    @override_settings(PREVIOUS_RELEASES_PER_PAGE=1)
+    def test_page_publish__article_series_with_multiple_editions(self, patched_purge_urls):
+        StatisticalArticlePageFactory(parent=self.series_page, live=True)
+
+        self.series_page.save_revision().publish()
+
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.series_url,
+                f"{self.series_url}/related-data",
+                self.series_edition_url,
+                f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+            }
+        )
+
+    def test_page_publish__articles_series_changes_title(self, patched_purge_urls):
+        article_translation = self.statistical_article.copy_for_translation(
+            locale=self.welsh_locale, copy_parents=True, alias=True
+        )
+        article_translation_url = article_translation.get_full_url(self.request)
+        series_translation_url = article_translation.get_parent().specific.get_full_url(self.request)
+
+        # add a draft article to test that it is not included
+        StatisticalArticlePageFactory(parent=self.series_page, live=False)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.series_page.title = "New series"
+            self.series_page.save_revision().publish()
+
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        self.series_url,
+                        f"{self.series_url}/related-data",
+                        self.series_edition_url,
+                        f"{self.series_edition_url}?page=1",
+                    }
+                ),
+                call(
+                    {
+                        series_translation_url,
+                        f"{series_translation_url}/related-data",
+                        f"{series_translation_url}/editions",
+                        f"{series_translation_url}/editions?page=1",
+                    }
+                ),
+                call(
+                    {
+                        self.article_url,
+                        self.article_related_data_url,
+                        article_translation_url,
+                        f"{article_translation_url}/related-data",
+                    }
+                ),
+            ]
+        )
+
+    def test_page_publish__methodology(self, patched_purge_urls):
+        self.methodology_page.save_revision().publish()
+
+        self.assertEqual(patched_purge_urls.call_count, 2)
+        patched_purge_urls.assert_has_calls(
+            [
+                # the published page
+                call(
+                    {
+                        self.methodology_page_url,
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                    }
+                ),
+                # the follow-up alias page, as called by PublishPageRevisionAction
+                # https://github.com/wagtail/wagtail/blob/faadee05ca/wagtail/actions/publish_page_revision.py#L61
+                # https://github.com/wagtail/wagtail/blob/faadee05ca/wagtail/models/pages.py#L1176
+                call({self.methodology_page_translation_url}),
+            ]
+        )
+
+    def test_page_publish__methodology_and_all_linked_topics(self, patched_purge_urls):
+        # Add more topics (in addition to the original two):
+        # 1. a draft topic page with a topic term that the methodology page has -> not counted
+        # 2. a published topic with a topic term that the methodology page has -> counted
+        topic_term_for_draft = TopicFactory()
+        TopicPageFactory(title="Draft topic page", topic=topic_term_for_draft, live=False)
+        GenericPageToTaxonomyTopic.objects.create(page=self.methodology_page, topic=topic_term_for_draft)
+
+        another_related_topic = TopicFactory()
+        related_topic_page = TopicPageFactory(title="Related topic page", topic=another_related_topic)
+        GenericPageToTaxonomyTopic.objects.create(page=self.methodology_page, topic=another_related_topic)
+
+        # now publish the second topic, then our page.
+        self.another_topic_page.save_revision().publish()
+        patched_purge_urls.reset_mock()
+        self.methodology_page.save_revision().publish()
+
+        patched_purge_urls.assert_has_calls(
+            [
+                # the published page + linked
+                call(
+                    {
+                        self.methodology_page_url,
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                        related_topic_page.get_full_url(request=self.request),
+                        related_topic_page.get_translations().first().get_full_url(request=self.request),
+                    }
+                ),
+                # the alias page
+                call({self.methodology_page_translation_url}),
+            ]
+        )
+
+    def test_page_publish__information_page(self, patched_purge_urls):
+        self.information_page.save_revision().publish()
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.information_page_url,
+                self.index_page_url,
+            }
+        )
+
+    def test_page_publish__information_page__referenced_in_statistical_article(self, patched_purge_urls):
+        with self.captureOnCommitCallbacks(execute=True):
+            content = [
+                {
+                    "type": "related_links",
+                    "value": [{"page": self.information_page.pk}],
+                },
+            ]
+            self.statistical_article.content = [{"type": "section", "value": {"content": content, "title": "Section"}}]
+            self.statistical_article.save()
+
+            self.statistical_article.save_revision().publish()
+
+        self.information_page.save_revision().publish()
+        patched_purge_urls.assert_called_with(
+            {
+                self.information_page_url,
+                self.index_page_url,
+                self.article_url,
+                self.article_related_data_url,
+            }
+        )
+
+    def test_page_publish__no_special_case(self, patched_purge_urls):
+        self.index_page.save_revision().publish()
+        patched_purge_urls.assert_called_once_with({self.index_page_url})
+
+    def test_page_publish__includes_downloadable_block_urls_where_relevant(self, patched_purge_urls):
+        self.information_page.content = [
+            {
+                "type": "section",
+                "value": {
+                    "title": "Content",
+                    "content": [
+                        {
+                            "id": "test-table-id",
+                            "type": "table",
+                            "value": make_table_block_value(
+                                title="Test Table 1",
+                                caption="Table caption 1",
+                                source="Test Source",
+                                headers=[["Header 1"]],
+                                rows=[["Row 1 Col 1"]],
+                            ),
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.information_page.save_revision().publish()
+
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.information_page_url,
+                self.index_page_url,
+                f"{self.information_page_url}/download-table/test-table-id",
+            }
+        )
+
+    def test_page_publish__with_chart__includes_downloadable_block_urls_where_relevant(self, patched_purge_urls):
+        self.statistical_article.content = [
+            {
+                "type": "section",
+                "value": {
+                    "title": "Content",
+                    "content": [
+                        {
+                            "id": "test-table-id",
+                            "type": "table",
+                            "value": make_table_block_value(
+                                title="Test Table 1",
+                                caption="Table caption 1",
+                                source="Test Source",
+                                headers=[["Header 1"]],
+                                rows=[["Row 1 Col 1"]],
+                            ),
+                        },
+                        {
+                            "id": "test-chart-id",
+                            "type": "line_chart",
+                            "value": {
+                                "title": "Test Chart",
+                                "subtitle": "Chart subtitle",
+                                "theme": "primary",
+                                "tabletable": TableDataFactory(table_data=[["", "Series 0"], ["2004", "100"]]),
+                            },
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.statistical_article.save_revision().publish()
+
+        patched_purge_urls.assert_called_once_with(
+            self._get_base_expected_statistical_page_urls_to_purge()
+            | {
+                f"{self.article_url}/download-table/test-table-id",
+                f"{self.article_url}/download-chart/test-chart-id",
+            }
+        )
+
+    @patch("cms.frontend_cache.signal_handlers.purge_page_from_frontend_cache")
+    def test_page_unpublish__calls_purge_page_like_page_publish(self, patched_purge_page, _patched_purge_urls):
+        self.information_page.save_revision().publish()
+        patched_purge_page.assert_called_once_with(self.information_page)
+        patched_purge_page.reset_mock()
+
+        self.information_page.unpublish()
+        patched_purge_page.assert_called_once_with(self.information_page)
+
+    def test_page_unpublish__statistical_article(self, patched_purge_urls):
+        self.statistical_article.save_revision().publish()
+        patched_purge_urls.reset_mock()
+
+        self.statistical_article.unpublish()
+        patched_purge_urls.assert_called_once_with(self._get_base_expected_statistical_page_urls_to_purge())
+
+    def test_page_unpublish__no_special_case(self, patched_purge_urls):
+        self.index_page.unpublish()
+        patched_purge_urls.assert_called_once_with({self.index_page_url})
+
+    def test_page_delete(self, patched_purge_urls):
+        self.index_page.delete()
+
+        patched_purge_urls.assert_called_with({self.index_page_url, self.information_page_url})
+
+    def test_page_slug_changed__purges_old_descendant_urls(self, patched_purge_urls):
+        information_page_translation = self.information_page.copy_for_translation(
+            locale=self.welsh_locale, copy_parents=True, alias=True
+        )
+        information_page_translation_url = information_page_translation.get_full_url(self.request)
+
+        old_index_url = self.index_page_url
+        old_index_translation_url = self.index_page.aliases.first().get_full_url(self.request)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.index_page.slug = "new-index-slug"
+            self.index_page.save_revision().publish()
+
+        self.index_page.refresh_from_db()
+
+        patched_purge_urls.assert_has_calls(
+            [
+                # via the publish signal
+                call({self.index_page.get_full_url(self.request)}),
+                call({old_index_translation_url}),
+                # via the slug changed signal - English page and its alias handled separately
+                call({old_index_url, self.information_page_url}),
+                call({old_index_translation_url, information_page_translation_url}),
+            ]
+        )
+
+    def test_page_move__statistical_article_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+
+        another_series = ArticleSeriesPageFactory(
+            parent=ArticlesIndexPage.objects.child_of(self.another_topic_page).first(), title="Another series"
+        )
+        another_series_url = another_series.get_full_url(self.request)
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.statistical_article.pk, another_series.pk),
+            )
+        )
+
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.article_url,
+                self.article_related_data_url,
+                # the old series and topic
+                self.series_url,
+                f"{self.series_url}/related-data",
+                self.series_edition_url,
+                f"{self.series_edition_url}?page=1",
+                self.topic_page_url,
+                self.topic_page_translation_url,
+                # the new series and topic
+                another_series_url,
+                f"{another_series_url}/related-data",
+                f"{another_series_url}/editions",
+                f"{another_series_url}/editions?page=1",
+                self.another_topic_page_url,
+                self.another_topic_page_translation_url,
+            }
+        )
+
+    def test_page_move__series_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.series_page.pk, ArticlesIndexPage.objects.child_of(self.another_topic_page).first().pk),
+            )
+        )
+
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.series_url,
+                f"{self.series_url}/related-data",
+                self.series_edition_url,
+                f"{self.series_edition_url}?page=1",
+                self.article_url,
+                self.article_related_data_url,
+                # the old topic
+                self.topic_page_url,
+                self.topic_page_translation_url,
+                # the new topic
+                self.another_topic_page_url,
+                self.another_topic_page_translation_url,
+            }
+        )
+
+    def test_page_move__methodology_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        other_methodology_index = MethodologyIndexPage.objects.child_of(self.another_topic_page).first()
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.methodology_page.pk, other_methodology_index.pk),
+            )
+        )
+
+        # note: there are two calls as the second call is for the old translation alias
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        # old page
+                        self.methodology_page_url,
+                        # old and new parent topics
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                    }
+                ),
+                call({self.methodology_page_translation_url}),
+            ]
+        )
+
+    def test_page_move__information_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        another_index = IndexPageFactory(title="Another index")
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.information_page.pk, another_index.pk),
+            )
+        )
+
+        patched_purge_urls.assert_called_once_with(
+            {
+                self.information_page_url,  # old page
+                self.index_page_url,
+                another_index.get_full_url(self.request),  # old and new indexes
+            }
+        )
+
+
+@override_settings(CMS_USE_SUBDOMAIN_LOCALES=False)
+@patch("cms.frontend_cache.cache.purge_urls_from_cache")
+class PageFrontEndCacheInvalidationWithPathLocalisationTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.home_page = HomePage.objects.first()
+        cls.welsh_locale = Locale.objects.get(language_code="cy")
+
+        cls.topic_1 = TopicFactory()
+
+        cls.topic_page = TopicPageFactory(title="The topic page", topic=cls.topic_1)
+        cls.topic_page.save_revision().publish()
+        cls.topic_page_translation = cls.topic_page.get_translations().first()
+
+        # remove all but the default site
+        Site.objects.filter(is_default_site=False).delete()
+
+    def test_page_publish__in_path_based_locale_setup(self, patched_purge_urls):
+        self.topic_page.save_revision().publish()
+        patched_purge_urls.assert_has_calls(
+            [
+                call({self.topic_page.full_url}),
+                call({self.topic_page_translation.full_url}),
+            ]
+        )
+
+        self.assertStartsWith(self.topic_page_translation.url, "/cy/")
+
+
+@patch("cms.frontend_cache.cache.purge_urls_from_cache")
+class PageViaSnippetFrontEndCacheInvalidationTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.contact = ContactDetails.objects.create(name="PSF", email="psf@ons.gov.uk")
+        cls.definition = Definition.objects.create(name="Term", definition="Definition")
+
+        content = [
+            {
+                "type": "definitions",
+                "value": [{"id": "d880c8a3-51ac-4dd7-b8d8-4cee0decf37d", "type": "item", "value": cls.definition.pk}],
+            }
+        ]
+
+        cls.statistical_article = StatisticalArticlePageFactory(
+            content=[{"type": "section", "value": {"content": content, "title": "Section"}}],
+            contact_details=cls.contact,
+        )
+
+        # should not appear in purge calls
+        cls.draft_statistical_article = StatisticalArticlePageFactory(
+            content=[{"type": "section", "value": {"content": content, "title": "Section"}}],
+            contact_details=cls.contact,
+            live=False,
+        )
+
+        cls.statistical_article_url = cls.statistical_article.get_full_url(get_dummy_request())
+        cls.statistical_article_related_data_url = f"{cls.statistical_article_url}/related-data"
+
+    def setUp(self):
+        # doing this here to avoid noise from deferred internal search index update via tasks
+        with self.captureOnCommitCallbacks(execute=True):
+            self.statistical_article.save()
+
+    def test_publish__contact_details(self, mocked_purge_urls):
+        self.contact.save_revision().publish()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+    def test_unpublish__contact_details(self, mocked_purge_urls):
+        self.contact.unpublish()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+    def test_publish__definition(self, mocked_purge_urls):
+        self.definition.save_revision().publish()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+    def test_unpublish__definition(self, mocked_purge_urls):
+        self.definition.unpublish()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+    def test_delete__contact(self, mocked_purge_urls):
+        self.contact.delete()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+    def test_delete__definition(self, mocked_purge_urls):
+        self.definition.delete()
+
+        mocked_purge_urls.assert_called_once_with(
+            {self.statistical_article_url, self.statistical_article_related_data_url}
+        )
+
+
+class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.topic_page = TopicPageFactory(title="The topic page")
+        # StatisticalArticlePage adds extra cached paths (e.g. /related-data)
+        cls.statistical_article = StatisticalArticlePageFactory(title="The article")
+        cls.request = get_dummy_request()
+
+    def test_no_routable_url_returns_empty_list(self):
+        with patch.object(Page, "get_full_url", return_value=None):
+            self.assertEqual(get_page_cached_urls(self.topic_page), [])
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False)
+    def test_without_append_slash(self):
+        page_url = self.topic_page.get_full_url(self.request)
+
+        self.assertEqual(get_page_cached_urls(self.topic_page), [page_url.rstrip("/")])
+
+    @override_settings(WAGTAIL_APPEND_SLASH=True)
+    def test_with_append_slash(self):
+        page_url = self.topic_page.get_full_url(self.request)
+
+        self.assertEqual(get_page_cached_urls(self.topic_page), [f"{page_url.rstrip('/')}/"])
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False)
+    def test_sub_paths_without_append_slash(self):
+        article_url = self.statistical_article.get_full_url(self.request).rstrip("/")
+
+        self.assertEqual(
+            get_page_cached_urls(self.statistical_article),
+            [article_url, f"{article_url}/related-data"],
+        )
+
+    @override_settings(WAGTAIL_APPEND_SLASH=True)
+    def test_sub_paths_with_append_slash(self):
+        article_url = self.statistical_article.get_full_url(self.request).rstrip("/")
+
+        self.assertEqual(
+            get_page_cached_urls(self.statistical_article),
+            [f"{article_url}/", f"{article_url}/related-data/"],
+        )
+
+    @override_settings(WAGTAIL_APPEND_SLASH=True)
+    def test_query_string_path_with_append_slash(self):
+        # The slash is added to the path, not after the query string.
+        series_url = self.statistical_article.get_parent().get_full_url(self.request).rstrip("/")
+
+        self.assertEqual(
+            get_page_cached_urls(self.statistical_article.get_parent()),
+            [
+                f"{series_url}/",
+                f"{series_url}/related-data/",
+                f"{series_url}/editions/",
+                f"{series_url}/editions/?page=1",
+            ],
+        )
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False)
+    def test_query_string_path_without_append_slash(self):
+        series_url = self.statistical_article.get_parent().get_full_url(self.request).rstrip("/")
+
+        self.assertEqual(
+            get_page_cached_urls(self.statistical_article.get_parent()),
+            [series_url, f"{series_url}/related-data", f"{series_url}/editions", f"{series_url}/editions?page=1"],
+        )

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from datetime import timedelta
 from unittest.mock import call, patch
 
@@ -311,6 +312,57 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 ),
             ]
         )
+
+    def _all_purged_urls(self, patched_purge_urls):
+        """Return the union of all URLs across every purge_urls_from_cache call."""
+        urls: set[str] = set()
+        for purge_call in patched_purge_urls.call_args_list:
+            urls |= purge_call.args[0]
+        return urls
+
+    def test_page_publish__topic_title_change_purges_descendants(self, patched_purge_urls):
+        # The topic title is shown in the breadcrumbs of all pages beneath it, so a title
+        # change must purge the whole descendant subtree (incl. Welsh aliases).
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.title = "New topic title"
+            self.topic_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.topic_page_url, purged)
+        self.assertIn(self.article_url, purged)
+        self.assertIn(self.article_related_data_url, purged)
+        self.assertIn(self.series_url, purged)
+        self.assertIn(self.methodology_page_url, purged)
+        # the Welsh alias of a descendant is purged too
+        self.assertIn(self.methodology_page_translation_url, purged)
+
+    def test_page_publish__topic_without_title_change_skips_descendants(self, patched_purge_urls):
+        # Republishing without a title change must not cascade to descendants.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.topic_page_url, purged)
+        self.assertNotIn(self.article_url, purged)
+        self.assertNotIn(self.methodology_page_url, purged)
+
+    def test_page_save_revision__title_change_without_publish_skips_descendants(self, patched_purge_urls):
+        # Changing the title on a draft (without publishing) must not purge the cache,
+        # as the live `title` field is untouched until publish.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.topic_page.title = "New draft topic title"
+            self.topic_page.save_revision()
+
+        patched_purge_urls.assert_not_called()
+
+    def test_page_publish__index_title_change_purges_descendants(self, patched_purge_urls):
+        with self.captureOnCommitCallbacks(execute=True):
+            self.index_page.title = "New index title"
+            self.index_page.save_revision().publish()
+
+        purged = self._all_purged_urls(patched_purge_urls)
+        self.assertIn(self.index_page_url, purged)
+        self.assertIn(self.information_page_url, purged)
 
     def test_page_publish__methodology(self, patched_purge_urls):
         self.methodology_page.save_revision().publish()

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -4,6 +4,7 @@ from unittest.mock import call, patch
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail.blocks import StreamValue
+from wagtail.contrib.redirects.models import Redirect
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Page, Site
 from wagtail.test.utils import WagtailTestUtils
@@ -533,6 +534,28 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             ]
         )
 
+    def test_page_slug_changed__creates_redirect(self, _patched_purge_urls):
+        with self.captureOnCommitCallbacks(execute=True):
+            self.index_page.slug = "new-index-slug"
+            self.index_page.save_revision().publish()
+
+        self.assertTrue(Redirect.objects.filter(redirect_page=self.index_page, automatically_created=True).exists())
+
+    def test_page_move__creates_redirect(self, _patched_purge_urls):
+        self.client.force_login(self.superuser)
+        another_index = IndexPageFactory(title="Another index")
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(self.information_page.pk, another_index.pk),
+            )
+        )
+
+        self.assertTrue(
+            Redirect.objects.filter(redirect_page=self.information_page, automatically_created=True).exists()
+        )
+
     def test_page_move__statistical_article_page(self, patched_purge_urls):
         self.client.force_login(self.superuser)
 
@@ -651,6 +674,86 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 self.index_page_url,
                 another_index.get_full_url(self.request),  # old and new indexes
             }
+        )
+
+    def test_page_move__articles_index_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        articles_index = ArticlesIndexPage.objects.child_of(self.topic_page).first()
+        # the target topic (and its translation) already has its own auto-created index page which would clash on slug
+        ArticlesIndexPage.objects.child_of(self.another_topic_page).delete()
+        ArticlesIndexPage.objects.child_of(self.another_topic_page_translation).delete()
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(articles_index.pk, self.another_topic_page.pk),
+            )
+        )
+
+        # note: there are two calls as the second call is for the old translation alias
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        # old paths for the index and everything under it
+                        f"{self.topic_page_url}/articles",
+                        self.series_url,
+                        f"{self.series_url}/related-data",
+                        self.series_edition_url,
+                        f"{self.series_edition_url}?page=1",
+                        f"{self.series_edition_url}?page=2",
+                        f"{self.series_edition_url}?page=3",
+                        self.article_url,
+                        self.article_related_data_url,
+                        f"{self.article_related_data_url}?page=1",
+                        f"{self.article_related_data_url}?page=2",
+                        # old and new topics related to the series (both linked to topic_2)
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                    }
+                ),
+                call({f"{self.topic_page_translation_url}/articles"}),
+            ]
+        )
+
+    def test_page_move__methodology_index_page(self, patched_purge_urls):
+        self.client.force_login(self.superuser)
+        methodology_index = MethodologyIndexPage.objects.child_of(self.topic_page).first()
+        # the target topic (and its translation) already has its own auto-created index page which would clash on slug
+        MethodologyIndexPage.objects.child_of(self.another_topic_page).delete()
+        MethodologyIndexPage.objects.child_of(self.another_topic_page_translation).delete()
+
+        self.client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                args=(methodology_index.pk, self.another_topic_page.pk),
+            )
+        )
+
+        # note: there are two calls as the second call is for the old translation alias
+        patched_purge_urls.assert_has_calls(
+            [
+                call(
+                    {
+                        # old paths for the index and the methodology page under it
+                        f"{self.topic_page_url}/methodologies",
+                        self.methodology_page_url,
+                        # old and new topics related to the methodology page (both linked to topic_2)
+                        self.topic_page_url,
+                        self.topic_page_translation_url,
+                        self.another_topic_page_url,
+                        self.another_topic_page_translation_url,
+                    }
+                ),
+                call(
+                    {
+                        f"{self.topic_page_translation_url}/methodologies",
+                        self.methodology_page_translation_url,
+                    }
+                ),
+            ]
         )
 
 

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -84,10 +84,14 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
         urls = {
             self.article_url,
             self.article_related_data_url,
+            f"{self.article_related_data_url}?page=1",
+            f"{self.article_related_data_url}?page=2",
             self.series_url,
             f"{self.series_url}/related-data",
             self.series_edition_url,
             f"{self.series_edition_url}?page=1",
+            f"{self.series_edition_url}?page=2",
+            f"{self.series_edition_url}?page=3",
             self.topic_page_url,
         }
         if with_translation_alias:
@@ -170,13 +174,17 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
         self.statistical_article.save_revision().publish()
 
         expected_urls = self._get_base_expected_statistical_page_urls_to_purge()
-        expected_urls.add(f"{self.article_related_data_url}?page=1")
+        expected_urls |= {
+            f"{self.article_related_data_url}?page=1",
+            f"{self.article_related_data_url}?page=2",
+            f"{self.article_related_data_url}?page=3",
+        }
         patched_purge_urls.assert_called_once_with(expected_urls)
 
         with override_settings(RELATED_DATASETS_PER_PAGE=2):
             self.statistical_article.save_revision().publish()
 
-            expected_urls |= {f"{self.article_related_data_url}?page=2", f"{self.article_related_data_url}?page=3"}
+            expected_urls |= {f"{self.article_related_data_url}?page=4", f"{self.article_related_data_url}?page=5"}
             patched_purge_urls.assert_called_with(expected_urls)
 
     def test_page_publish__statistical_article_featured_in_different_topic(self, patched_purge_urls):
@@ -212,10 +220,14 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 # the usual urls
                 new_article_url,
                 f"{new_article_url}/related-data",
+                f"{new_article_url}/related-data?page=1",
+                f"{new_article_url}/related-data?page=2",
                 self.series_url,
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.topic_page_url,
                 self.topic_page_translation_url,
                 # the topic page that features the statistical article's series
@@ -243,6 +255,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
                 f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
+                f"{self.series_edition_url}?page=4",
             }
         )
 
@@ -268,6 +282,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                         f"{self.series_url}/related-data",
                         self.series_edition_url,
                         f"{self.series_edition_url}?page=1",
+                        f"{self.series_edition_url}?page=2",
+                        f"{self.series_edition_url}?page=3",
                     }
                 ),
                 call(
@@ -276,14 +292,20 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                         f"{series_translation_url}/related-data",
                         f"{series_translation_url}/editions",
                         f"{series_translation_url}/editions?page=1",
+                        f"{series_translation_url}/editions?page=2",
+                        f"{series_translation_url}/editions?page=3",
                     }
                 ),
                 call(
                     {
                         self.article_url,
                         self.article_related_data_url,
+                        f"{self.article_related_data_url}?page=1",
+                        f"{self.article_related_data_url}?page=2",
                         article_translation_url,
                         f"{article_translation_url}/related-data",
+                        f"{article_translation_url}/related-data?page=1",
+                        f"{article_translation_url}/related-data?page=2",
                     }
                 ),
             ]
@@ -375,6 +397,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 self.index_page_url,
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
             }
         )
 
@@ -528,11 +552,15 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
             {
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
                 # the old series and topic
                 self.series_url,
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.topic_page_url,
                 self.topic_page_translation_url,
                 # the new series and topic
@@ -540,6 +568,8 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{another_series_url}/related-data",
                 f"{another_series_url}/editions",
                 f"{another_series_url}/editions?page=1",
+                f"{another_series_url}/editions?page=2",
+                f"{another_series_url}/editions?page=3",
                 self.another_topic_page_url,
                 self.another_topic_page_translation_url,
             }
@@ -561,8 +591,12 @@ class PageFrontEndCacheInvalidationTestCase(WagtailTestUtils, TestCase):
                 f"{self.series_url}/related-data",
                 self.series_edition_url,
                 f"{self.series_edition_url}?page=1",
+                f"{self.series_edition_url}?page=2",
+                f"{self.series_edition_url}?page=3",
                 self.article_url,
                 self.article_related_data_url,
+                f"{self.article_related_data_url}?page=1",
+                f"{self.article_related_data_url}?page=2",
                 # the old topic
                 self.topic_page_url,
                 self.topic_page_translation_url,
@@ -687,42 +721,72 @@ class PageViaSnippetFrontEndCacheInvalidationTestCase(TestCase):
         self.contact.save_revision().publish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_unpublish__contact_details(self, mocked_purge_urls):
         self.contact.unpublish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_publish__definition(self, mocked_purge_urls):
         self.definition.save_revision().publish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_unpublish__definition(self, mocked_purge_urls):
         self.definition.unpublish()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_delete__contact(self, mocked_purge_urls):
         self.contact.delete()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
     def test_delete__definition(self, mocked_purge_urls):
         self.definition.delete()
 
         mocked_purge_urls.assert_called_once_with(
-            {self.statistical_article_url, self.statistical_article_related_data_url}
+            {
+                self.statistical_article_url,
+                self.statistical_article_related_data_url,
+                f"{self.statistical_article_related_data_url}?page=1",
+                f"{self.statistical_article_related_data_url}?page=2",
+            }
         )
 
 
@@ -756,7 +820,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article),
-            [article_url, f"{article_url}/related-data"],
+            [
+                article_url,
+                f"{article_url}/related-data",
+                f"{article_url}/related-data?page=1",
+                f"{article_url}/related-data?page=2",
+            ],
         )
 
     @override_settings(WAGTAIL_APPEND_SLASH=True)
@@ -765,7 +834,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article),
-            [f"{article_url}/", f"{article_url}/related-data/"],
+            [
+                f"{article_url}/",
+                f"{article_url}/related-data/",
+                f"{article_url}/related-data/?page=1",
+                f"{article_url}/related-data/?page=2",
+            ],
         )
 
     @override_settings(WAGTAIL_APPEND_SLASH=True)
@@ -780,6 +854,8 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
                 f"{series_url}/related-data/",
                 f"{series_url}/editions/",
                 f"{series_url}/editions/?page=1",
+                f"{series_url}/editions/?page=2",
+                f"{series_url}/editions/?page=3",
             ],
         )
 
@@ -789,5 +865,12 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
 
         self.assertEqual(
             get_page_cached_urls(self.statistical_article.get_parent()),
-            [series_url, f"{series_url}/related-data", f"{series_url}/editions", f"{series_url}/editions?page=1"],
+            [
+                series_url,
+                f"{series_url}/related-data",
+                f"{series_url}/editions",
+                f"{series_url}/editions?page=1",
+                f"{series_url}/editions?page=2",
+                f"{series_url}/editions?page=3",
+            ],
         )

--- a/cms/frontend_cache/tests/test_signal_handlers.py
+++ b/cms/frontend_cache/tests/test_signal_handlers.py
@@ -17,10 +17,13 @@ from cms.datasets.blocks import DatasetStoryBlock
 from cms.datasets.tests.factories import DatasetFactory
 from cms.datavis.tests.factories import TableDataFactory, make_table_block_value
 from cms.frontend_cache.cache import get_page_cached_urls
-from cms.frontend_cache.signal_handlers import _get_tracked_page_models
+from cms.frontend_cache.signal_handlers import _get_tracked_page_models, purge_published_page_from_frontend_cache
 from cms.home.models import HomePage
 from cms.methodology.models import MethodologyIndexPage, MethodologyPage
 from cms.methodology.tests.factories import MethodologyPageFactory
+from cms.post_publish_actions import registry
+from cms.post_publish_actions.models import PostPublishActionType
+from cms.post_publish_actions.registry import PostPublishActionPriority, get_post_publish_actions
 from cms.release_calendar.models import ReleaseCalendarPage
 from cms.standard_pages.models import CookiesPage, IndexPage, InformationPage
 from cms.standard_pages.tests.factories import IndexPageFactory, InformationPageFactory
@@ -1029,3 +1032,40 @@ class GetPageCachedUrlsTestCase(WagtailTestUtils, TestCase):
                 f"{series_url}/editions?page=3",
             ],
         )
+
+
+class PublishPurgeRunsAsPostPublishActionTestCase(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.index_page = IndexPageFactory()
+        cls.information_page = InformationPageFactory(parent=cls.index_page, title="Info page")
+
+    def test_registered_as_the_frontend_cache_action(self):
+        self.assertIs(
+            get_post_publish_actions()[PostPublishActionType.CACHE_PURGE], purge_published_page_from_frontend_cache
+        )
+
+    def test_registered_with_medium_priority(self):
+        registered = registry._registry[PostPublishActionType.CACHE_PURGE]  # pylint: disable=protected-access
+        self.assertEqual(registered.priority, PostPublishActionPriority.MEDIUM)
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_publish_does_not_purge_outside_registry(self, patched_purge_urls):
+        with patch.dict(registry._registry, {}, clear=True):  # pylint: disable=protected-access
+            self.information_page.save_revision().publish()
+
+        patched_purge_urls.assert_not_called()
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_running_the_action_directly_purges_page(self, patched_purge_urls):
+        purge_published_page_from_frontend_cache(self.information_page, None)
+
+        patched_purge_urls.assert_called_once_with(
+            {self.information_page.get_full_url(get_dummy_request()), self.index_page.get_full_url(get_dummy_request())}
+        )
+
+    @patch("cms.frontend_cache.cache.purge_urls_from_cache")
+    def test_running_action_skips_untracked_page_types(self, patched_purge_urls):
+        purge_published_page_from_frontend_cache(HomePage.objects.first(), None)
+
+        patched_purge_urls.assert_not_called()

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -154,6 +154,9 @@ class MethodologyPage(  # type: ignore[django-manager-missing]
         context["related_publications"] = self.get_formatted_related_publications_list(request=request)
         return context
 
+    def get_cached_paths(self) -> list[str]:
+        return ["/", *self.get_downloadable_block_paths()]
+
     @property
     def release_date(self) -> datetime.date:
         return self.publication_date

--- a/cms/methodology/tests/test_models.py
+++ b/cms/methodology/tests/test_models.py
@@ -162,6 +162,26 @@ class MethodologyPageCSVDownloadTestCase(WagtailTestUtils, TestCase):
         table = self.page.get_table("test-table-id-2")
         self.assertEqual(table["title"], "Test Table 2")
 
+    def test_get_cached_paths(self):
+        """Test get_cached_paths includes downloadable table/chart block paths."""
+        self.page.content = [
+            {
+                "type": "section",
+                "value": {
+                    "title": "Table Section",
+                    "content": [
+                        {
+                            "type": "table",
+                            "value": make_table_block_value(title="Test Table 1"),
+                            "id": "test-table-id",
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertEqual(self.page.get_cached_paths(), ["/", "/download-table/test-table-id"])
+
     def test_get_table_returns_empty_dict_when_not_found(self):
         """Test get_table returns empty dict when table_id is not found."""
         self.page.content = [

--- a/cms/post_publish_actions/models.py
+++ b/cms/post_publish_actions/models.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 class PostPublishActionType(models.TextChoices):
+    CACHE_PURGE = "CACHE_PURGE", "Frontend cache purge"
     S3_ACL = "S3_ACL", "Private Media ACLs"
     SEARCH_UPDATED = "SEARCH_UPDATED", "Search updated"
 
@@ -23,10 +24,14 @@ class PostPublishActionStatus(models.TextChoices):
 
 class PostPublishActionQuerySet(models.QuerySet):
     def active(self) -> Self:
-        """Exclude stale action types.
-        These may be from previous deployments with different types.
+        """Exclude action types with no registered handler.
+
+        May be deprecated action types from previous versions, or handlers that are not currently
+        registered with the current configuration (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`).
         """
-        return self.filter(action_type__in=PostPublishActionType.values)
+        from .registry import get_registered_action_types  # pylint: disable=import-outside-toplevel
+
+        return self.filter(action_type__in=get_registered_action_types())
 
     def finished(self) -> Self:
         return self.exclude(finished_at=None)

--- a/cms/post_publish_actions/registry.py
+++ b/cms/post_publish_actions/registry.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ImproperlyConfigured
@@ -12,27 +14,61 @@ if TYPE_CHECKING:
 
 ActionHandler = Callable[[Page, "Bundle | None"], None]
 
-_registry: dict[PostPublishActionType, ActionHandler] = {}
+
+class PostPublishActionPriority(IntEnum):
+    """Defines the priority of a post-publish action. Lower numbers are higher priority."""
+
+    HIGH = 1
+    MEDIUM = 2
+    LOW = 3
 
 
-def register_post_publish_action(action_type: PostPublishActionType, action_handler: ActionHandler) -> None:
+@dataclass(frozen=True)
+class RegisteredPostPublishAction:
+    handler: ActionHandler
+    priority: int = PostPublishActionPriority.MEDIUM
+
+
+_registry: dict[PostPublishActionType, RegisteredPostPublishAction] = {}
+
+
+def register_post_publish_action(
+    action_type: PostPublishActionType,
+    action_handler: ActionHandler,
+    *,
+    priority: int = PostPublishActionPriority.MEDIUM,
+) -> None:
     if action_type in _registry:
-        raise ImproperlyConfigured(f"{action_type} is already configured: {_registry[action_type]}")
+        raise ImproperlyConfigured(f"{action_type} is already configured: {_registry[action_type].handler}")
 
-    _registry[action_type] = action_handler
+    _registry[action_type] = RegisteredPostPublishAction(handler=action_handler, priority=priority)
 
 
-def post_publish_action(action_type: PostPublishActionType) -> Callable[[ActionHandler], ActionHandler]:
+def post_publish_action(
+    action_type: PostPublishActionType, priority: int = PostPublishActionPriority.MEDIUM
+) -> Callable[[ActionHandler], ActionHandler]:
     def decorator(action_handler: ActionHandler) -> ActionHandler:
-        register_post_publish_action(action_type, action_handler)
+        register_post_publish_action(action_type, action_handler, priority=priority)
         return action_handler
 
     return decorator
 
 
 def get_post_publish_actions() -> dict[PostPublishActionType, ActionHandler]:
-    return _registry
+    return {
+        action_type: registered.handler
+        for action_type, registered in sorted(_registry.items(), key=lambda item: item[1].priority)
+    }
 
 
 def get_post_publish_action_for_type(action_type: PostPublishActionType) -> ActionHandler:
-    return _registry[action_type]
+    return _registry[action_type].handler
+
+
+def get_registered_action_types() -> list[PostPublishActionType]:
+    """Returns a list of all registered post-publish action types.
+
+    Handlers can be conditionally registered (e.g. `CACHE_PURGE` is only registered with `cms.frontend_cache`)
+    so this may only be a subset of all action types defined in `PostPublishActionType`.
+    """
+    return list(_registry)

--- a/cms/post_publish_actions/tests/test_management_commands.py
+++ b/cms/post_publish_actions/tests/test_management_commands.py
@@ -175,7 +175,11 @@ class RetryPostPublishActionsTestCase(TransactionTestCase):
     def test_republishing_restores_retry_budget(self):
         action = self._create_stalled_action(retry_count=2, status=PostPublishActionStatus.FAILED)
 
-        with patch.dict(registry._registry, {PostPublishActionType.SEARCH_UPDATED: MagicMock()}, clear=True):  # pylint: disable=protected-access
+        with patch.dict(
+            registry._registry,  # pylint: disable=protected-access
+            {PostPublishActionType.SEARCH_UPDATED: registry.RegisteredPostPublishAction(handler=MagicMock())},
+            clear=True,
+        ):
             run_post_publish_actions_for(self.page, self.bundle)
 
         action.refresh_from_db()

--- a/cms/post_publish_actions/tests/test_models.py
+++ b/cms/post_publish_actions/tests/test_models.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
 from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.bundles.tests.factories import BundleFactory
+from cms.post_publish_actions import registry
 from cms.post_publish_actions.models import PostPublishAction, PostPublishActionStatus, PostPublishActionType
 
 
@@ -54,3 +56,14 @@ class PostPublishActionTestCase(TestCase):
 
         self.assertIn(action, PostPublishAction.objects.active())
         self.assertNotIn(invalid_action, PostPublishAction.objects.active())
+
+    def test_active_excludes_action_types_without_a_registered_handler(self):
+        action = PostPublishAction.objects.create(
+            bundle=self.bundle, page=self.page, action_type=PostPublishActionType.CACHE_PURGE
+        )
+
+        with patch.dict(registry._registry) as patched_registry:  # pylint: disable=protected-access
+            del patched_registry[PostPublishActionType.CACHE_PURGE]
+            self.assertNotIn(action, PostPublishAction.objects.active())
+
+        self.assertIn(action, PostPublishAction.objects.active())

--- a/cms/post_publish_actions/tests/test_registry.py
+++ b/cms/post_publish_actions/tests/test_registry.py
@@ -1,8 +1,12 @@
+from unittest.mock import patch
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
+from cms.post_publish_actions import registry
 from cms.post_publish_actions.models import PostPublishActionType
 from cms.post_publish_actions.registry import (
+    PostPublishActionPriority,
     get_post_publish_action_for_type,
     get_post_publish_actions,
     register_post_publish_action,
@@ -30,3 +34,64 @@ class RegistryTestCase(SimpleTestCase):
             register_post_publish_action(PostPublishActionType.SEARCH_UPDATED, _noop_handler)
 
         self.assertIsNot(get_post_publish_action_for_type(PostPublishActionType.SEARCH_UPDATED), _noop_handler)
+
+
+class RegistryPriorityTestCase(SimpleTestCase):
+    def setUp(self):
+        patcher = patch.dict(registry._registry, {}, clear=True)  # pylint: disable=protected-access
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_actions_are_returned_highest_priority_first(self):
+        """Test that actions are returned in order of priority."""
+        register_post_publish_action(
+            PostPublishActionType.SEARCH_UPDATED, _noop_handler, priority=PostPublishActionPriority.LOW
+        )
+        register_post_publish_action(
+            PostPublishActionType.S3_ACL, _noop_handler, priority=PostPublishActionPriority.HIGH
+        )
+        register_post_publish_action(
+            PostPublishActionType.CACHE_PURGE, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+
+        actions = get_post_publish_actions()
+
+        self.assertEqual(
+            list(actions.keys()),
+            [
+                PostPublishActionType.S3_ACL,
+                PostPublishActionType.CACHE_PURGE,
+                PostPublishActionType.SEARCH_UPDATED,
+            ],
+        )
+
+    def test_equal_priorities_keep_their_registration_order(self):
+        register_post_publish_action(
+            PostPublishActionType.SEARCH_UPDATED, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+        register_post_publish_action(
+            PostPublishActionType.S3_ACL, _noop_handler, priority=PostPublishActionPriority.MEDIUM
+        )
+
+        self.assertEqual(
+            list(get_post_publish_actions().keys()),
+            [PostPublishActionType.SEARCH_UPDATED, PostPublishActionType.S3_ACL],
+        )
+
+    def test_registration_defaults_to_medium_priority(self):
+        register_post_publish_action(PostPublishActionType.SEARCH_UPDATED, _noop_handler)
+
+        self.assertEqual(
+            registry._registry[PostPublishActionType.SEARCH_UPDATED],  # pylint: disable=protected-access
+            registry.RegisteredPostPublishAction(handler=_noop_handler, priority=PostPublishActionPriority.MEDIUM),
+        )
+
+    def test_decorator_passes_priority_to_registration(self):
+        @registry.post_publish_action(PostPublishActionType.SEARCH_UPDATED, priority=PostPublishActionPriority.HIGH)
+        def handler(page, bundle):  # pylint: disable=unused-argument
+            pass
+
+        self.assertEqual(
+            registry._registry[PostPublishActionType.SEARCH_UPDATED],  # pylint: disable=protected-access
+            registry.RegisteredPostPublishAction(handler=handler, priority=PostPublishActionPriority.HIGH),
+        )

--- a/cms/post_publish_actions/tests/test_utils.py
+++ b/cms/post_publish_actions/tests/test_utils.py
@@ -21,7 +21,11 @@ class RunPostPublishActionsForTestCase(TestCase):
 
     def test_without_bundle_runs_handlers_synchronously(self):
         """Test that pages published without a bundle publish synchronously for now."""
-        with patch.dict(registry._registry, {PostPublishActionType.S3_ACL: self.handler}, clear=True):
+        with patch.dict(
+            registry._registry,
+            {PostPublishActionType.S3_ACL: registry.RegisteredPostPublishAction(handler=self.handler)},
+            clear=True,
+        ):
             run_post_publish_actions_for(self.page, None)
 
         self.handler.assert_called_with(self.page, None)

--- a/cms/post_publish_actions/utils.py
+++ b/cms/post_publish_actions/utils.py
@@ -90,6 +90,9 @@ def post_publish_notify_slack(start_time: datetime, bundle: Bundle, *, publish_f
 
 
 def run_post_publish_actions_for(page: Page, bundle: Bundle | None) -> None:
+    # Actions are returned in ascending priority order.
+    # Sync path (no bundle): runs strictly in priority order.
+    # Bundle path: enqueued in priority order, but execution order is not guaranteed (thread pool).
     registry = get_post_publish_actions()
 
     # TODO: Handle pages not in bundle.

--- a/cms/private_media/signal_handlers.py
+++ b/cms/private_media/signal_handlers.py
@@ -9,7 +9,7 @@ from wagtail.signals import published, unpublished
 
 from cms.bundles.models import Bundle
 from cms.post_publish_actions.models import PostPublishActionType
-from cms.post_publish_actions.registry import register_post_publish_action
+from cms.post_publish_actions.registry import PostPublishActionPriority, register_post_publish_action
 from cms.private_media.constants import Privacy
 from cms.private_media.models import PrivateImageMixin
 from cms.private_media.utils import get_private_media_models
@@ -124,4 +124,6 @@ def register_signal_handlers() -> None:
     published.connect(publish_media_on_publish, dispatch_uid="publish_media")
     unpublished.connect(unpublish_media_on_unpublish, dispatch_uid="unpublish_media")
 
-    register_post_publish_action(PostPublishActionType.S3_ACL, publish_media_post_publish_action)
+    register_post_publish_action(
+        PostPublishActionType.S3_ACL, publish_media_post_publish_action, priority=PostPublishActionPriority.HIGH
+    )

--- a/cms/search/signal_handlers.py
+++ b/cms/search/signal_handlers.py
@@ -9,14 +9,14 @@ from wagtail.signals import page_slug_changed, page_unpublished, post_page_move
 
 from cms.bundles.models import Bundle
 from cms.post_publish_actions.models import PostPublishActionType
-from cms.post_publish_actions.registry import post_publish_action
+from cms.post_publish_actions.registry import PostPublishActionPriority, post_publish_action
 from cms.search.publishers import get_publisher
 from cms.search.utils import get_model_by_name, is_indexable_page
 
 logger = logging.getLogger(__name__)
 
 
-@post_publish_action(PostPublishActionType.SEARCH_UPDATED)
+@post_publish_action(PostPublishActionType.SEARCH_UPDATED, PostPublishActionPriority.LOW)
 def update_index_post_publish_action(page: Page, _bundle: Bundle | None) -> None:
     if is_indexable_page(page):
         get_publisher().publish_created_or_updated(page)

--- a/cms/search/tests/test_signal_handlers.py
+++ b/cms/search/tests/test_signal_handlers.py
@@ -144,8 +144,14 @@ class SearchSignalsTest(TestCase):
         """Test all non excluded pages trigger publish_created_or_updated on move."""
         for page in self.included_pages:
             with self.subTest(page=page):
+                parent = page.get_parent()
                 post_page_move.send(
-                    sender=Page, instance=page, url_path_before="/old-path/", url_path_after="/new-path/"
+                    sender=Page,
+                    instance=page,
+                    parent_page_before=parent,
+                    parent_page_after=parent,
+                    url_path_before="/old-path/",
+                    url_path_after="/new-path/",
                 )
                 self.mock_publisher.publish_created_or_updated.assert_called_once_with(page, old_url_path="/old-path/")
                 self.mock_publisher.publish_created_or_updated.reset_mock()
@@ -155,7 +161,15 @@ class SearchSignalsTest(TestCase):
         page = StatisticalArticlePageFactory()
         page.live = False
         page.save()
-        post_page_move.send(sender=Page, instance=page, url_path_before="/old-path/", url_path_after="/new-path/")
+        parent = page.get_parent()
+        post_page_move.send(
+            sender=Page,
+            instance=page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
+        )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     def test_on_page_moved_ignores_draft_descendant_page(self):
@@ -164,28 +178,58 @@ class SearchSignalsTest(TestCase):
         descendant_page = StatisticalArticlePageFactory(parent=parent_page)
         descendant_page.live = False
         descendant_page.save()
+        parent = parent_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=parent_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=parent_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     def test_on_page_moved_no_url_change(self):
         """Moves that do not change the URL path should not trigger publish_created_or_updated."""
         page = StatisticalArticlePageFactory()
-        post_page_move.send(sender=Page, instance=page, url_path_before="/old-path/", url_path_after="/old-path/")
+        parent = page.get_parent()
+        post_page_move.send(
+            sender=Page,
+            instance=page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/old-path/",
+        )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     def test_on_page_moved_excluded_page(self):
         """Excluded pages should not trigger publish_created_or_updated on move."""
         page = ArticleSeriesPageFactory()
-        post_page_move.send(sender=Page, instance=page, url_path_before="/old-path/", url_path_after="/new-path/")
+        parent = page.get_parent()
+        post_page_move.send(
+            sender=Page,
+            instance=page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
+        )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     def test_on_page_moved_private_page(self):
         """Pages with view restrictions should not trigger publish_created_or_updated on move."""
         page = StatisticalArticlePageFactory()
         PageViewRestriction.objects.create(page=page, restriction_type=PageViewRestriction.LOGIN)
-        post_page_move.send(sender=Page, instance=page, url_path_before="/old-path/", url_path_after="/new-path/")
+        parent = page.get_parent()
+        post_page_move.send(
+            sender=Page,
+            instance=page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
+        )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     def test_on_page_moved_private_descendant_page(self):
@@ -194,8 +238,14 @@ class SearchSignalsTest(TestCase):
         descendant_page = StatisticalArticlePageFactory(parent=parent_page)
         PageViewRestriction.objects.create(page=descendant_page, restriction_type=PageViewRestriction.LOGIN)
 
+        parent = parent_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=parent_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=parent_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
 
         # Expect no search update events published since the descendant is private
@@ -208,8 +258,14 @@ class SearchSignalsTest(TestCase):
         article_page = StatisticalArticlePageFactory(parent=series_page)
         url_path_before = "/home/old-path/"
 
+        parent = topic_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=topic_page, url_path_before=url_path_before, url_path_after=topic_page.url_path
+            sender=Page,
+            instance=topic_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before=url_path_before,
+            url_path_after=topic_page.url_path,
         )
 
         # Expect the topic and article page to have search update events published, the series pages are excluded
@@ -462,37 +518,71 @@ class SearchSignalsTest(TestCase):
 
     @override_settings(SEARCH_INDEX_INCLUDED_LANGUAGES=["en-gb"])
     def test_move_only_english_locale(self):
+        parent = self.en_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=self.en_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=self.en_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.mock_publisher.publish_created_or_updated.assert_called_once_with(self.en_page, old_url_path="/old-path/")
         self.mock_publisher.publish_created_or_updated.reset_mock()
 
         post_page_move.send(
-            sender=Page, instance=self.cy_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=self.cy_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     @override_settings(SEARCH_INDEX_INCLUDED_LANGUAGES=["cy"])
     def test_move_only_welsh_locale(self):
+        parent = self.cy_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=self.cy_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=self.cy_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.mock_publisher.publish_created_or_updated.assert_called_once_with(self.cy_page, old_url_path="/old-path/")
         self.mock_publisher.publish_created_or_updated.reset_mock()
 
         post_page_move.send(
-            sender=Page, instance=self.en_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            instance=self.en_page,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.mock_publisher.publish_created_or_updated.assert_not_called()
 
     @override_settings(SEARCH_INDEX_INCLUDED_LANGUAGES=["en-gb", "cy"])
     def test_move_both_locales(self):
+        parent = self.en_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=self.en_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=self.en_page,
+            parent_page_before=parent,
+            parent_page_after=parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
+        cy_parent = self.cy_page.get_parent()
         post_page_move.send(
-            sender=Page, instance=self.cy_page, url_path_before="/old-path/", url_path_after="/new-path/"
+            sender=Page,
+            instance=self.cy_page,
+            parent_page_before=cy_parent,
+            parent_page_after=cy_parent,
+            url_path_before="/old-path/",
+            url_path_after="/new-path/",
         )
         self.assertEqual(self.mock_publisher.publish_created_or_updated.call_count, 2)
         self.mock_publisher.publish_created_or_updated.assert_has_calls(

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -717,8 +717,11 @@ WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 # The backend can be configured to use an account-wide API key, or an API token with
 # restricted access.
 
+# Deliberately set to an empty list as cms.frontend_cache uses purge_urls_from_cache which will
+# default to the list of defined content languages if this is not defined.
+WAGTAILFRONTENDCACHE_LANGUAGES: list[str] = []
 if "FRONTEND_CACHE_CLOUDFLARE_TOKEN" in env or "FRONTEND_CACHE_CLOUDFLARE_BEARER_TOKEN" in env:
-    INSTALLED_APPS.append("wagtail.contrib.frontend_cache")
+    INSTALLED_APPS += ["wagtail.contrib.frontend_cache", "cms.frontend_cache"]
     WAGTAILFRONTENDCACHE = {
         "default": {
             "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudflareBackend",
@@ -939,6 +942,15 @@ WAGTAIL_ENABLE_WHATS_NEW_BANNER = False
 # Set to "same-origin-allow-popups" to allow popups
 # from third-party applications like PayPal or Zoom as needed
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
+
+
+# Explicitly set the ImmediateBackend for tasks (even though it is the default at the time of writing)
+# We do this to ensure certain tasks, such as updating the reference index, happen sequentially.
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+    }
+}
 
 #
 # ONS CMS specific-settings

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -918,6 +918,12 @@ PREVIOUS_RELEASES_PER_PAGE = int(env.get("PREVIOUS_RELEASES_PER_PAGE", 10))
 CMS_RELEASES_INDEX_REDIRECT_ENABLED = env.get("CMS_RELEASES_INDEX_REDIRECT_ENABLED", "true").lower() == "true"
 RELATED_DATASETS_PER_PAGE = int(env.get("RELATED_DATASETS_PER_PAGE", DEFAULT_PER_PAGE))
 
+# Number of extra trailing pages to purge from the front-end cache beyond the current page count,
+# so that pages orphaned by shrinking pagination (e.g. after a correction removes items) get invalidated too.
+# This is a workaround until Wagtail supports prefix-based cache purging:
+# https://github.com/wagtail/wagtail/pull/13773
+CMS_PAGINATION_OVER_PURGE = int(env.get("CMS_PAGINATION_OVER_PURGE", 2))
+
 # Google Tag Manager ID from env
 GOOGLE_TAG_MANAGER_CONTAINER_ID = env.get("GOOGLE_TAG_MANAGER_CONTAINER_ID", "")
 

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -721,6 +721,7 @@ WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 # default to the list of defined content languages if this is not defined.
 WAGTAILFRONTENDCACHE_LANGUAGES: list[str] = []
 if "FRONTEND_CACHE_CLOUDFLARE_TOKEN" in env or "FRONTEND_CACHE_CLOUDFLARE_BEARER_TOKEN" in env:
+    # Apps need to be installed in this order so that any signal disconnects work as intended
     INSTALLED_APPS += ["wagtail.contrib.frontend_cache", "cms.frontend_cache"]
     WAGTAILFRONTENDCACHE = {
         "default": {

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -110,6 +110,12 @@ CMS_HOSTNAME_LOCALE_MAP = {
 }
 CMS_HOSTNAME_ALTERNATIVES = {"ons.localhost": "pub.ons.localhost", "cy.ons.localhost": "cy.pub.ons.localhost"}
 
+# Ensure cms.frontend_cache is installed
+if "cms.frontend_cache" not in INSTALLED_APPS:  # noqa: F405
+    INSTALLED_APPS += ["wagtail.contrib.frontend_cache", "cms.frontend_cache"]  # noqa: F405
+
+    WAGTAILFRONTENDCACHE = {"default": {"BACKEND": "cms.frontend_cache.tests.backends.DummyFrontEndCacheBackend"}}
+
 URL_CONFIG_SETTINGS = {
     "IS_EXTERNAL_ENV",
     "CMS_USE_SUBDOMAIN_LOCALES",

--- a/cms/settings/test.py
+++ b/cms/settings/test.py
@@ -128,6 +128,8 @@ URL_CONFIG_SETTINGS = {
     "WAGTAILADMIN_LOGIN_URL",
 }
 
+CMS_PAGINATION_OVER_PURGE = 2
+
 
 def _reset_url_caches_on_setting_changed_signal_handler(*, setting: str, **_: Any) -> None:
     """Resets the url cache if `setting` is any of URL_CONFIG_SETTINGS.

--- a/cms/standard_pages/models.py
+++ b/cms/standard_pages/models.py
@@ -78,6 +78,9 @@ class InformationPage(  # type: ignore[django-manager-missing]
         context["table_of_contents"] = self.table_of_contents
         return context
 
+    def get_cached_paths(self) -> list[str]:
+        return ["/", *self.get_downloadable_block_paths()]
+
     def serve_preview(self, request: HttpRequest, mode_name: str) -> TemplateResponse:
         self._log_preview(request, mode_name)
         return super().serve_preview(request, mode_name)

--- a/cms/standard_pages/tests/test_models.py
+++ b/cms/standard_pages/tests/test_models.py
@@ -187,6 +187,31 @@ class InformationPageTestCase(WagtailTestUtils, TestCase):
         self.assertContains(response, "MathJax.js")
         self.assertContains(response, "pym.min.js")
 
+    def test_get_cached_paths(self):
+        self.page.content = [
+            {
+                "type": "section",
+                "value": {
+                    "title": "Content",
+                    "content": [
+                        {
+                            "id": "test-table-id",
+                            "type": "table",
+                            "value": make_table_block_value(
+                                title="Test Table 1",
+                                caption="Table caption 1",
+                                source="Test Source",
+                                headers=[["Header 1"]],
+                                rows=[["Row 1 Col 1"]],
+                            ),
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertEqual(self.page.get_cached_paths(), ["/", "/download-table/test-table-id"])
+
 
 class StandardPagesAddViewTests(WagtailTestUtils, TestCase):
     @classmethod

--- a/docs/custom-features/post-publish-actions.md
+++ b/docs/custom-features/post-publish-actions.md
@@ -13,10 +13,13 @@ When a bundle is published, each page triggers registered post-publish actions. 
 
 Actions are registered via a decorator or function call:
 
-- **`SEARCH_UPDATED`** — notifies the search service that a page has been created or updated (see `cms/search/signal_handlers.py`).
 - **`S3_ACL`** — updates S3 object ACLs for private media associated with the page (see `cms/private_media/signal_handlers.py`).
+- **`CACHE_PURGE`** — purges urls specified for the page from the Cloudflare cache (see `cms/frontend_cache/signal_handlers.py`). Only registered when `cms.frontend_cache` app installed.
+- **`SEARCH_UPDATED`** — notifies the search service that a page has been created or updated (see `cms/search/signal_handlers.py`).
 
 New action types can be added by defining a handler that accepts `(page: Page, bundle: Bundle | None)` and registering it with `@post_publish_action(PostPublishActionType.MY_TYPE)` or `register_post_publish_action(...)`.
+
+Registration is conditional on the owning app being installed, so the set of registered actions can be smaller than the total list of action types defined here. `PostPublishAction.objects.active()` returns only actions for which a handler is registered, so they will be ignored by completion polling and retries.
 
 ## Architecture
 
@@ -42,6 +45,41 @@ publish_bundles command / manual publish in wagtail admin
 ### Registry
 
 `cms/post_publish_actions/registry.py` maintains a mapping of `PostPublishActionType` → handler callable. Handlers receive `(page, bundle)` and perform the side effect. Registration happens at app startup (in `signal_handlers.py` / `apps.py`).
+
+#### Priority
+
+Each handler is registered with a priority, `PostPublishActionPriority`.
+
+```python
+class PostPublishActionPriority(IntEnum):
+    HIGH = 1
+    MEDIUM = 2
+    LOW = 3
+```
+
+This determines the order in which actions are executed (sync path) or enqueued (thread pooling). Lower priority integer values run first, and equal numbers are run in registration order.
+
+```python
+register_post_publish_action(
+    PostPublishActionType.CACHE_PURGE,
+    purge_published_page_from_frontend_cache,
+    priority=PostPublishActionPriority.MEDIUM,
+)
+
+
+@post_publish_action(PostPublishActionType.SEARCH_UPDATED, PostPublishActionPriority.LOW)
+def update_index_post_publish_action(page: Page, bundle: Bundle | None) -> None: ...
+```
+
+Alternatively an integer can be passed directly as the priority, which may enable extra high or low values to guarantee a particular action runs first/last.
+
+For now the actions are registered in the following order
+
+| Action Type      | Priority |
+| ---------------- | -------- |
+| `S3_ACL`         | `HIGH`   |
+| `CACHE_PURGE`    | `MEDIUM` |
+| `SEARCH_UPDATED` | `LOW`    |
 
 ### Model
 
@@ -187,6 +225,7 @@ If a bundle is re-published, any actions are deleted and re-created so we don't 
 | `cms/post_publish_actions/signal_handlers.py`                                | Wagtail signal integration and bundle context manager |
 | `cms/post_publish_actions/utils.py`                                          | Completion polling, Slack notification orchestration  |
 | `cms/post_publish_actions/management/commands/retry_post_publish_actions.py` | Retry management command                              |
+| `cms/frontend_cache/signal_handlers.py`                                      | `CACHE_PURGE` action handler                          |
 | `cms/bundles/management/commands/publish_bundles.py`                         | Bundle publishing orchestration                       |
 | `cms/bundles/utils.py`                                                       |                                                       |
 | `cms/search/signal_handlers.py`                                              | `SEARCH_UPDATED` action handler                       |
@@ -200,5 +239,3 @@ Bundles were the first use case for concurrent post-publish actions, but in futu
 
 - Individual page publishes (outside of bundles)
 - Page unpublishes (both inside and outside of bundles)
-
-This will also include new registry actions for custom cache purging (in development on feature branch `feature-frontend-cache-invalidation`).


### PR DESCRIPTION
### What is the context of this PR?

This PR merges the approved PRs related to frontend cache invalidation (CMS-724).

#505 
#696 
#794 
#780 
#785
#797

While updating with `main`, merge conflicts were resolved in the following files:
* `cms/data_downloads/mixins.py`
* `cms/private_media/signal_handlers.py`

### How to review

Ensure that all of the combined changes are still valid and can be merged into `main` without creating any regressions.

- Ensure that the files which had merge conflicts look correct and clean
- Ensure that tests pass
- Ensure that no duplicate code is present
- Ensure that no dead code was left in the codebase
- Ensure that all ACs are still met

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [ ] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [CMS-724](https://officefornationalstatistics.atlassian.net/browse/CMS-724)

[CMS-724]: https://officefornationalstatistics.atlassian.net/browse/CMS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ