### PR TITLE
feat(chart-api): add RenderedChartImageChooserBlock for chart exporter API

### DIFF
--- a/cms/articles/forms.py
+++ b/cms/articles/forms.py
@@ -4,7 +4,12 @@ from typing import Any
 from wagtail.blocks.stream_block import StreamValue
 from wagtail.models import Page
 
-from cms.core.forms import DeduplicateTopicsAdminForm, PageWithCorrectionsAdminForm, PageWithEquationsAdminForm
+from cms.core.forms import (
+    DeduplicateTopicsAdminForm,
+    PageWithCorrectionsAdminForm,
+    PageWithEquationsAdminForm,
+    PageWithProtectedChartImagesAdminForm,
+)
 
 
 class PageWithHeadlineFiguresAdminForm(DeduplicateTopicsAdminForm):
@@ -42,5 +47,9 @@ class PageWithHeadlineFiguresAdminForm(DeduplicateTopicsAdminForm):
 
 
 class StatisticalArticlePageAdminForm(
-    PageWithHeadlineFiguresAdminForm, PageWithCorrectionsAdminForm, PageWithEquationsAdminForm
-): ...
+    PageWithHeadlineFiguresAdminForm,
+    PageWithCorrectionsAdminForm,
+    PageWithProtectedChartImagesAdminForm,
+    PageWithEquationsAdminForm,
+):
+    protected_chart_image_fields = ("content", "featured_chart")

--- a/cms/core/forms.py
+++ b/cms/core/forms.py
@@ -242,7 +242,7 @@ class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
             raise ImproperlyConfigured(f"{cls.__name__} must define protected_chart_image_fields")
 
     def clean(self) -> dict[str, Any] | None:
-        cleaned_data = super().clean()
+        cleaned_data: dict[str, Any] | None = super().clean()
 
         for field_name in self.protected_chart_image_fields:
             if field_name not in self.cleaned_data:

--- a/cms/core/forms.py
+++ b/cms/core/forms.py
@@ -1,6 +1,8 @@
 import logging
-from typing import Any
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
 from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.admin.forms.choosers import BaseFilterForm, SearchFilterMixin
@@ -8,7 +10,11 @@ from wagtail.admin.forms.pages import CopyForm
 from wagtail.blocks.stream_block import StreamValue
 from wagtail.models import PageLogEntry
 
+from cms.core.blocks.constants import CHART_BLOCK_TYPES
 from cms.core.utils import FORMULA_INDICATORS, latex_formula_to_svg
+
+if TYPE_CHECKING:
+    from wagtail.blocks.stream_block import StreamChild
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +211,51 @@ class PageWithEquationsAdminForm(WagtailAdminPageForm):
                 self._process_content_block(block)
 
         return content
+
+
+def _iter_chart_blocks(value: StreamValue | None) -> Iterator[StreamChild]:
+    """Recursively yield chart blocks from a StreamValue, including those nested in sections."""
+    if not value:
+        return
+    for block in value:
+        if block.block_type == "section":
+            yield from _iter_chart_blocks(block.value.get("content"))
+        elif block.block_type in CHART_BLOCK_TYPES:
+            yield block
+
+
+class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
+    """Discards client-submitted rendered_chart_image references on chart blocks.
+
+    That field is hidden in the editor and populated only by the chart render pipeline, so any
+    value present in submitted form data must be treated as tampering. It is replaced here with
+    whatever is already persisted for the matching block (matched by block id), or with None for
+    blocks that have no persisted match.
+    """
+
+    protected_chart_image_fields: ClassVar[tuple[str, ...]] = ()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # If protected_chart_image_fields is empty, the whole thing is redundant
+        if not cls.protected_chart_image_fields:
+            raise ImproperlyConfigured(f"{cls.__name__} must define protected_chart_image_fields")
+
+    def clean(self) -> dict[str, Any] | None:
+        cleaned_data = super().clean()
+
+        for field_name in self.protected_chart_image_fields:
+            if field_name not in self.cleaned_data:
+                continue
+
+            persisted_images = {
+                block.id: block.value.get("rendered_chart_image")
+                for block in _iter_chart_blocks(getattr(self.instance, field_name, None))
+            }
+            for block in _iter_chart_blocks(self.cleaned_data[field_name]):
+                block.value["rendered_chart_image"] = persisted_images.get(block.id)
+
+        return cleaned_data
 
 
 class ONSCopyForm(CopyForm):

--- a/cms/core/static/js/blocks/chart-block.js
+++ b/cms/core/static/js/blocks/chart-block.js
@@ -1,0 +1,26 @@
+/**
+ * Hides the rendered_chart_image field on chart blocks. It is populated only by the chart
+ * render pipeline and is never edited directly, so it should not be shown in the form.
+ */
+class ChartBlockDefinition extends window.wagtailStreamField.blocks.StructBlockDefinition {
+  hiddenFields = ['rendered_chart_image'];
+
+  render(placeholder, prefix, initialState, initialError) {
+    const block = super.render(placeholder, prefix, initialState, initialError);
+
+    const parent = `[data-streamfield-child]:has([id^="${prefix}"])`;
+
+    this.hiddenFields.forEach((field) => {
+      const fieldContainer = document.querySelector(
+        `${parent} [data-contentpath="${field}"]:has(#${prefix}-${field})`,
+      );
+      if (fieldContainer) {
+        fieldContainer.style.display = 'none';
+      }
+    });
+
+    return block;
+  }
+}
+
+window.telepath.register('cms.datavis.blocks.base.BaseChartBlock', ChartBlockDefinition);

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -3,17 +3,21 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.conf import settings
+from django.forms import Media
 from django.forms.widgets import RadioSelect
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
-from wagtail.blocks.struct_block import StructValue
+from wagtail.admin.telepath import register
+from wagtail.blocks.struct_block import StructBlockAdapter, StructValue
 
 from cms.core.analytics_utils import get_gtm_attributes_file_download
 from cms.core.utils import format_file_size_kb
 from cms.data_downloads.utils import get_csv_download_filename
 from cms.datavis.blocks.chart_options import AspectRatioBlock
+from cms.datavis.blocks.rendered_chart_image import RenderedChartImageChooserBlock
 from cms.datavis.blocks.table import SimpleTableBlock
 from cms.datavis.blocks.utils import get_approximate_file_size_in_kb
 from cms.datavis.constants import AxisType, HighChartsChartType, HighchartsTheme
@@ -118,6 +122,10 @@ class BaseChartBlock(BaseVisualisationBlock):
     )
 
     series_customisation = blocks.StaticBlock()
+
+    # Hidden field populated by the chart render pipeline; see RenderedChartImageChooserBlock
+    # and the tamper-protection form mixin in cms.core.forms for why it must stay off-form.
+    rendered_chart_image = RenderedChartImageChooserBlock(required=False)
 
     def get_context(self, value: StructValue, parent_context: dict[str, Any] | None = None) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context(value, parent_context)
@@ -463,3 +471,26 @@ class BaseChartBlock(BaseVisualisationBlock):
             "data_downloads:revision_chart_download",
             kwargs={"page_id": page.pk, "revision_id": revision_id, "chart_id": block_id},
         )
+
+
+class BaseChartBlockAdapter(StructBlockAdapter):
+    """Hides the rendered_chart_image field from the chart block form.
+
+    The field is populated only by the chart render pipeline, not by editors, so it is hidden
+    client-side here and any submitted value is discarded server-side (see
+    cms.core.forms.PageWithProtectedChartImagesAdminForm). Registering against BaseChartBlock
+    covers every chart block subclass, including the Featured* variants.
+    """
+
+    js_constructor = "cms.datavis.blocks.base.BaseChartBlock"
+
+    @cached_property
+    def media(self) -> Media:
+        structblock_media = super().media
+        return Media(
+            js=[*structblock_media._js, "js/blocks/chart-block.js"],  # pylint: disable=protected-access
+            css=structblock_media._css,  # pylint: disable=protected-access
+        )
+
+
+register(BaseChartBlockAdapter(), BaseChartBlock)

--- a/cms/datavis/blocks/rendered_chart_image.py
+++ b/cms/datavis/blocks/rendered_chart_image.py
@@ -1,9 +1,17 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from django import forms
 from wagtail.blocks import ChooserBlock
 
 from cms.datavis.models import RenderedChartImage
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from django.core.files.uploadedfile import UploadedFile
+    from django.utils.datastructures import MultiValueDict
 
 
 class RenderedChartImageWidget(forms.HiddenInput):
@@ -13,7 +21,8 @@ class RenderedChartImageWidget(forms.HiddenInput):
     editors, so a plain hidden input is enough; there is no need for the full chooser modal UI.
     """
 
-    def value_from_datadict(self, data: dict, files: dict, name: str) -> Any:
+    def value_from_datadict(self, data: Mapping[str, Any], files: MultiValueDict[str, UploadedFile], name: str) -> Any:
+        # Treat the empty string as "nothing chosen", as Wagtail's own chooser widgets do.
         return super().value_from_datadict(data, files, name) or None
 
     def get_value_data(self, value: RenderedChartImage | int | None) -> int | None:

--- a/cms/datavis/blocks/rendered_chart_image.py
+++ b/cms/datavis/blocks/rendered_chart_image.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from django import forms
+from wagtail.blocks import ChooserBlock
+
+from cms.datavis.models import RenderedChartImage
+
+
+class RenderedChartImageWidget(forms.HiddenInput):
+    """Widget for the hidden rendered_chart_image chooser field.
+
+    The field is populated only by the chart render pipeline and never edited directly by
+    editors, so a plain hidden input is enough; there is no need for the full chooser modal UI.
+    """
+
+    def value_from_datadict(self, data: dict, files: dict, name: str) -> Any:
+        return super().value_from_datadict(data, files, name) or None
+
+    def get_value_data(self, value: RenderedChartImage | int | None) -> int | None:
+        if isinstance(value, RenderedChartImage):
+            return value.pk
+        return value
+
+
+class RenderedChartImageChooserBlock(ChooserBlock):
+    target_model = RenderedChartImage
+    widget = RenderedChartImageWidget()
+
+    class Meta:
+        icon = "image"

--- a/cms/datavis/tests/test_chart_image_references.py
+++ b/cms/datavis/tests/test_chart_image_references.py
@@ -1,0 +1,55 @@
+import uuid
+
+from django.test import TestCase
+from wagtail.models import ReferenceIndex
+
+from cms.articles.models import StatisticalArticlePage
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.datavis.models import RenderedChartImage
+from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
+
+
+def chart_block(image_pk):
+    return {
+        "type": "line_chart",
+        "id": str(uuid.uuid4()),
+        "value": {
+            "title": "Test Chart",
+            "audio_description": "Description",
+            "table": TableDataFactory(),
+            "theme": "primary",
+            "rendered_chart_image": image_pk,
+        },
+    }
+
+
+class RenderedChartImageReferenceTests(TestCase):
+    """The privacy machinery keys off references, so the image must be discoverable as one."""
+
+    def setUp(self):
+        self.image = RenderedChartImageFactory()
+        page = StatisticalArticlePageFactory()
+        page.content = [
+            {
+                "type": "section",
+                "id": str(uuid.uuid4()),
+                "value": {"title": "Section", "content": [chart_block(self.image.pk)]},
+            }
+        ]
+        page.featured_chart = [chart_block(self.image.pk)]
+        page.save()
+        self.page = StatisticalArticlePage.objects.get(pk=page.pk)
+
+    def test_image_is_recorded_in_the_reference_index(self):
+        ReferenceIndex.create_or_update_for_object(self.page)
+
+        self.assertTrue(
+            ReferenceIndex.objects.filter(
+                to_content_type__app_label="datavis",
+                to_content_type__model="renderedchartimage",
+                to_object_id=str(self.image.pk),
+            ).exists()
+        )
+
+    def test_image_in_content_is_returned_by_get_referenced_asset_ids(self):
+        self.assertIn(str(self.image.pk), self.page.get_referenced_asset_ids(RenderedChartImage))

--- a/cms/datavis/tests/test_chart_image_tamper_protection.py
+++ b/cms/datavis/tests/test_chart_image_tamper_protection.py
@@ -1,0 +1,93 @@
+import copy
+import uuid
+
+from django.test import TestCase
+from wagtail.blocks.stream_block import StreamValue
+
+from cms.articles.models import StatisticalArticlePage
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
+
+CONTENT_CHART_ID = "11111111-1111-1111-1111-111111111111"
+FEATURED_CHART_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def chart_block_value(image_pk):
+    return {
+        "figure_number": "Figure 1",
+        "title": "Test Chart",
+        "audio_description": "Description",
+        "table": TableDataFactory(),
+        "theme": "primary",
+        "rendered_chart_image": image_pk,
+    }
+
+
+class TamperProtectionTests(TestCase):
+    def setUp(self):
+        self.persisted = RenderedChartImageFactory()
+        self.forged = RenderedChartImageFactory()
+
+        page = StatisticalArticlePageFactory()
+        page.content = [
+            {
+                "type": "section",
+                "id": str(uuid.uuid4()),
+                "value": {
+                    "title": "Section",
+                    "content": [
+                        {
+                            "type": "line_chart",
+                            "id": CONTENT_CHART_ID,
+                            "value": chart_block_value(self.persisted.pk),
+                        }
+                    ],
+                },
+            }
+        ]
+        page.featured_chart = [
+            {"type": "line_chart", "id": FEATURED_CHART_ID, "value": chart_block_value(self.persisted.pk)}
+        ]
+        page.save()
+
+        self.page = StatisticalArticlePage.objects.get(pk=page.pk)
+        self.form_class = self.page.get_edit_handler().get_form_class()
+
+    def _submitted_stream(self, field_name, *, image_pk, block_id=None):
+        """Build an independent stream for the field, with the given image id forced onto charts."""
+        original = getattr(self.page, field_name)
+        raw = copy.deepcopy(original.get_prep_value())
+        for block in raw:
+            charts = block["value"]["content"] if block["type"] == "section" else [block]
+            for chart in charts:
+                chart["value"]["rendered_chart_image"] = image_pk
+                if block_id is not None:
+                    chart["id"] = block_id
+        return StreamValue(original.stream_block, raw, is_lazy=True)
+
+    def test_forged_ids_are_replaced_with_persisted_values(self):
+        form = self.form_class(instance=self.page)
+        form.cleaned_data = {
+            "content": self._submitted_stream("content", image_pk=self.forged.pk),
+            "featured_chart": self._submitted_stream("featured_chart", image_pk=self.forged.pk),
+        }
+
+        form.clean()
+
+        content_chart = form.cleaned_data["content"][0].value["content"][0]
+        featured_chart = form.cleaned_data["featured_chart"][0]
+
+        self.assertEqual(content_chart.value["rendered_chart_image"], self.persisted)
+        self.assertEqual(featured_chart.value["rendered_chart_image"], self.persisted)
+
+    def test_image_on_block_with_no_persisted_match_is_cleared(self):
+        form = self.form_class(instance=self.page)
+        form.cleaned_data = {
+            "featured_chart": self._submitted_stream(
+                "featured_chart", image_pk=self.forged.pk, block_id=str(uuid.uuid4())
+            )
+        }
+
+        form.clean()
+
+        self.assertIsNone(form.cleaned_data["featured_chart"][0].value["rendered_chart_image"])

--- a/cms/datavis/tests/test_chart_image_tamper_protection.py
+++ b/cms/datavis/tests/test_chart_image_tamper_protection.py
@@ -7,6 +7,8 @@ from wagtail.blocks.stream_block import StreamValue
 from cms.articles.models import StatisticalArticlePage
 from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
+from cms.methodology.models import MethodologyPage
+from cms.methodology.tests.factories import MethodologyPageFactory
 
 CONTENT_CHART_ID = "11111111-1111-1111-1111-111111111111"
 FEATURED_CHART_ID = "22222222-2222-2222-2222-222222222222"
@@ -91,3 +93,43 @@ class TamperProtectionTests(TestCase):
         form.clean()
 
         self.assertIsNone(form.cleaned_data["featured_chart"][0].value["rendered_chart_image"])
+
+
+class MethodologyPageTamperProtectionTests(TestCase):
+    def setUp(self):
+        self.persisted = RenderedChartImageFactory()
+        self.forged = RenderedChartImageFactory()
+
+        page = MethodologyPageFactory()
+        page.content = [
+            {
+                "type": "section",
+                "id": str(uuid.uuid4()),
+                "value": {
+                    "title": "Section",
+                    "content": [
+                        {
+                            "type": "line_chart",
+                            "id": CONTENT_CHART_ID,
+                            "value": chart_block_value(self.persisted.pk),
+                        }
+                    ],
+                },
+            }
+        ]
+        page.save()
+
+        self.page = MethodologyPage.objects.get(pk=page.pk)
+
+    def test_forged_id_is_replaced_with_persisted_value(self):
+        form_class = self.page.get_edit_handler().get_form_class()
+        raw = copy.deepcopy(self.page.content.get_prep_value())
+        raw[0]["value"]["content"][0]["value"]["rendered_chart_image"] = self.forged.pk
+
+        form = form_class(instance=self.page)
+        form.cleaned_data = {"content": StreamValue(self.page.content.stream_block, raw, is_lazy=True)}
+
+        form.clean()
+
+        chart = form.cleaned_data["content"][0].value["content"][0]
+        self.assertEqual(chart.value["rendered_chart_image"], self.persisted)

--- a/cms/methodology/forms.py
+++ b/cms/methodology/forms.py
@@ -1,0 +1,5 @@
+from cms.core.forms import PageWithEquationsAdminForm, PageWithProtectedChartImagesAdminForm
+
+
+class MethodologyPageAdminForm(PageWithProtectedChartImagesAdminForm, PageWithEquationsAdminForm):
+    protected_chart_image_fields = ("content",)

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -16,13 +16,13 @@ from cms.bundles.mixins import BundledPageMixin
 from cms.core.analytics_utils import add_table_of_contents_gtm_attributes, format_date_for_gtm
 from cms.core.blocks.stream_blocks import SectionStoryBlock
 from cms.core.fields import StreamField
-from cms.core.forms import PageWithEquationsAdminForm
 from cms.core.models import BasePage
 from cms.core.models.mixins import NoTrailingSlashRoutablePageMixin
 from cms.core.query import order_by_pk_position
 from cms.core.utils import redirect_to_parent_listing
 from cms.core.widgets import date_widget
 from cms.data_downloads.mixins import DataDownloadMixin
+from cms.methodology.forms import MethodologyPageAdminForm
 from cms.taxonomy.mixins import GenericTaxonomyMixin
 
 if TYPE_CHECKING:
@@ -88,7 +88,7 @@ class MethodologyPage(  # type: ignore[django-manager-missing]
     GenericTaxonomyMixin,
     BasePage,
 ):
-    base_form_class = PageWithEquationsAdminForm
+    base_form_class = MethodologyPageAdminForm
     parent_page_types: ClassVar[list[str]] = ["MethodologyIndexPage"]
     search_index_content_type: ClassVar[str] = "static_methodology"
     template = "templates/pages/methodology_page.html"


### PR DESCRIPTION
### What is the context of this PR?

This PR is part of a stack and addresses CMS-1286. It adds a `RenderedChartImageChooserBlock` which is similar to previously implemented custom blocks which have hidden elements / tamper protection.

The chooser block exists so Wagtail's `ReferenceIndex` sees the page to image relationship.

`_publish_media` ([cms/private_media/signal_handlers.py](https://github.com/ONSdigital/dis-wagtail/blob/eaa1bb95de81eb3cf12df0892b0f1a3b76e03c98/cms/private_media/signal_handlers.py#L21)) calls `ReferenceIndex.get_references_for_object(page)`, filters to the model's content type, and runs `bulk_make_public` on what it finds.

### How to review

* Ensure that all tests pass
* Confirm that data cannot be modified by the user, and tamper protection works

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Merge stack

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---
Ticket: [CMS-1286](https://officefornationalstatistics.atlassian.net/browse/CMS-1286)

[CMS-1286]: https://officefornationalstatistics.atlassian.net/browse/CMS-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ