### PR TITLE
fix(deps): downgrade dis-authorisation-client-js to ~1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "dis-authorisation-client-js": "^1.2.0"
+        "dis-authorisation-client-js": "~1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^8.0.1",
@@ -7426,9 +7426,9 @@
       }
     },
     "node_modules/dis-authorisation-client-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dis-authorisation-client-js/-/dis-authorisation-client-js-1.2.0.tgz",
-      "integrity": "sha512-S56O7RtJdO+BakFTkteZDw/bXfKldn4p1nmVOY4sEn3EhRkHU4ykSRtBAKoNAlkjmA08N+SkQ+EAv5LTNYZrHg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dis-authorisation-client-js/-/dis-authorisation-client-js-1.1.0.tgz",
+      "integrity": "sha512-2jiiSISW8wBfaraEw53ABXKsS7YcKxpcuiqi066R4fYprbCVtX4lncjbZqRIVu1S950Bq34CyKGdPwiKU+V1XA==",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-dev-server": "^6.0.0"
   },
   "dependencies": {
-    "dis-authorisation-client-js": "^1.2.0"
+    "dis-authorisation-client-js": "~1.1.0"
   },
   "overrides": {
     "sockjs": {


### PR DESCRIPTION
### What is the context of this PR?

Downgrades `dis-authorisation-client-js` from `^1.2.0` to `~1.1.0` to avoid a bug introduced in 1.2. The tilde range allows 1.1.x patch releases while excluding 1.2.

### How to review

Ensure changes make sense

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

- Extends Cognito tests to cover the cases that are currently missed. The bug is a bit obscure, hence the complexity of adding a test