### PR TITLE
feat(chart-api): add chart generation triggers, preview, download and tests

### DIFF
--- a/cms/articles/forms.py
+++ b/cms/articles/forms.py
@@ -51,5 +51,4 @@ class StatisticalArticlePageAdminForm(
     PageWithCorrectionsAdminForm,
     PageWithProtectedChartImagesAdminForm,
     PageWithEquationsAdminForm,
-):
-    protected_chart_image_fields = ("content", "featured_chart")
+): ...

--- a/cms/articles/models.py
+++ b/cms/articles/models.py
@@ -42,6 +42,7 @@ from cms.datasets.utils import format_datasets_as_document_list
 from cms.datavis.blocks.base import BaseChartBlock
 from cms.datavis.blocks.featured_charts import FeaturedChartBlock
 from cms.datavis.blocks.iframe import IframeBlock
+from cms.datavis.mixins import ChartImageRenderMixin
 from cms.taxonomy.mixins import GenericTaxonomyMixin
 
 if TYPE_CHECKING:
@@ -237,6 +238,7 @@ class ArticleSeriesPage(  # type: ignore[django-manager-missing]
 
 # pylint: disable=too-many-public-methods
 class StatisticalArticlePage(  # type: ignore[django-manager-missing]
+    ChartImageRenderMixin,
     DataDownloadMixin,
     BundledPageMixin,
     NoTrailingSlashRoutablePageMixin,
@@ -248,6 +250,7 @@ class StatisticalArticlePage(  # type: ignore[django-manager-missing]
     """
 
     base_form_class = StatisticalArticlePageAdminForm
+    chart_image_fields: ClassVar[tuple[str, ...]] = ("content", "featured_chart")
 
     schema_org_type = "Article"
 

--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -20,6 +20,7 @@ from cms.bundles.enums import ACTIVE_BUNDLE_STATUS_CHOICES, EDITABLE_BUNDLE_STAT
 from cms.core.forms import DeduplicateInlinePanelAdminForm
 from cms.datasets.models import Dataset, ONSDataset
 from cms.datasets.utils import get_dataset_for_published_state, get_local_topic_ids, update_dataset_metadata
+from cms.datavis.services import render_charts_for_page
 from cms.workflows.utils import is_page_ready_to_publish
 
 from .bundle_api_sync_service import BundleAPISyncService
@@ -423,6 +424,36 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
                 "Please save your changes first, then Approve the bundle in a separate step."
             )
 
+    def _validate_charts_render_for_review(self) -> None:
+        """Renders charts for every bundled page when the bundle moves into review.
+
+        Runs synchronously; a failed render blocks the transition to IN_REVIEW so a page never
+        enters review with a stale or missing chart image.
+        """
+        moving_into_review = (
+            self.cleaned_data.get("status") == BundleStatus.IN_REVIEW.value
+            and self.original_status != BundleStatus.IN_REVIEW.value
+        )
+        if not moving_into_review:
+            return
+        if "bundled_pages" not in self.formsets:
+            return
+
+        render_errors: list[str] = []
+        for form in self.formsets["bundled_pages"].forms:
+            if not form.is_valid() or form.cleaned_data.get("DELETE"):
+                continue
+
+            if page := form.clean().get("page"):
+                for result in render_charts_for_page(page.specific):
+                    if result.error:
+                        render_errors.append(f"'{page}': {result.error}")
+
+        if render_errors:
+            # revert the status change back to original to prevent the transition from applying
+            self.cleaned_data["status"] = self.instance.status
+            raise ValidationError(["Could not render charts for one or more pages in this bundle:", *render_errors])
+
     def _validate_approval(self) -> None:
         if self.cleaned_data.get("status") != BundleStatus.APPROVED.value:
             return
@@ -463,6 +494,9 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
 
         # On approval, this must run before any other validation
         self._validate_approval()
+
+        # On moving into review, render charts for every bundled page before anything else
+        self._validate_charts_render_for_review()
 
         self._validate_publication_date()
 

--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -20,7 +20,6 @@ from cms.bundles.enums import ACTIVE_BUNDLE_STATUS_CHOICES, EDITABLE_BUNDLE_STAT
 from cms.core.forms import DeduplicateInlinePanelAdminForm
 from cms.datasets.models import Dataset, ONSDataset
 from cms.datasets.utils import get_dataset_for_published_state, get_local_topic_ids, update_dataset_metadata
-from cms.datavis.services import render_charts_for_page
 from cms.workflows.utils import is_page_ready_to_publish
 
 from .bundle_api_sync_service import BundleAPISyncService
@@ -424,36 +423,6 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
                 "Please save your changes first, then Approve the bundle in a separate step."
             )
 
-    def _validate_charts_render_for_review(self) -> None:
-        """Renders charts for every bundled page when the bundle moves into review.
-
-        Runs synchronously; a failed render blocks the transition to IN_REVIEW so a page never
-        enters review with a stale or missing chart image.
-        """
-        moving_into_review = (
-            self.cleaned_data.get("status") == BundleStatus.IN_REVIEW.value
-            and self.original_status != BundleStatus.IN_REVIEW.value
-        )
-        if not moving_into_review:
-            return
-        if "bundled_pages" not in self.formsets:
-            return
-
-        render_errors: list[str] = []
-        for form in self.formsets["bundled_pages"].forms:
-            if not form.is_valid() or form.cleaned_data.get("DELETE"):
-                continue
-
-            if page := form.clean().get("page"):
-                for result in render_charts_for_page(page.specific):
-                    if result.error:
-                        render_errors.append(f"'{page}': {result.error}")
-
-        if render_errors:
-            # revert the status change back to original to prevent the transition from applying
-            self.cleaned_data["status"] = self.instance.status
-            raise ValidationError(["Could not render charts for one or more pages in this bundle:", *render_errors])
-
     def _validate_approval(self) -> None:
         if self.cleaned_data.get("status") != BundleStatus.APPROVED.value:
             return
@@ -494,9 +463,6 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
 
         # On approval, this must run before any other validation
         self._validate_approval()
-
-        # On moving into review, render charts for every bundled page before anything else
-        self._validate_charts_render_for_review()
 
         self._validate_publication_date()
 

--- a/cms/bundles/tests/test_forms.py
+++ b/cms/bundles/tests/test_forms.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from typing import Any
+from unittest.mock import patch
 
 from django import forms
 from django.test import TestCase
@@ -14,6 +15,7 @@ from cms.bundles.models import Bundle
 from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory, BundlePageFactory, BundleTeamFactory
 from cms.bundles.viewsets.bundle_chooser import BundleChooserWidget
 from cms.datasets.tests.factories import DatasetFactory
+from cms.datavis.services import ChartRenderResult
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.teams.tests.factories import TeamFactory
 from cms.users.tests.factories import UserFactory
@@ -601,3 +603,64 @@ class BundleAdminFormTestCase(TestCase):
 
         # assert bundled_pages not in formsets
         self.assertEqual(form.formsets, {})
+
+
+class BundleChartRenderTriggerTestCase(TestCase):
+    """Covers the bundle trigger: rendering charts for every bundled page on DRAFT -> IN_REVIEW."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.bundle = BundleFactory(name="Chart Bundle")
+        cls.form_class = get_edit_handler(Bundle).get_form_class()
+        cls.page = StatisticalArticlePageFactory(title="Chart Page")
+
+    def raw_form_data(self) -> dict[str, Any]:
+        return {
+            "name": self.bundle.name,
+            "status": BundleStatus.IN_REVIEW,
+            "bundled_pages": inline_formset([{"page": self.page.id}]),
+            "teams": inline_formset([]),
+            "bundled_datasets": inline_formset([]),
+        }
+
+    @patch("cms.bundles.forms.render_charts_for_page")
+    def test_moving_to_in_review_renders_charts_for_every_bundled_page(self, mock_render):
+        mock_render.return_value = [ChartRenderResult(block_id="x", changed=True)]
+
+        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
+
+        self.assertTrue(form.is_valid(), form.errors)
+        mock_render.assert_called_once()
+        self.assertEqual(mock_render.call_args.args[0].pk, self.page.pk)
+
+    @patch("cms.bundles.forms.render_charts_for_page")
+    def test_render_failure_blocks_the_transition_to_in_review(self, mock_render):
+        mock_render.return_value = [ChartRenderResult(block_id="x", changed=False, error="Something went wrong")]
+
+        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
+
+        self.assertFalse(form.is_valid())
+        self.assertFormError(
+            form,
+            None,
+            ["Could not render charts for one or more pages in this bundle:", "'Chart Page': Something went wrong"],
+        )
+        self.assertEqual(form.cleaned_data["status"], self.bundle.status)
+
+    @patch("cms.bundles.forms.render_charts_for_page")
+    def test_unchanged_config_does_not_block_the_transition(self, mock_render):
+        mock_render.return_value = [ChartRenderResult(block_id="x", changed=False, error=None)]
+
+        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+    @patch("cms.bundles.forms.render_charts_for_page")
+    def test_does_not_render_again_when_already_in_review(self, mock_render):
+        self.bundle.status = BundleStatus.IN_REVIEW
+        self.bundle.save(update_fields=["status"])
+
+        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
+        form.is_valid()
+
+        mock_render.assert_not_called()

--- a/cms/bundles/tests/test_forms.py
+++ b/cms/bundles/tests/test_forms.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 from typing import Any
-from unittest.mock import patch
 
 from django import forms
 from django.test import TestCase
@@ -15,7 +14,6 @@ from cms.bundles.models import Bundle
 from cms.bundles.tests.factories import BundleDatasetFactory, BundleFactory, BundlePageFactory, BundleTeamFactory
 from cms.bundles.viewsets.bundle_chooser import BundleChooserWidget
 from cms.datasets.tests.factories import DatasetFactory
-from cms.datavis.services import ChartRenderResult
 from cms.release_calendar.tests.factories import ReleaseCalendarPageFactory
 from cms.teams.tests.factories import TeamFactory
 from cms.users.tests.factories import UserFactory
@@ -603,64 +601,3 @@ class BundleAdminFormTestCase(TestCase):
 
         # assert bundled_pages not in formsets
         self.assertEqual(form.formsets, {})
-
-
-class BundleChartRenderTriggerTestCase(TestCase):
-    """Covers the bundle trigger: rendering charts for every bundled page on DRAFT -> IN_REVIEW."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.bundle = BundleFactory(name="Chart Bundle")
-        cls.form_class = get_edit_handler(Bundle).get_form_class()
-        cls.page = StatisticalArticlePageFactory(title="Chart Page")
-
-    def raw_form_data(self) -> dict[str, Any]:
-        return {
-            "name": self.bundle.name,
-            "status": BundleStatus.IN_REVIEW,
-            "bundled_pages": inline_formset([{"page": self.page.id}]),
-            "teams": inline_formset([]),
-            "bundled_datasets": inline_formset([]),
-        }
-
-    @patch("cms.bundles.forms.render_charts_for_page")
-    def test_moving_to_in_review_renders_charts_for_every_bundled_page(self, mock_render):
-        mock_render.return_value = [ChartRenderResult(block_id="x", changed=True)]
-
-        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
-
-        self.assertTrue(form.is_valid(), form.errors)
-        mock_render.assert_called_once()
-        self.assertEqual(mock_render.call_args.args[0].pk, self.page.pk)
-
-    @patch("cms.bundles.forms.render_charts_for_page")
-    def test_render_failure_blocks_the_transition_to_in_review(self, mock_render):
-        mock_render.return_value = [ChartRenderResult(block_id="x", changed=False, error="Something went wrong")]
-
-        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
-
-        self.assertFalse(form.is_valid())
-        self.assertFormError(
-            form,
-            None,
-            ["Could not render charts for one or more pages in this bundle:", "'Chart Page': Something went wrong"],
-        )
-        self.assertEqual(form.cleaned_data["status"], self.bundle.status)
-
-    @patch("cms.bundles.forms.render_charts_for_page")
-    def test_unchanged_config_does_not_block_the_transition(self, mock_render):
-        mock_render.return_value = [ChartRenderResult(block_id="x", changed=False, error=None)]
-
-        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
-
-        self.assertTrue(form.is_valid(), form.errors)
-
-    @patch("cms.bundles.forms.render_charts_for_page")
-    def test_does_not_render_again_when_already_in_review(self, mock_render):
-        self.bundle.status = BundleStatus.IN_REVIEW
-        self.bundle.save(update_fields=["status"])
-
-        form = self.form_class(instance=self.bundle, data=nested_form_data(self.raw_form_data()))
-        form.is_valid()
-
-        mock_render.assert_not_called()

--- a/cms/core/forms.py
+++ b/cms/core/forms.py
@@ -1,6 +1,5 @@
 import logging
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
@@ -10,11 +9,8 @@ from wagtail.admin.forms.pages import CopyForm
 from wagtail.blocks.stream_block import StreamValue
 from wagtail.models import PageLogEntry
 
-from cms.core.blocks.constants import CHART_BLOCK_TYPES
 from cms.core.utils import FORMULA_INDICATORS, latex_formula_to_svg
-
-if TYPE_CHECKING:
-    from wagtail.blocks.stream_block import StreamChild
+from cms.datavis.services import iter_chart_blocks, render_chart_blocks
 
 logger = logging.getLogger(__name__)
 
@@ -213,24 +209,18 @@ class PageWithEquationsAdminForm(WagtailAdminPageForm):
         return content
 
 
-def _iter_chart_blocks(value: StreamValue | None) -> Iterator[StreamChild]:
-    """Recursively yield chart blocks from a StreamValue, including those nested in sections."""
-    if not value:
-        return
-    for block in value:
-        if block.block_type == "section":
-            yield from _iter_chart_blocks(block.value.get("content"))
-        elif block.block_type in CHART_BLOCK_TYPES:
-            yield block
-
-
 class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
-    """Discards client-submitted rendered_chart_image references on chart blocks.
+    """Discards client-submitted rendered_chart_image references on chart blocks, and renders
+    charts on submission for review.
 
-    That field is hidden in the editor and populated only by the chart render pipeline, so any
-    value present in submitted form data must be treated as tampering. It is replaced here with
-    whatever is already persisted for the matching block (matched by block id), or with None for
-    blocks that have no persisted match.
+    The rendered_chart_image field is hidden in the editor and populated only by the chart
+    render pipeline, so any value present in submitted form data must be treated as tampering.
+    It is replaced here with whatever is already persisted for the matching block (matched by
+    block id), or with None for blocks that have no persisted match.
+
+    When the page is submitted for review, every chart block's image is (re-)rendered
+    synchronously so a failed render blocks the transition with a form error, rather than
+    letting a page reach review with a stale or missing chart image.
     """
 
     protected_chart_image_fields: ClassVar[tuple[str, ...]] = ()
@@ -250,12 +240,26 @@ class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
 
             persisted_images = {
                 block.id: block.value.get("rendered_chart_image")
-                for block in _iter_chart_blocks(getattr(self.instance, field_name, None))
+                for block in iter_chart_blocks(getattr(self.instance, field_name, None))
             }
-            for block in _iter_chart_blocks(self.cleaned_data[field_name]):
+            for block in iter_chart_blocks(self.cleaned_data[field_name]):
                 block.value["rendered_chart_image"] = persisted_images.get(block.id)
 
+        if self.data.get("action-submit"):
+            self._render_charts_for_submission()
+
         return cleaned_data
+
+    def _render_charts_for_submission(self) -> None:
+        blocks = [
+            block
+            for field_name in self.protected_chart_image_fields
+            if field_name in self.cleaned_data
+            for block in iter_chart_blocks(self.cleaned_data[field_name])
+        ]
+        errors = [result.error for result in render_chart_blocks(blocks) if result.error]
+        if errors:
+            raise ValidationError(errors)
 
 
 class ONSCopyForm(CopyForm):

--- a/cms/core/forms.py
+++ b/cms/core/forms.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, ClassVar
+from typing import Any
 
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
@@ -218,23 +218,30 @@ class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
     It is replaced here with whatever is already persisted for the matching block (matched by
     block id), or with None for blocks that have no persisted match.
 
-    When the page is submitted for review, every chart block's image is (re-)rendered
-    synchronously so a failed render blocks the transition with a form error, rather than
-    letting a page reach review with a stale or missing chart image.
+    Images are pre-rendered on every revision by ``ChartImageRenderMixin``, but that is best
+    effort. Submitting for review re-checks every chart block synchronously, and blocks the
+    transition with a form error if any image cannot be produced, so a page never reaches
+    review with a missing or stale chart image. Blocks whose attached image still matches the
+    current config hash are skipped, so this normally reaches the exporter only for the ones
+    the pre-render failed to produce.
+
+    The set of fields to cover is declared as ``chart_image_fields`` on the page model, via
+    ``ChartImageRenderMixin``.
     """
 
-    protected_chart_image_fields: ClassVar[tuple[str, ...]] = ()
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        # If protected_chart_image_fields is empty, the whole thing is redundant
-        if not cls.protected_chart_image_fields:
-            raise ImproperlyConfigured(f"{cls.__name__} must define protected_chart_image_fields")
+        if not getattr(self.instance, "chart_image_fields", ()):
+            raise ImproperlyConfigured(
+                f"{type(self.instance).__name__} must apply ChartImageRenderMixin and define chart_image_fields "
+                f"to be used with {type(self).__name__}"
+            )
 
     def clean(self) -> dict[str, Any] | None:
         cleaned_data: dict[str, Any] | None = super().clean()
 
-        for field_name in self.protected_chart_image_fields:
+        for field_name in self.instance.chart_image_fields:
             if field_name not in self.cleaned_data:
                 continue
 
@@ -253,7 +260,7 @@ class PageWithProtectedChartImagesAdminForm(WagtailAdminPageForm):
     def _render_charts_for_submission(self) -> None:
         blocks = [
             block
-            for field_name in self.protected_chart_image_fields
+            for field_name in self.instance.chart_image_fields
             if field_name in self.cleaned_data
             for block in iter_chart_blocks(self.cleaned_data[field_name])
         ]

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -130,9 +130,14 @@ class BaseChartBlock(BaseVisualisationBlock):
     def get_context(self, value: StructValue, parent_context: dict[str, Any] | None = None) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context(value, parent_context)
 
-        context["chart_config"] = self.get_component_config(
-            value, parent_context=parent_context, block_id=context.get("block_id")
-        )
+        chart_config = self.get_component_config(value, parent_context=parent_context, block_id=context.get("block_id"))
+        # Image added here rather than in get_component_config, since get_export_config reuses that
+        # method to build the chart exporter API payload: including the rendered image's own
+        # URL there would make the config self-referential, changing on every render and
+        # defeating the config_hash idempotency check.
+        if rendered_chart_image := value.get("rendered_chart_image"):
+            chart_config["fallbackImageUrl"] = rendered_chart_image.url
+        context["chart_config"] = chart_config
         return context
 
     def get_highcharts_chart_type(self, value: StructValue) -> str:

--- a/cms/datavis/blocks/base.py
+++ b/cms/datavis/blocks/base.py
@@ -8,6 +8,7 @@ from django.forms.widgets import RadioSelect
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.html import strip_tags
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.admin.telepath import register
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
     from cms.core.models import BasePage
+    from cms.datavis.models import RenderedChartImage
 
 
 AnnotationsList = list[dict[str, Any]]
@@ -343,12 +345,52 @@ class BaseChartBlock(BaseVisualisationBlock):
 
         return options
 
-    @staticmethod
-    def _get_image_download_item() -> dict[str, str]:
-        # Placeholder for future image download implementation
+    def _get_image_download_item(
+        self,
+        *,
+        value: StructValue,
+        parent_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Download item for the chart image rendered by the chart exporter.
+
+        Returns None until an image has been rendered, so the menu never offers a dead link.
+        """
+        image: RenderedChartImage | None = value.get("rendered_chart_image")
+        if not image:
+            return None
+
+        size_suffix = f"({format_file_size_kb(image.size_bytes, decimal_places=0, minimum=1)}KB)"
+        link_text = _("Download image %(size)s") % {"size": size_suffix}
+
+        # Resolves to the serve view while the image is private, and to the file itself
+        # once the page is published and the image made public.
+        image_url = image.url
+        request: HttpRequest | None = parent_context.get("request") if parent_context else None
+        # No-op for the already-absolute URL of a public image.
+        absolute_image_url = request.build_absolute_uri(image_url) if request else image_url
+
         return {
-            "text": "Download image (18KB)",
-            "url": "xyz",
+            "text": link_text,
+            "url": image_url,
+            # Matches the image block's download item (see cms.core.blocks.embeddable).
+            "download": "file",
+            "attributes": self._get_gtm_attributes_image_download(link_text, absolute_image_url, image, value),
+        }
+
+    def _get_gtm_attributes_image_download(
+        self, text: str, url: str, image: RenderedChartImage, value: StructValue
+    ) -> dict[str, str]:
+        file_name = f"{slugify(value.get('title') or '') or 'chart'}.png"
+        return {
+            **get_gtm_attributes_file_download(
+                text=text,
+                url=url,
+                file_extension="png",
+                file_name=file_name,
+                file_size_kb=format_file_size_kb(image.size_bytes),
+            ),
+            "data-ga-chart-title": value.get("title"),
+            "data-ga-chart-type": self.get_highcharts_chart_type(value),
         }
 
     def _get_csv_download_item(
@@ -409,7 +451,8 @@ class BaseChartBlock(BaseVisualisationBlock):
         rows: list[list[str | int | float]] | None = None,
     ) -> dict[str, Any]:
         items_list: list[dict[str, Any]] = []
-        items_list.append(self._get_image_download_item())
+        if image_item := self._get_image_download_item(value=value, parent_context=parent_context):
+            items_list.append(image_item)
         if csv_item := self._get_csv_download_item(
             value=value,
             parent_context=parent_context,

--- a/cms/datavis/mixins.py
+++ b/cms/datavis/mixins.py
@@ -1,0 +1,53 @@
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.core.exceptions import ImproperlyConfigured
+
+from cms.datavis.services import iter_chart_blocks, render_chart_blocks
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from wagtail.blocks.stream_block import StreamChild
+    from wagtail.models import Revision
+
+logger = logging.getLogger(__name__)
+
+
+class ChartImageRenderMixin:
+    """Pre-renders chart fallback images whenever a revision is saved.
+
+    This is best effort: a failed render is logged and leaves whatever image is already
+    attached in place, so an exporter outage never stops an editor saving their work. The
+    guarantee that images are present and current comes from
+    ``PageWithProtectedChartImagesAdminForm``, which renders synchronously and blocks
+    submission for review on failure. A bundle can only be approved once every bundled page
+    has passed through that gate, via its own workflow reaching a review task, so nothing
+    further is needed at the bundle level.
+
+    ``chart_image_fields`` also drives the tamper protection in
+    ``PageWithProtectedChartImagesAdminForm``, so both must be applied to the same page model.
+    """
+
+    chart_image_fields: ClassVar[tuple[str, ...]] = ()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not cls.chart_image_fields:
+            raise ImproperlyConfigured(f"{cls.__name__} must define chart_image_fields")
+
+    def get_chart_blocks(self) -> Iterator[StreamChild]:
+        for field_name in self.chart_image_fields:
+            yield from iter_chart_blocks(getattr(self, field_name, None))
+
+    def save_revision(self, *args: Any, **kwargs: Any) -> Revision:
+        try:
+            render_chart_blocks(self.get_chart_blocks())
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Saving must never fail because of the exporter, so nothing may escape here.
+            logger.exception(
+                "Could not pre-render chart images",
+                extra={"page_id": self.pk},  # type: ignore[attr-defined]
+            )
+
+        return super().save_revision(*args, **kwargs)  # type: ignore[misc]

--- a/cms/datavis/permissions.py
+++ b/cms/datavis/permissions.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from wagtail.documents.permissions import permission_policy as document_permission_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from cms.datavis.models import RenderedChartImage
+    from cms.users.models import User
+
+
+class RenderedChartImagePermissionPolicy:
+    """A minimal permission policy for `RenderedChartImage`, for use with `user_can_access_asset`.
+
+    Unlike documents and images, `RenderedChartImage` has no collection and no admin UI of its
+    own to assign per-instance permissions against; it's populated only by the chart render
+    pipeline. So instead of a per-instance check, editorial access is gated on the general
+    Wagtail document permissions, since anyone who can manage documents already handles
+    similarly-private media. Draft-preview access (e.g. via a bundle preview link) is handled
+    separately by the bundle-preview cookie check in `user_can_access_asset`, not this policy.
+    """
+
+    def user_has_any_permission_for_instance(
+        self,
+        user: User,
+        actions: Sequence[str],
+        instance: RenderedChartImage,  # pylint: disable=unused-argument
+    ) -> bool:
+        return bool(document_permission_policy.user_has_any_permission(user, actions))
+
+
+rendered_chart_image_permission_policy = RenderedChartImagePermissionPolicy()

--- a/cms/datavis/services.py
+++ b/cms/datavis/services.py
@@ -1,0 +1,113 @@
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cms.core.blocks.constants import CHART_BLOCK_TYPES
+from cms.datavis.clients.chart_exporter import (
+    ChartExporterClient,
+    ChartExporterError,
+    ChartExporterMalformedRequest,
+    ChartExporterUnavailable,
+)
+from cms.datavis.models import RenderedChartImage
+from cms.datavis.utils import hash_chart_config
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from wagtail.blocks.stream_block import StreamChild, StreamValue
+    from wagtail.models import Page
+
+logger = logging.getLogger(__name__)
+
+GENERIC_RENDER_ERROR = "This chart could not be rendered. Please contact support."
+UNAVAILABLE_RENDER_ERROR = "The chart rendering service is temporarily unavailable. Please try again."
+
+
+@dataclass(frozen=True)
+class ChartRenderResult:
+    block_id: str
+    changed: bool
+    error: str | None = None
+
+
+def iter_chart_blocks(value: StreamValue | None) -> Iterator[StreamChild]:
+    """Recursively yield chart blocks from a StreamValue, including those nested in sections."""
+    if not value:
+        return
+    for block in value:
+        if block.block_type == "section":
+            yield from iter_chart_blocks(block.value.get("content"))
+        elif block.block_type in CHART_BLOCK_TYPES:
+            yield block
+
+
+def _render_chart_block(block: StreamChild, client: ChartExporterClient) -> ChartRenderResult:
+    config = block.block.get_export_config(block.value)
+    config_hash = hash_chart_config(config)
+
+    existing = block.value.get("rendered_chart_image")
+    if isinstance(existing, RenderedChartImage) and existing.config_hash == config_hash:
+        return ChartRenderResult(block_id=block.id, changed=False)
+
+    try:
+        response = client.create_chart(config)
+    except ChartExporterMalformedRequest:
+        return ChartRenderResult(block_id=block.id, changed=False, error=GENERIC_RENDER_ERROR)
+    except ChartExporterUnavailable:
+        return ChartRenderResult(block_id=block.id, changed=False, error=UNAVAILABLE_RENDER_ERROR)
+    except ChartExporterError:
+        return ChartRenderResult(block_id=block.id, changed=False, error=GENERIC_RENDER_ERROR)
+
+    if response is None:
+        # Integration disabled: nothing to attach.
+        return ChartRenderResult(block_id=block.id, changed=False)
+
+    image = RenderedChartImage.objects.create_from_export_response(response, config_hash=config_hash)
+    block.value["rendered_chart_image"] = image
+    return ChartRenderResult(block_id=block.id, changed=True)
+
+
+def render_chart_blocks(blocks: Iterable[StreamChild]) -> list[ChartRenderResult]:
+    """Render (or reuse) chart images for the given chart blocks, in place.
+
+    Each block's ``rendered_chart_image`` value is updated directly when a new image is
+    created or reused. Blocks whose config hash already matches their currently attached
+    image are skipped, so unchanged charts are not re-rendered on resubmission.
+    """
+    blocks = list(blocks)
+    if not blocks:
+        return []
+
+    client = ChartExporterClient()
+    start = time.monotonic()
+    results = [_render_chart_block(block, client) for block in blocks]
+    duration = time.monotonic() - start
+
+    logger.info(
+        "Rendered %d chart block(s) in %.2fs (%d failed)",
+        len(blocks),
+        duration,
+        sum(1 for result in results if result.error),
+    )
+    return results
+
+
+def render_charts_for_page(page: Page) -> list[ChartRenderResult]:
+    """Render (or reuse) chart images for every chart block on the page's latest revision.
+
+    Saves a new revision when any image changed, so the result is carried by a subsequent
+    publish. Operates on the latest revision's content rather than the live page, since this
+    is called ahead of a page being submitted for review, before it may ever be published.
+    """
+    revision_page = page.get_latest_revision_as_object()
+    field_names = getattr(type(revision_page).base_form_class, "protected_chart_image_fields", ())
+    blocks = [
+        block for field_name in field_names for block in iter_chart_blocks(getattr(revision_page, field_name, None))
+    ]
+
+    results = render_chart_blocks(blocks)
+    if any(result.changed for result in results):
+        revision_page.save_revision(log_action=False)
+    return results

--- a/cms/datavis/services.py
+++ b/cms/datavis/services.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from wagtail.blocks.stream_block import StreamChild, StreamValue
-    from wagtail.models import Page
 
 logger = logging.getLogger(__name__)
 
@@ -91,23 +90,4 @@ def render_chart_blocks(blocks: Iterable[StreamChild]) -> list[ChartRenderResult
         duration,
         sum(1 for result in results if result.error),
     )
-    return results
-
-
-def render_charts_for_page(page: Page) -> list[ChartRenderResult]:
-    """Render (or reuse) chart images for every chart block on the page's latest revision.
-
-    Saves a new revision when any image changed, so the result is carried by a subsequent
-    publish. Operates on the latest revision's content rather than the live page, since this
-    is called ahead of a page being submitted for review, before it may ever be published.
-    """
-    revision_page = page.get_latest_revision_as_object()
-    field_names = getattr(type(revision_page).base_form_class, "protected_chart_image_fields", ())
-    blocks = [
-        block for field_name in field_names for block in iter_chart_blocks(getattr(revision_page, field_name, None))
-    ]
-
-    results = render_chart_blocks(blocks)
-    if any(result.changed for result in results):
-        revision_page.save_revision(log_action=False)
     return results

--- a/cms/datavis/services.py
+++ b/cms/datavis/services.py
@@ -1,7 +1,10 @@
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from django.conf import settings
 
 from cms.core.blocks.constants import CHART_BLOCK_TYPES
 from cms.datavis.clients.chart_exporter import (
@@ -9,6 +12,7 @@ from cms.datavis.clients.chart_exporter import (
     ChartExporterError,
     ChartExporterMalformedRequest,
     ChartExporterUnavailable,
+    ChartObjectResponse,
 )
 from cms.datavis.models import RenderedChartImage
 from cms.datavis.utils import hash_chart_config
@@ -31,6 +35,14 @@ class ChartRenderResult:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class ChartFetched:
+    """A chart image is ready to be created from this exporter response."""
+
+    response: ChartObjectResponse
+    config_hash: str
+
+
 def iter_chart_blocks(value: StreamValue | None) -> Iterator[StreamChild]:
     """Recursively yield chart blocks from a StreamValue, including those nested in sections."""
     if not value:
@@ -42,7 +54,13 @@ def iter_chart_blocks(value: StreamValue | None) -> Iterator[StreamChild]:
             yield block
 
 
-def _render_chart_block(block: StreamChild, client: ChartExporterClient) -> ChartRenderResult:
+def _fetch_chart_response(block: StreamChild, client: ChartExporterClient) -> ChartFetched | ChartRenderResult:
+    """Do the (slow, network-bound) part of rendering a chart block.
+
+    Safe to run off the main thread: it only calls out to the exporter and never touches the
+    database. Returns a final ``ChartRenderResult`` when there's nothing left to do, or a
+    ``ChartFetched`` when a chart image still needs to be created from the response.
+    """
     config = block.block.get_export_config(block.value)
     config_hash = hash_chart_config(config)
 
@@ -63,9 +81,7 @@ def _render_chart_block(block: StreamChild, client: ChartExporterClient) -> Char
         # Integration disabled: nothing to attach.
         return ChartRenderResult(block_id=block.id, changed=False)
 
-    image = RenderedChartImage.objects.create_from_export_response(response, config_hash=config_hash)
-    block.value["rendered_chart_image"] = image
-    return ChartRenderResult(block_id=block.id, changed=True)
+    return ChartFetched(response=response, config_hash=config_hash)
 
 
 def render_chart_blocks(blocks: Iterable[StreamChild]) -> list[ChartRenderResult]:
@@ -81,7 +97,22 @@ def render_chart_blocks(blocks: Iterable[StreamChild]) -> list[ChartRenderResult
 
     client = ChartExporterClient()
     start = time.monotonic()
-    results = [_render_chart_block(block, client) for block in blocks]
+
+    with ThreadPoolExecutor(max_workers=settings.CMS_CHART_EXPORTER_API_MAX_CONCURRENT_RENDERS) as executor:
+        fetched = list(executor.map(lambda block: _fetch_chart_response(block, client), blocks))
+
+    results = []
+    for block, outcome in zip(blocks, fetched, strict=True):
+        if isinstance(outcome, ChartRenderResult):
+            # Nothing to do, we already have a result (either it was skipped or an error occurred)
+            results.append(outcome)
+            continue
+        image = RenderedChartImage.objects.create_from_export_response(
+            outcome.response, config_hash=outcome.config_hash
+        )
+        block.value["rendered_chart_image"] = image
+        results.append(ChartRenderResult(block_id=block.id, changed=True))
+
     duration = time.monotonic() - start
 
     logger.info(

--- a/cms/datavis/tests/test_chart_blocks_base.py
+++ b/cms/datavis/tests/test_chart_blocks_base.py
@@ -14,6 +14,7 @@ from cms.data_downloads.utils import get_csv_download_filename
 from cms.datavis.blocks.base import BaseChartBlock, BaseVisualisationBlock
 from cms.datavis.blocks.charts import LineChartBlock
 from cms.datavis.blocks.utils import get_approximate_file_size_in_kb
+from cms.datavis.models import RenderedChartImage
 from cms.datavis.tests.factories import TableDataFactory
 from cms.datavis.utils import hash_chart_config
 
@@ -192,15 +193,54 @@ class GetDownloadConfigTests(TestCase):
             "y_axis": {"title": ""},
         }
 
+    @staticmethod
+    def _csv_item(config: dict) -> dict:
+        """The CSV item's position depends on whether a rendered image is attached."""
+        return next(item for item in config["itemsList"] if "CSV" in str(item["text"]))
+
     def test_download_config_without_context(self):
-        """Without parent_context, only image download should be present."""
+        """Without parent_context there is no CSV item, and with no rendered image, no image item."""
         value = self.block.to_python(self.raw_data)
         config = self.block.get_download_config(value)
 
         self.assertIn("title", config)
-        self.assertIn("itemsList", config)
-        self.assertEqual(len(config["itemsList"]), 1)
-        self.assertIn("image", config["itemsList"][0]["text"])
+        self.assertEqual(config["itemsList"], [])
+
+    def test_download_config_omits_image_item_until_one_is_rendered(self):
+        """A chart with no rendered image must not offer a dead download link."""
+        value = self.block.to_python(self.raw_data)
+        config = self.block.get_download_config(
+            value, parent_context={"page": Mock(url="/articles/test/")}, block_id="test-block-id"
+        )
+
+        self.assertNotIn("image", " ".join(str(item["text"]) for item in config["itemsList"]))
+
+    def test_download_config_includes_rendered_image(self):
+        value = self.block.to_python(self.raw_data)
+        image = RenderedChartImage(pk=42, size_bytes=48213, width=1200, height=640, content_type="image/png")
+        image.file.name = "charts/abc.png"
+        value["rendered_chart_image"] = image
+
+        config = self.block.get_download_config(value)
+
+        image_item = config["itemsList"][0]
+        # Private until the page is published, so it must point at the serve view, not S3.
+        self.assertEqual(image_item["url"], image.serve_url)
+        self.assertEqual(str(image_item["text"]), "Download image (47KB)")
+        self.assertEqual(image_item["download"], "file")
+        self.assertEqual(
+            image_item["attributes"],
+            {
+                "data-ga-event": "file-download",
+                "data-ga-file-extension": "png",
+                "data-ga-file-name": "test-chart-title-that-is-quite-long-indeed.png",
+                "data-ga-link-text": "Download image (47KB)",
+                "data-ga-link-url": image.serve_url,
+                "data-ga-file-size": format_file_size_kb(48213),
+                "data-ga-chart-title": self.raw_data["title"],
+                "data-ga-chart-type": "line",
+            },
+        )
 
     def test_download_config_with_context_includes_csv(self):
         """With parent_context and block_id, CSV download should be included."""
@@ -215,8 +255,8 @@ class GetDownloadConfigTests(TestCase):
             rows=[["a", "b"], ["1", "2"]],
         )
 
-        self.assertEqual(len(config["itemsList"]), 2)
-        csv_item = config["itemsList"][1]
+        self.assertEqual(len(config["itemsList"]), 1)
+        csv_item = self._csv_item(config)
         self.assertIn("CSV", csv_item["text"])
         self.assertIn("KB", csv_item["text"])  # Should include file size
         self.assertEqual(csv_item["url"], "/articles/test/download-chart/test-block-id")
@@ -233,7 +273,7 @@ class GetDownloadConfigTests(TestCase):
             block_id="test-block-id",
         )
 
-        csv_item = config["itemsList"][1]
+        csv_item = self._csv_item(config)
         self.assertEqual(csv_item["url"], "/articles/test/versions/1/download-chart/test-block-id")
 
     def test_download_config_in_preview_mode_uses_admin_url(self):
@@ -253,7 +293,7 @@ class GetDownloadConfigTests(TestCase):
             block_id="test-block-id",
         )
 
-        csv_item = config["itemsList"][1]
+        csv_item = self._csv_item(config)
         # Should use the admin URL for revision chart download
         self.assertEqual(csv_item["url"], "/admin/data-downloads/pages/123/revisions/456/download-chart/test-block-id/")
 
@@ -273,7 +313,7 @@ class GetDownloadConfigTests(TestCase):
             block_id="test-block-id",
         )
 
-        csv_item = config["itemsList"][1]
+        csv_item = self._csv_item(config)
         self.assertEqual(csv_item["url"], "#")
 
     def test_download_config_not_in_preview_mode_uses_real_url(self):
@@ -291,7 +331,7 @@ class GetDownloadConfigTests(TestCase):
             block_id="test-block-id",
         )
 
-        csv_item = config["itemsList"][1]
+        csv_item = self._csv_item(config)
         self.assertEqual(csv_item["url"], "/articles/test/download-chart/test-block-id")
 
     def test_download_config_csv_download_data_attributes_in_config(self):
@@ -313,8 +353,7 @@ class GetDownloadConfigTests(TestCase):
             rows=rows,
         )
 
-        # CSV item is at index 1 (image download is at index 0)
-        csv_item = config["itemsList"][1]
+        csv_item = self._csv_item(config)
         expected_url = f"{page.url.rstrip('/')}/download-chart/test-block-id"
         absolute_expected_url = context["request"].build_absolute_uri(expected_url)
         expected_file_size_with_unit = get_approximate_file_size_in_kb(rows)

--- a/cms/datavis/tests/test_chart_exporter_client.py
+++ b/cms/datavis/tests/test_chart_exporter_client.py
@@ -134,7 +134,7 @@ class ChartExporterClientTests(TestCase):
         responses.post(f"{BASE_URL}/charts", body=requests.exceptions.ConnectionError("boom"))
         responses.post(f"{BASE_URL}/charts", body=requests.exceptions.ConnectionError("boom"))
 
-        with patch("cms.datavis.clients.chart_exporter.time.sleep"), self.assertRaises(ChartExporterUnavailable):
+        with self.assertRaises(ChartExporterUnavailable):
             self.client.create_chart(self.chart_config)
 
         self.assertEqual(len(responses.calls), 3)

--- a/cms/datavis/tests/test_chart_exporter_client.py
+++ b/cms/datavis/tests/test_chart_exporter_client.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 
 from cms.datavis.clients.chart_exporter import (
     ChartExporterClient,
+    ChartExporterError,
     ChartExporterMalformedRequest,
     ChartExporterUnavailable,
     ChartObjectResponse,
@@ -108,3 +109,43 @@ class ChartExporterClientTests(TestCase):
         result = self.client.create_chart(self.chart_config)
 
         self.assertEqual(result, ChartObjectResponse(**self.mock_response_data))
+
+    @responses.activate
+    def test_create_chart_payload_too_large_not_retried(self):
+        responses.post(f"{BASE_URL}/charts", status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+
+        with self.assertRaises(ChartExporterMalformedRequest):
+            self.client.create_chart(self.chart_config)
+
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_create_chart_unsupported_media_type_not_retried(self):
+        responses.post(f"{BASE_URL}/charts", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+
+        with self.assertRaises(ChartExporterMalformedRequest):
+            self.client.create_chart(self.chart_config)
+
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_create_chart_connection_error_is_retried_then_raises(self):
+        responses.post(f"{BASE_URL}/charts", body=requests.exceptions.ConnectionError("boom"))
+        responses.post(f"{BASE_URL}/charts", body=requests.exceptions.ConnectionError("boom"))
+        responses.post(f"{BASE_URL}/charts", body=requests.exceptions.ConnectionError("boom"))
+
+        with patch("cms.datavis.clients.chart_exporter.time.sleep"), self.assertRaises(ChartExporterUnavailable):
+            self.client.create_chart(self.chart_config)
+
+        self.assertEqual(len(responses.calls), 3)
+
+    @responses.activate
+    def test_create_chart_unexpected_status_raises_generic_error_and_is_not_retried(self):
+        responses.post(f"{BASE_URL}/charts", status=HTTPStatus.NOT_FOUND)
+
+        with self.assertRaises(ChartExporterError) as ctx:
+            self.client.create_chart(self.chart_config)
+
+        self.assertNotIsInstance(ctx.exception, ChartExporterMalformedRequest)
+        self.assertNotIsInstance(ctx.exception, ChartExporterUnavailable)
+        self.assertEqual(len(responses.calls), 1)

--- a/cms/datavis/tests/test_chart_image_references.py
+++ b/cms/datavis/tests/test_chart_image_references.py
@@ -53,3 +53,11 @@ class RenderedChartImageReferenceTests(TestCase):
 
     def test_image_in_content_is_returned_by_get_referenced_asset_ids(self):
         self.assertIn(str(self.image.pk), self.page.get_referenced_asset_ids(RenderedChartImage))
+
+    def test_publishing_page_makes_referenced_image_public(self):
+        self.assertTrue(self.image.is_private)
+
+        self.page.save_revision().publish()
+
+        self.image.refresh_from_db()
+        self.assertTrue(self.image.is_public)

--- a/cms/datavis/tests/test_chart_render_on_save.py
+++ b/cms/datavis/tests/test_chart_render_on_save.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.test.utils.form_data import nested_form_data, rich_text, streamfield
+
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.datavis.models import RenderedChartImage
+from cms.datavis.services import iter_chart_blocks
+from cms.datavis.tests.test_services import make_export_response, make_page_with_chart
+from cms.users.tests.factories import UserFactory
+
+
+class ChartRenderOnSaveTests(TestCase):
+    """Covers the save trigger: pre-rendering chart images whenever a revision is saved."""
+
+    def test_save_revision_renders_and_persists_the_reference(self):
+        page = make_page_with_chart()
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            mock_client_cls.return_value.create_chart.return_value = make_export_response()
+            revision = page.save_revision()
+
+        rendered_block = next(iter_chart_blocks(revision.as_object().content))
+        self.assertIsInstance(rendered_block.value["rendered_chart_image"], RenderedChartImage)
+
+    def test_second_save_revision_with_unchanged_config_does_not_call_the_exporter(self):
+        page = make_page_with_chart()
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            mock_client_cls.return_value.create_chart.return_value = make_export_response()
+            page.save_revision()
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            page.save_revision()
+
+        mock_client_cls.return_value.create_chart.assert_not_called()
+        self.assertEqual(RenderedChartImage.objects.count(), 1)
+
+    def test_save_revision_succeeds_when_rendering_raises(self):
+        page = make_page_with_chart()
+
+        with (
+            patch("cms.datavis.mixins.render_chart_blocks", side_effect=RuntimeError("boom")),
+            self.assertLogs("cms.datavis.mixins", level="ERROR"),
+        ):
+            revision = page.save_revision()
+
+        self.assertEqual(page.revisions.count(), 1)
+        rendered_block = next(iter_chart_blocks(revision.as_object().content))
+        self.assertIsNone(rendered_block.value["rendered_chart_image"])
+
+    def test_page_without_chart_blocks_does_not_reach_the_exporter(self):
+        page = StatisticalArticlePageFactory()
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            page.save_revision()
+
+        mock_client_cls.assert_not_called()
+
+    def test_preview_does_not_render(self):
+        """The live preview panel POSTs the whole form on every edit, and its validation must
+        not reach the exporter.
+        """
+        page = make_page_with_chart()
+        self.client.force_login(UserFactory(is_superuser=True, access_admin=True))
+        data = nested_form_data(
+            {
+                "title": page.title,
+                "slug": page.slug,
+                "summary": rich_text(page.summary),
+                "main_points_summary": rich_text(page.main_points_summary),
+                "release_date": page.release_date,
+                "content": streamfield(
+                    [("section", {"title": "Test", "content": streamfield([("rich_text", rich_text("text"))])})]
+                ),
+                "datasets": streamfield([]),
+                "dataset_sorting": "AS_SHOWN",
+                "corrections": streamfield([]),
+                "notices": streamfield([]),
+                "headline_figures": streamfield([]),
+                "featured_chart": streamfield([]),
+            }
+        )
+
+        with (
+            patch("cms.datavis.mixins.render_chart_blocks") as mock_mixin_render,
+            patch("cms.core.forms.render_chart_blocks") as mock_form_render,
+        ):
+            response = self.client.post(reverse("wagtailadmin_pages:preview_on_edit", args=[page.pk]), data)
+
+        self.assertEqual(response.status_code, 200)
+        mock_mixin_render.assert_not_called()
+        mock_form_render.assert_not_called()

--- a/cms/datavis/tests/test_chart_render_on_submit.py
+++ b/cms/datavis/tests/test_chart_render_on_submit.py
@@ -1,0 +1,85 @@
+import uuid
+from unittest.mock import patch
+
+from django.forms import ValidationError
+from django.test import TestCase
+
+from cms.articles.models import StatisticalArticlePage
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.datavis.services import ChartRenderResult
+from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
+
+CONTENT_CHART_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def chart_block_value():
+    return {
+        "figure_number": "Figure 1",
+        "title": "Test Chart",
+        "audio_description": "Description",
+        "table": TableDataFactory(),
+        "theme": "primary",
+        "rendered_chart_image": None,
+    }
+
+
+class ChartRenderOnSubmitTests(TestCase):
+    """Covers the workflow trigger: rendering charts when a page is submitted for review."""
+
+    def setUp(self):
+        page = StatisticalArticlePageFactory()
+        page.content = [
+            {
+                "type": "section",
+                "id": str(uuid.uuid4()),
+                "value": {
+                    "title": "Section",
+                    "content": [{"type": "line_chart", "id": CONTENT_CHART_ID, "value": chart_block_value()}],
+                },
+            }
+        ]
+        page.save()
+        self.page = StatisticalArticlePage.objects.get(pk=page.pk)
+        self.form_class = self.page.get_edit_handler().get_form_class()
+
+    def _build_form(self, *, submitting):
+        form = self.form_class(instance=self.page)
+        form.data = {"action-submit": "1"} if submitting else {}
+        form.cleaned_data = {"content": self.page.content}
+        return form
+
+    def test_render_does_not_run_on_a_plain_save(self):
+        with patch("cms.core.forms.render_chart_blocks") as mock_render:
+            form = self._build_form(submitting=False)
+            form.clean()
+
+        mock_render.assert_not_called()
+
+    def test_render_runs_on_submit_and_attaches_the_resulting_image(self):
+        image = RenderedChartImageFactory()
+
+        def fake_render(blocks):
+            results = []
+            for block in blocks:
+                block.value["rendered_chart_image"] = image
+                results.append(ChartRenderResult(block_id=block.id, changed=True))
+            return results
+
+        with patch("cms.core.forms.render_chart_blocks", side_effect=fake_render) as mock_render:
+            form = self._build_form(submitting=True)
+            form.clean()
+
+        mock_render.assert_called_once()
+        content_chart = form.cleaned_data["content"][0].value["content"][0]
+        self.assertEqual(content_chart.value["rendered_chart_image"], image)
+
+    def test_render_failure_blocks_submission_with_a_validation_error(self):
+        with patch(
+            "cms.core.forms.render_chart_blocks",
+            return_value=[ChartRenderResult(block_id=CONTENT_CHART_ID, changed=False, error="Something went wrong")],
+        ):
+            form = self._build_form(submitting=True)
+            with self.assertRaises(ValidationError) as ctx:
+                form.clean()
+
+        self.assertIn("Something went wrong", ctx.exception.messages)

--- a/cms/datavis/tests/test_chart_render_on_submit.py
+++ b/cms/datavis/tests/test_chart_render_on_submit.py
@@ -24,7 +24,11 @@ def chart_block_value():
 
 
 class ChartRenderOnSubmitTests(TestCase):
-    """Covers the workflow trigger: rendering charts when a page is submitted for review."""
+    """Covers the review gate: the blocking render when a page is submitted for review.
+
+    Saves outside submit-for-review are pre-rendered by ``ChartImageRenderMixin`` instead,
+    which never blocks - see ``test_chart_render_on_save``.
+    """
 
     def setUp(self):
         page = StatisticalArticlePageFactory()
@@ -48,7 +52,7 @@ class ChartRenderOnSubmitTests(TestCase):
         form.cleaned_data = {"content": self.page.content}
         return form
 
-    def test_render_does_not_run_on_a_plain_save(self):
+    def test_blocking_render_does_not_run_on_a_plain_save(self):
         with patch("cms.core.forms.render_chart_blocks") as mock_render:
             form = self._build_form(submitting=False)
             form.clean()

--- a/cms/datavis/tests/test_services.py
+++ b/cms/datavis/tests/test_services.py
@@ -1,0 +1,158 @@
+import uuid
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+
+from cms.articles.models import StatisticalArticlePage
+from cms.articles.tests.factories import StatisticalArticlePageFactory
+from cms.datavis.clients.chart_exporter import (
+    ChartExporterMalformedRequest,
+    ChartExporterUnavailable,
+    ChartObjectResponse,
+)
+from cms.datavis.models import RenderedChartImage
+from cms.datavis.services import (
+    GENERIC_RENDER_ERROR,
+    UNAVAILABLE_RENDER_ERROR,
+    iter_chart_blocks,
+    render_chart_blocks,
+    render_charts_for_page,
+)
+from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
+from cms.datavis.utils import hash_chart_config
+
+
+def chart_block(*, image_pk=None, title="Test Chart"):
+    return {
+        "type": "line_chart",
+        "id": str(uuid.uuid4()),
+        "value": {
+            "title": title,
+            "audio_description": "Description",
+            "table": TableDataFactory(),
+            "theme": "primary",
+            "rendered_chart_image": image_pk,
+        },
+    }
+
+
+def make_page_with_chart():
+    """Create and persist a StatisticalArticlePage with a single chart block in its content.
+
+    The chart must be nested in a section: SectionStoryBlock only permits `section` at the top
+    level, and Wagtail silently drops any other block type when loading the stream.
+    """
+    page = StatisticalArticlePageFactory()
+    page.content = [
+        {
+            "type": "section",
+            "id": str(uuid.uuid4()),
+            "value": {"title": "Section", "content": [chart_block()]},
+        }
+    ]
+    page.save()
+    return StatisticalArticlePage.objects.get(pk=page.pk)
+
+
+def make_export_response(**overrides):
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "created_at": "2026-01-01T00:00:00Z",
+        "bucket": settings.AWS_STORAGE_BUCKET_NAME,
+        "key": "charts/abc.png",
+        "content_type": "image/png",
+        "size_bytes": 100,
+        "width": 10,
+        "height": 10,
+    }
+    defaults.update(overrides)
+    return ChartObjectResponse(**defaults)
+
+
+class RenderChartBlocksTests(TestCase):
+    def setUp(self):
+        self.page = make_page_with_chart()
+        self.block = next(iter_chart_blocks(self.page.content))
+
+    @patch("cms.datavis.services.ChartExporterClient")
+    def test_creates_and_attaches_image_on_success(self, mock_client_cls):
+        mock_client_cls.return_value.create_chart.return_value = make_export_response()
+
+        results = render_chart_blocks([self.block])
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].changed)
+        self.assertIsNone(results[0].error)
+        self.assertIsInstance(self.block.value["rendered_chart_image"], RenderedChartImage)
+
+    def test_skips_when_hash_matches_currently_attached_image(self):
+        config_hash = hash_chart_config(self.block.block.get_export_config(self.block.value))
+        existing = RenderedChartImageFactory(config_hash=config_hash)
+        self.block.value["rendered_chart_image"] = existing
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            results = render_chart_blocks([self.block])
+
+        mock_client_cls.return_value.create_chart.assert_not_called()
+        self.assertFalse(results[0].changed)
+        self.assertIsNone(results[0].error)
+        self.assertEqual(self.block.value["rendered_chart_image"], existing)
+
+    @patch("cms.datavis.services.ChartExporterClient")
+    def test_malformed_request_produces_generic_error_and_leaves_image_unset(self, mock_client_cls):
+        mock_client_cls.return_value.create_chart.side_effect = ChartExporterMalformedRequest("bad")
+
+        results = render_chart_blocks([self.block])
+
+        self.assertFalse(results[0].changed)
+        self.assertEqual(results[0].error, GENERIC_RENDER_ERROR)
+        self.assertIsNone(self.block.value["rendered_chart_image"])
+
+    @patch("cms.datavis.services.ChartExporterClient")
+    def test_unavailable_produces_retry_error(self, mock_client_cls):
+        mock_client_cls.return_value.create_chart.side_effect = ChartExporterUnavailable("down")
+
+        results = render_chart_blocks([self.block])
+
+        self.assertFalse(results[0].changed)
+        self.assertEqual(results[0].error, UNAVAILABLE_RENDER_ERROR)
+
+    def test_empty_blocks_returns_empty_list_without_creating_a_client(self):
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            results = render_chart_blocks([])
+
+        self.assertEqual(results, [])
+        mock_client_cls.assert_not_called()
+
+
+class RenderChartsForPageTests(TestCase):
+    def test_saves_a_new_revision_when_a_chart_is_rendered(self):
+        page = make_page_with_chart()
+        self.assertEqual(page.revisions.count(), 0)
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            mock_client_cls.return_value.create_chart.return_value = make_export_response()
+            results = render_charts_for_page(page)
+
+        self.assertTrue(any(result.changed for result in results))
+        self.assertEqual(page.revisions.count(), 1)
+        revision_content = page.get_latest_revision().as_object().content
+        rendered_block = next(iter_chart_blocks(revision_content))
+        self.assertIsInstance(rendered_block.value["rendered_chart_image"], RenderedChartImage)
+
+    def test_second_render_with_unchanged_config_is_skipped(self):
+        page = make_page_with_chart()
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            mock_client_cls.return_value.create_chart.return_value = make_export_response()
+            render_charts_for_page(page)
+
+        self.assertEqual(page.revisions.count(), 1)
+
+        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
+            results = render_charts_for_page(page)
+
+        mock_client_cls.return_value.create_chart.assert_not_called()
+        self.assertFalse(any(result.changed for result in results))
+        self.assertEqual(page.revisions.count(), 1)

--- a/cms/datavis/tests/test_services.py
+++ b/cms/datavis/tests/test_services.py
@@ -17,7 +17,6 @@ from cms.datavis.services import (
     UNAVAILABLE_RENDER_ERROR,
     iter_chart_blocks,
     render_chart_blocks,
-    render_charts_for_page,
 )
 from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
 from cms.datavis.utils import hash_chart_config
@@ -124,35 +123,3 @@ class RenderChartBlocksTests(TestCase):
 
         self.assertEqual(results, [])
         mock_client_cls.assert_not_called()
-
-
-class RenderChartsForPageTests(TestCase):
-    def test_saves_a_new_revision_when_a_chart_is_rendered(self):
-        page = make_page_with_chart()
-        self.assertEqual(page.revisions.count(), 0)
-
-        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
-            mock_client_cls.return_value.create_chart.return_value = make_export_response()
-            results = render_charts_for_page(page)
-
-        self.assertTrue(any(result.changed for result in results))
-        self.assertEqual(page.revisions.count(), 1)
-        revision_content = page.get_latest_revision().as_object().content
-        rendered_block = next(iter_chart_blocks(revision_content))
-        self.assertIsInstance(rendered_block.value["rendered_chart_image"], RenderedChartImage)
-
-    def test_second_render_with_unchanged_config_is_skipped(self):
-        page = make_page_with_chart()
-
-        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
-            mock_client_cls.return_value.create_chart.return_value = make_export_response()
-            render_charts_for_page(page)
-
-        self.assertEqual(page.revisions.count(), 1)
-
-        with patch("cms.datavis.services.ChartExporterClient") as mock_client_cls:
-            results = render_charts_for_page(page)
-
-        mock_client_cls.return_value.create_chart.assert_not_called()
-        self.assertFalse(any(result.changed for result in results))
-        self.assertEqual(page.revisions.count(), 1)

--- a/cms/locale/cy/LC_MESSAGES/django.po
+++ b/cms/locale/cy/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 14:50+0100\n"
+"POT-Creation-Date: 2026-09-07 15:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,29 +17,29 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: cms/articles/models.py:246 cms/core/enums.py:8 cms/core/enums.py:23
+#: cms/articles/models.py:258 cms/core/enums.py:8 cms/core/enums.py:23
 msgid "Article"
 msgstr "Erthygl"
 
-#: cms/articles/models.py:478
+#: cms/articles/models.py:490
 #: cms/jinja2/templates/pages/methodology_page.html:103
 #: cms/jinja2/templates/pages/statistical_article_page.html:228
-#: cms/methodology/models.py:198
+#: cms/methodology/models.py:201
 msgid "Cite this page"
 msgstr "Dyfynnwch y dudalen hon"
 
-#: cms/articles/models.py:480
+#: cms/articles/models.py:492
 #: cms/jinja2/templates/components/contact_details/contact_details.html:6
-#: cms/methodology/models.py:200 cms/release_calendar/models.py:272
+#: cms/methodology/models.py:203 cms/release_calendar/models.py:272
 msgid "Contact details"
 msgstr "Manylion cyswllt"
 
-#: cms/articles/models.py:552
+#: cms/articles/models.py:564
 #, python-format
 msgid "All data related to %(article_title)s"
 msgstr "Yr holl ddata sy'n gysylltiedig â %(article_title)s"
 
-#: cms/articles/models.py:623
+#: cms/articles/models.py:635
 msgid "Release date"
 msgstr "Dyddiad rhyddhau"
 
@@ -74,12 +74,12 @@ msgid "Hide all"
 msgstr "Cuddio popeth"
 
 #: cms/core/blocks/embeddable.py:86 cms/core/blocks/markup.py:228
-#: cms/datavis/blocks/base.py:153 cms/datavis/blocks/iframe.py:156
+#: cms/datavis/blocks/base.py:168 cms/datavis/blocks/iframe.py:156
 msgid "Source"
 msgstr "Ffynhonnell"
 
 #: cms/core/blocks/embeddable.py:90 cms/core/blocks/markup.py:233
-#: cms/datavis/blocks/base.py:170 cms/datavis/blocks/iframe.py:163
+#: cms/datavis/blocks/base.py:185 cms/datavis/blocks/iframe.py:163
 msgid "Footnotes"
 msgstr "Troednodiadau"
 
@@ -87,7 +87,7 @@ msgstr "Troednodiadau"
 msgid "Download this image"
 msgstr "Lawrlwythwch y ddelwedd hon"
 
-#: cms/core/blocks/markup.py:271 cms/datavis/blocks/base.py:358
+#: cms/core/blocks/markup.py:271 cms/datavis/blocks/base.py:424
 #, python-format
 msgid "Download CSV %(size)s"
 msgstr "Lawrlwythwch CSV %(size)s"
@@ -130,7 +130,7 @@ msgstr "Adrodd"
 msgid "Webpage"
 msgstr "Tudalen we"
 
-#: cms/core/enums.py:16 cms/standard_pages/models.py:113
+#: cms/core/enums.py:16 cms/standard_pages/models.py:116
 msgid "Index"
 msgstr "Mynegai"
 
@@ -144,8 +144,7 @@ msgstr "Thema"
 msgid "Released"
 msgstr "Rhyddhawyd"
 
-#: cms/core/models/base.py:201
-#: megalinter-reports/updated_sources/cms/core/models/base.py:226
+#: cms/core/models/base.py:226
 msgid "Home"
 msgstr "Hafan"
 
@@ -180,6 +179,11 @@ msgstr "Mae’r holl gynnwys ar gael o dan y"
 #: cms/core/templatetags/page_config_tags.py:243
 msgid ", except where otherwise stated"
 msgstr ", ac eithrio lle y nodir fel arall"
+
+#: cms/datavis/blocks/base.py:363
+#, python-format
+msgid "Download image %(size)s"
+msgstr ""
 
 #: cms/datavis/blocks/table.py:58
 #: cms/jinja2/templates/pages/release_calendar/release_calendar_page.html:91
@@ -818,7 +822,7 @@ msgstr "Archwilio mwy"
 msgid "Continue"
 msgstr "Parhau"
 
-#: cms/methodology/models.py:186 cms/methodology/models.py:196
+#: cms/methodology/models.py:189 cms/methodology/models.py:199
 msgid "Related publications"
 msgstr "Cyhoeddiadau cysylltiedig"
 

--- a/cms/methodology/forms.py
+++ b/cms/methodology/forms.py
@@ -1,5 +1,4 @@
 from cms.core.forms import PageWithEquationsAdminForm, PageWithProtectedChartImagesAdminForm
 
 
-class MethodologyPageAdminForm(PageWithProtectedChartImagesAdminForm, PageWithEquationsAdminForm):
-    protected_chart_image_fields = ("content",)
+class MethodologyPageAdminForm(PageWithProtectedChartImagesAdminForm, PageWithEquationsAdminForm): ...

--- a/cms/methodology/models.py
+++ b/cms/methodology/models.py
@@ -22,6 +22,7 @@ from cms.core.query import order_by_pk_position
 from cms.core.utils import redirect_to_parent_listing
 from cms.core.widgets import date_widget
 from cms.data_downloads.mixins import DataDownloadMixin
+from cms.datavis.mixins import ChartImageRenderMixin
 from cms.methodology.forms import MethodologyPageAdminForm
 from cms.taxonomy.mixins import GenericTaxonomyMixin
 
@@ -82,6 +83,7 @@ class MethodologyRelatedPage(Orderable):
 
 
 class MethodologyPage(  # type: ignore[django-manager-missing]
+    ChartImageRenderMixin,
     DataDownloadMixin,
     BundledPageMixin,
     NoTrailingSlashRoutablePageMixin,
@@ -89,6 +91,7 @@ class MethodologyPage(  # type: ignore[django-manager-missing]
     BasePage,
 ):
     base_form_class = MethodologyPageAdminForm
+    chart_image_fields: ClassVar[tuple[str, ...]] = ("content",)
     parent_page_types: ClassVar[list[str]] = ["MethodologyIndexPage"]
     search_index_content_type: ClassVar[str] = "static_methodology"
     template = "templates/pages/methodology_page.html"

--- a/cms/private_media/tests/test_serve_views.py
+++ b/cms/private_media/tests/test_serve_views.py
@@ -6,6 +6,7 @@ from unittest import mock
 import time_machine
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail.documents import get_document_model
@@ -14,10 +15,13 @@ from wagtail.images.models import Filter
 from wagtail.models import Collection
 from wagtail_factories import DocumentFactory, ImageFactory
 
+from cms.articles.models import StatisticalArticlePage
+from cms.articles.tests.factories import StatisticalArticlePageFactory
 from cms.bundles.models import BundleTeam
 from cms.bundles.tests.factories import BundleFactory, BundlePageFactory
 from cms.bundles.tests.utils import create_bundle_viewer
 from cms.core.tests.utils import rebuild_references_index
+from cms.datavis.tests.factories import RenderedChartImageFactory, TableDataFactory
 from cms.private_media.constants import Privacy
 from cms.standard_pages.tests.factories import InformationPageFactory
 from cms.teams.tests.factories import TeamFactory
@@ -222,6 +226,122 @@ class TestDocumentServeView(TestCase):
 
         response = self.client.get(serve_url)
         self.assertEqual(response.status_code, 404)
+
+
+class TestRenderedChartImageServeView(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.private_chart_image = RenderedChartImageFactory(file=ContentFile(b"fake-png-bytes", name="chart.png"))
+        cls.public_chart_image = RenderedChartImageFactory(
+            _privacy=Privacy.PUBLIC, file=ContentFile(b"fake-png-bytes", name="chart-public.png")
+        )
+        cls.superuser = get_user_model().objects.create(username="chart-superuser", is_superuser=True)
+
+    def test_serve_private_chart_image(self):
+        """Test the serve view behaviour for private chart images."""
+        serve_url = self.private_chart_image.url
+
+        # If not authenticated, permission checks should fail and a Forbidden response returned
+        for is_external_env in [True, False]:
+            with self.subTest(is_external_env=is_external_env) and override_settings(IS_EXTERNAL_ENV=is_external_env):
+                response = self.client.get(serve_url)
+                self.assertEqual(response.status_code, 403)
+
+        # If authenticated as a superuser, the view should serve the file
+        self.client.force_login(self.superuser)
+        for is_external_env in [True, False]:
+            with self.subTest(is_external_env=is_external_env) and override_settings(IS_EXTERNAL_ENV=is_external_env):
+                response = self.client.get(serve_url)
+                self.assertEqual(response.status_code, 403 if is_external_env else 200)
+
+    def test_serve_public_chart_image(self):
+        """Test the serve view behaviour for public chart images: it should redirect to the file."""
+        for is_external_env in [True, False]:
+            with self.subTest(is_external_env=is_external_env) and override_settings(IS_EXTERNAL_ENV=is_external_env):
+                response = self.client.get(self.public_chart_image.serve_url)
+                self.assertEqual(response.status_code, 302)
+
+    def test_serve_with_invalid_chart_image_id(self):
+        """Test the serve view behaviour when the chart image ID is not recognised."""
+        serve_url = self.private_chart_image.url
+        serve_url = serve_url.replace(f"/{self.private_chart_image.id}", "/9999999")
+
+        response = self.client.get(serve_url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_user_without_document_permissions_is_denied(self):
+        """A logged-in user with no document permissions and no bundle-preview grant is denied."""
+        non_editor = get_user_model().objects.create(username="chart-no-perms")
+        self.client.force_login(non_editor)
+        response = self.client.get(self.private_chart_image.url)
+        self.assertEqual(response.status_code, 403)
+
+
+class TestRenderedChartImageServeViewInBundlePreviewContext(TestCase):
+    """Verifies a previewer can access a private chart image via the bundle-preview cookie,
+    exercising the full path: chooser-block reference -> reference index -> preview cookie ->
+    RenderedChartImagePermissionPolicy -> serve view.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.private_chart_image = RenderedChartImageFactory(file=ContentFile(b"fake-png-bytes", name="chart.png"))
+
+        page = StatisticalArticlePageFactory()
+        page.content = [
+            {
+                "type": "section",
+                "id": str(uuid.uuid4()),
+                "value": {
+                    "title": "Section",
+                    "content": [
+                        {
+                            "type": "line_chart",
+                            "id": str(uuid.uuid4()),
+                            "value": {
+                                "title": "Test Chart",
+                                "audio_description": "Description",
+                                "table": TableDataFactory(),
+                                "theme": "primary",
+                                "x_axis": {"title": ""},
+                                "y_axis": {"title": ""},
+                                "rendered_chart_image": cls.private_chart_image.pk,
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+        page.save()
+        cls.page = StatisticalArticlePage.objects.get(pk=page.pk)
+        mark_page_as_ready_for_review(cls.page)
+
+        cls.preview_team = TeamFactory(name="Chart Preview Team")
+        cls.bundle = BundleFactory(in_review=True)
+        BundlePageFactory(parent=cls.bundle, page=cls.page)
+        BundleTeam.objects.create(parent=cls.bundle, team=cls.preview_team)
+
+        cls.viewer = create_bundle_viewer("chart.bundle.viewer")
+        cls.viewer.teams.add(cls.preview_team)
+
+    def setUp(self):
+        rebuild_references_index()
+
+    def test_direct_request_denied_without_preview_cookie(self):
+        self.client.force_login(self.viewer)
+        response = self.client.get(self.private_chart_image.serve_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_access_via_bundle_preview_for_viewer_in_bundle_team(self):
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(reverse("bundles:preview", args=[self.bundle.pk, self.page.pk]))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("bundle-preview", self.client.cookies)
+        self.assertContains(response, self.private_chart_image.serve_url)
+
+        response = self.client.get(self.private_chart_image.serve_url)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestPrivateMediaServeViewInBundlePreviewContext(TestCase):

--- a/cms/private_media/views.py
+++ b/cms/private_media/views.py
@@ -19,6 +19,8 @@ from wagtail.images.permissions import permission_policy as image_permission_pol
 from wagtail.images.utils import verify_signature
 
 from cms.core.utils import redirect
+from cms.datavis.models import RenderedChartImage
+from cms.datavis.permissions import rendered_chart_image_permission_policy
 from cms.private_media.utils import user_can_access_asset
 
 if TYPE_CHECKING:
@@ -239,6 +241,83 @@ class DocumentServeView(View):
         response["Content-Length"] = document.file.size
 
         # Prevent browsers from auto-detecting the content-type of a document
+        response["X-Content-Type-Options"] = "nosniff"
+
+        return response
+
+
+class RenderedChartImageServeView(View):
+    http_method_names: Sequence[str] = ["get"]
+
+    @method_decorator(csp_override({"default-src": [CSP.NONE]}))
+    def get(self, request: HttpRequest, chart_image_id: int) -> HttpResponseBase:
+        """This method mirrors `DocumentServeView.get()`, but for `RenderedChartImage`: a
+        permission check, a redirect to the file URL once the object is public, otherwise a
+        streamed response with cache headers varied by scenario.
+        """
+        chart_image = self.get_chart_image(chart_image_id)
+
+        # Block access to a private chart image if the user has insufficient permissions
+        if not user_can_access_asset(
+            request=self.request,
+            user=self.request.user,
+            asset=chart_image,
+            permission_policy=rendered_chart_image_permission_policy,
+        ):
+            raise PermissionDenied
+
+        # If there's no reason (within our control) for the file not to be served by
+        # media infrastructure, redirect
+        if chart_image.is_public and not chart_image.has_outdated_file_permissions():
+            try:
+                file_url = chart_image.file.url
+            except NotImplementedError:
+                file_url = chart_image.file.path
+            return self.redirect_to_file(file_url)
+
+        # Serve file contents
+        if chart_image.is_public:
+            return self.serve_public_chart_image(chart_image)
+        return self.serve_private_chart_image(chart_image)
+
+    def get_chart_image(self, chart_image_id: int) -> RenderedChartImage:
+        """Return a `RenderedChartImage` matching the provided `chart_image_id`, or raise a
+        `Http404` exception if no such object exists.
+        """
+        return get_object_or_404(RenderedChartImage, id=chart_image_id)
+
+    def redirect_to_file(self, url: str) -> HttpResponseRedirect | HttpResponsePermanentRedirect:
+        """Return a cachable temporary redirect to the file URL.
+
+        The redirect response is cached for 1 hour to alleviate load on the web server. If the
+        chart image's privacy changes in the meantime, a purge request for this URL will be
+        submitted to the active edge-cache provider.
+        """
+        response = redirect(url, preserve_request=False)
+        patch_cache_control(response, max_age=3600, public=True)
+        return response
+
+    def serve_public_chart_image(self, chart_image: RenderedChartImage) -> FileResponse:
+        """Return a cachable FileResponse for the requested chart image file."""
+        response = self._serve_chart_image(chart_image)
+        patch_cache_control(response, max_age=3600, public=True)
+        return response
+
+    def serve_private_chart_image(self, chart_image: RenderedChartImage) -> FileResponse:
+        """Return a non-cachable FileResponse for the requested chart image file.
+
+        While a chart image is still private, access is dependant on the current user's
+        permissions, so responses are not suitable for reuse.
+        """
+        response = self._serve_chart_image(chart_image)
+        add_never_cache_headers(response)
+        return response
+
+    def _serve_chart_image(self, chart_image: RenderedChartImage) -> FileResponse:
+        chart_image.file.open("rb")
+        response = FileResponse(chart_image.file, content_type=chart_image.content_type)
+
+        # Prevent browsers from auto-detecting the content-type
         response["X-Content-Type-Options"] = "nosniff"
 
         return response

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1020,6 +1020,7 @@ CMS_CHART_EXPORTER_API_BASE_URL = env.get("CMS_CHART_EXPORTER_API_BASE_URL", "")
 # Feature flag to enable/disable interaction with the Chart Exporter API
 CMS_CHART_EXPORTER_API_ENABLED = env.get("CMS_CHART_EXPORTER_API_ENABLED", "false").lower() == "true"
 CMS_CHART_EXPORTER_API_MAX_RETRIES = int(env.get("CMS_CHART_EXPORTER_API_MAX_RETRIES", 2))
+CMS_CHART_EXPORTER_API_MAX_CONCURRENT_RENDERS = int(env.get("CMS_CHART_EXPORTER_API_MAX_CONCURRENT_RENDERS", 5))
 
 # Feature flag to enable/disable validation of bundled datasets status on bundle approval
 BUNDLE_DATASET_STATUS_VALIDATION_ENABLED = (

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -200,7 +200,7 @@ urlpatterns = (
             name="wagtailimages_serve",
         ),
         re_path(
-            r"^rendered-chart-images/(\d+)/$",
+            r"^rendered-chart-images/(\d+)$",
             private_media_views.RenderedChartImageServeView.as_view(),
             name="rendered_chart_image_serve",
         ),

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -199,6 +199,11 @@ urlpatterns = (
             private_media_views.ImageServeView.as_view(),
             name="wagtailimages_serve",
         ),
+        re_path(
+            r"^rendered-chart-images/(\d+)/$",
+            private_media_views.RenderedChartImageServeView.as_view(),
+            name="rendered_chart_image_serve",
+        ),
     ]
 )
 


### PR DESCRIPTION
### What is the context of this PR?

This PR is the top of the stack related to CMS-1286. It finalises the implementation of the integration with the [Chart Exporter API](https://github.com/ONSdigital/design-system-chart-exporter).

Specifically this PR adds the appropriate triggers for generation, the preview views and the wires in the correct fallback and download image URLs as appropriate. It also expands the test suite.

### How to review

As this is the top of the stack, functional testing is now possible.

First, ensure that you have pulled the exporter code from [the active PR](https://github.com/ONSdigital/design-system-chart-exporter/pull/13) and have it up and running.

If you use OrbStack, you should be able to make everything work by using orbstack local URLs. You just need to set appropriate env variables, or add the following to your `local.py` settings file:

```bash
CMS_CHART_EXPORTER_API_BASE_URL="http://web.design-system-chart-exporter.orb.local"
CMS_CHART_EXPORTER_API_ENABLED="true"
AWS_STORAGE_BUCKET_NAME="ons-charts"
AWS_ACCESS_KEY_ID="test"
AWS_SECRET_ACCESS_KEY="test"
AWS_S3_ENDPOINT_URL="http://floci.design-system-chart-exporter.orb.local"
AWS_S3_URL_PROTOCOL="http:"
AWS_S3_ADDRESSING_STYLE="path"
```
---

@BJacksonONS has prepared a solution for people using other setups:

> * ran `docker network create design-system-network`
> * renamed the `web` service in the exporter compose file to `exporter`
> * added a networks section to the web container on the wagtail side, the exporter container and the floci container with
> ```yaml
> networks:
>   - default
>   - design-system-network
> ```
>  as well as adding
> ```yaml
> networks:
>   design-system-network:
>     external: true
> ```
> to the bottom of both compose files
> 
> * Added the following to my .env for wagtail
> ```bash
> CMS_CHART_EXPORTER_API_BASE_URL='http://exporter:30300/'
> CMS_CHART_EXPORTER_API_ENABLED='true'
> AWS_STORAGE_BUCKET_NAME='ons-charts'
> AWS_ACCESS_KEY_ID=test
> AWS_SECRET_ACCESS_KEY=test
> AWS_S3_REGION_NAME=us-east-1
> AWS_S3_ENDPOINT_URL=http://floci:4566/
> AWS_S3_ADDRESSING_STYLE=path
> ```
> * Added a small section to the AWS env settings in base.py with
> ```python
> if "AWS_S3_ENDPOINT_URL" in env:
>     AWS_S3_ENDPOINT_URL = env["AWS_S3_ENDPOINT_URL"]
> if "AWS_S3_ADDRESSING_STYLE" in env:
>     AWS_S3_ADDRESSING_STYLE = env["AWS_S3_ADDRESSING_STYLE"]
> ```
---
Once everything is setup and working:

1. Create a page
2. Add a chart
3. Save the page
4. Preview the page and disable JS
5. Ensure that the chart fallback image is displayed

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

* Deploy implementation of the exporter from https://github.com/ONSdigital/design-system-chart-exporter/pull/13
* Setup the correct env variables on test servers once infrastructure is in place

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---
Ticket: [CMS-1286](https://officefornationalstatistics.atlassian.net/browse/CMS-1286)

[CMS-1286]: https://officefornationalstatistics.atlassian.net/browse/CMS-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ