### PR TITLE
fix(release-calendar): keep release calendar pinned after filters are cleared

### DIFF
--- a/cms/release_calendar/tests/test_wagtail_hooks.py
+++ b/cms/release_calendar/tests/test_wagtail_hooks.py
@@ -85,11 +85,21 @@ class ReleaseCalendarHooksTestCase(WagtailTestUtils, TestCase):
         """Explorer results with an active filter should use Wagtail's default ordering."""
         response = self.client.get(
             reverse("wagtailadmin_explore_results", args=[self.home_page.id]),
-            {"content_type": str(self.older_topic_page.content_type_id)},
+            {
+                "content_type": [
+                    str(self.release_calendar_index.content_type_id),
+                    str(self.older_topic_page.content_type_id),
+                ]
+            },
         )
         pages = list(response.context["pages"])
 
-        self.assertNotEqual(pages[0], self.release_calendar_index, "Filtered results should not be pinned")
+        # Expect pages to be orderded by most recently updated
+        expected_page_order = [self.newer_topic_page, self.older_topic_page, self.release_calendar_index]
+
+        self.assertEqual(
+            pages, expected_page_order, "Release calendar index page should not be pinned in filtered results"
+        )
 
     def test_release_calendar_index_is_first_in_explorer_results_after_filter_is_cleared(self):
         """Explorer results with only blank filter values should pin the release calendar again."""

--- a/cms/release_calendar/tests/test_wagtail_hooks.py
+++ b/cms/release_calendar/tests/test_wagtail_hooks.py
@@ -1,14 +1,43 @@
 from types import SimpleNamespace
 
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 from wagtail.models import Page
 from wagtail.test.utils import WagtailTestUtils
 
 from cms.home.models import HomePage
 from cms.release_calendar.models import ReleaseCalendarIndex
-from cms.release_calendar.wagtail_hooks import pin_release_calendar_page
+from cms.release_calendar.wagtail_hooks import _explorer_has_active_query, pin_release_calendar_page
 from cms.topics.tests.factories import TopicPageFactory
+
+# Mirrors the empty query params Wagtail keeps on the results view after filters are cleared.
+CLEARED_FILTER_QUERY = {
+    "q": "",
+    "latest_revision_created_at_from": "",
+    "latest_revision_created_at_to": "",
+    "has_child_pages": "",
+    "locale": "",
+}
+
+
+class ExplorerHasActiveQueryTests(SimpleTestCase):
+    def test_explorer_has_active_query_returns_false_for_blank_values(self):
+        """Blank explorer query values should not count as active query state."""
+        request = RequestFactory().get("/", CLEARED_FILTER_QUERY)
+
+        self.assertFalse(_explorer_has_active_query(request))
+
+    def test_explorer_has_active_query_ignores_fragment_refresh_and_pagination(self):
+        """Wagtail fragment refresh and pagination params should not count as active query state."""
+        request = RequestFactory().get("/", {"_w_filter_fragment": "1", "p": "2"})
+
+        self.assertFalse(_explorer_has_active_query(request))
+
+    def test_explorer_has_active_query_returns_true_for_non_empty_value(self):
+        """Any non-empty user query value should count as active query state."""
+        request = RequestFactory().get("/", {"content_type": "63"})
+
+        self.assertTrue(_explorer_has_active_query(request))
 
 
 class ReleaseCalendarHooksTestCase(WagtailTestUtils, TestCase):
@@ -51,6 +80,40 @@ class ReleaseCalendarHooksTestCase(WagtailTestUtils, TestCase):
         self.assertEqual(pages[0], self.release_calendar_index, "Release calendar index page is not first in explorer")
         self.assertEqual(pages[1], self.older_topic_page, "Updated topic page is not second in explorer")
         self.assertEqual(pages[2], self.newer_topic_page, "Topic page is not ordered by recency as expected")
+
+    def test_release_calendar_index_is_not_first_in_explorer_results_with_active_filter(self):
+        """Explorer results with an active filter should use Wagtail's default ordering."""
+        response = self.client.get(
+            reverse("wagtailadmin_explore_results", args=[self.home_page.id]),
+            {"content_type": str(self.older_topic_page.content_type_id)},
+        )
+        pages = list(response.context["pages"])
+
+        self.assertNotEqual(pages[0], self.release_calendar_index, "Filtered results should not be pinned")
+
+    def test_release_calendar_index_is_first_in_explorer_results_after_filter_is_cleared(self):
+        """Explorer results with only blank filter values should pin the release calendar again."""
+        response = self.client.get(
+            reverse("wagtailadmin_explore_results", args=[self.home_page.id]),
+            CLEARED_FILTER_QUERY,
+        )
+        pages = list(response.context["pages"])
+
+        self.assertEqual(
+            pages[0],
+            self.release_calendar_index,
+            "Release calendar index page is not first after the filter is cleared",
+        )
+
+    def test_release_calendar_index_is_not_first_in_explorer_page_with_default_ordering_param(self):
+        """Explorer requests that carry an explicit default ordering should not pin the calendar index."""
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=[self.home_page.id]),
+            {"ordering": self.home_page.get_admin_default_ordering()},
+        )
+        pages = list(response.context["pages"])
+
+        self.assertNotEqual(pages[0], self.release_calendar_index, "Explicit ordering should not be overridden")
 
     def test_sidebar_is_not_reordered(self):
         """Unit test ensures sidebar pages retain their original path order by calling pin_release_calendar_page

--- a/cms/release_calendar/wagtail_hooks.py
+++ b/cms/release_calendar/wagtail_hooks.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
 
     from .viewsets import FutureReleaseCalendarPageChooserViewSet
 
+# Query keys that do not represent an active user-applied search or filter.
+EXPLORER_IGNORED_QUERY_KEYS = {"_w_filter_fragment", "p"}
+
+# Explorer views where the release calendar index should be pinned by default.
+EXPLORER_VIEW_NAMES = {
+    "wagtailadmin_explore",
+    "wagtailadmin_explore_results",
+}
+
 
 @hooks.register("before_delete_page")
 def before_delete_page(request: HttpRequest, page: Page) -> HttpResponseRedirect | HttpResponsePermanentRedirect | None:
@@ -58,11 +67,8 @@ def hide_release_date_text_field_for_non_provisional_release_pages() -> str:
 
 def _explorer_has_active_query(request: HttpRequest) -> bool:
     """Return whether the explorer request has any non-empty user query values."""
-    # Ignore pagination and internal Wagtail fragment-refresh params which are left after a filter is removed.
-    ignored_query_keys = {"_w_filter_fragment", "p"}
-
     for key, values in request.GET.lists():
-        if key in ignored_query_keys:
+        if key in EXPLORER_IGNORED_QUERY_KEYS:
             continue
 
         if any(value.strip() for value in values):
@@ -76,10 +82,9 @@ def pin_release_calendar_page(parent_page: Page, pages: PageQuerySet, request: H
     """Pin the Release Calendar index to the top of the homepage explorer page."""
     # Only apply to the homepage Explorer view.
     resolver_match = getattr(request, "resolver_match", None)
-    is_homepage_explorer = getattr(resolver_match, "view_name", "") in {
-        "wagtailadmin_explore",
-        "wagtailadmin_explore_results",
-    } and isinstance(parent_page.specific_deferred, HomePage)
+    is_homepage_explorer = getattr(resolver_match, "view_name", "") in EXPLORER_VIEW_NAMES and isinstance(
+        parent_page.specific_deferred, HomePage
+    )
 
     if not is_homepage_explorer:
         return pages

--- a/cms/release_calendar/wagtail_hooks.py
+++ b/cms/release_calendar/wagtail_hooks.py
@@ -56,20 +56,36 @@ def hide_release_date_text_field_for_non_provisional_release_pages() -> str:
     return format_html('<script src="{}"></script>', static("js/hide-date-text-on-non-provisional-releases.js"))
 
 
+def _explorer_has_active_query(request: HttpRequest) -> bool:
+    """Return whether the explorer request has any non-empty user query values."""
+    # Ignore pagination and internal Wagtail fragment-refresh params which are left after a filter is removed.
+    ignored_query_keys = {"_w_filter_fragment", "p"}
+
+    for key, values in request.GET.lists():
+        if key in ignored_query_keys:
+            continue
+
+        if any(value.strip() for value in values):
+            return True
+
+    return False
+
+
 @hooks.register("construct_explorer_page_queryset")
 def pin_release_calendar_page(parent_page: Page, pages: PageQuerySet, request: HttpRequest) -> PageQuerySet:
-    """Pin the Release Calendar index to the top of the explorer page and explorer menu."""
-    # Respect any existing user-selected ordering.
-    if request.GET.get("ordering"):
-        return pages
-
+    """Pin the Release Calendar index to the top of the homepage explorer page."""
     # Only apply to the homepage Explorer view.
     resolver_match = getattr(request, "resolver_match", None)
-    is_homepage_explorer = getattr(resolver_match, "view_name", "") == "wagtailadmin_explore" and isinstance(
-        parent_page.specific_deferred, HomePage
-    )
+    is_homepage_explorer = getattr(resolver_match, "view_name", "") in {
+        "wagtailadmin_explore",
+        "wagtailadmin_explore_results",
+    } and isinstance(parent_page.specific_deferred, HomePage)
 
     if not is_homepage_explorer:
+        return pages
+
+    # Only pin on the default explorer view. Searches, filters, and sorting should use Wagtail's default ordering.
+    if _explorer_has_active_query(request):
         return pages
 
     return pages.order_by(


### PR DESCRIPTION
### What is the context of this PR?

Defect raised during testing of [CMS-1216](https://officefornationalstatistics.atlassian.net/browse/CMS-1216)

The `pin_release_calendar_page` hook now applies to both the homepage explorer view and the homepage explorer results view. It checks the request for active non-empty query values so the Release Calendar Index page is only pinned on the default explorer listing.

That means:
- the Release Calendar Index page is pinned by default
- it is not pinned when a user is filtering, searching, or sorting
- once a filter/search is cleared and the results request only contains empty values, pinning is applied again

Note: creating a custom viewset using [PageViewSet](https://docs.wagtail.org/en/stable/advanced_topics/customization/custom_page_listings.html#custom-page-listings) was considered here to replace the `construct_explorer_page_queryset` hook, but it felt like a heavier solution than this change really needs.

### How to review

1. In the home page explorer view, apply a filter or search for a page
2. Ensure the default ordering is applied (Release Calendar Index page is not pinned)
3. Remove the filter or search text
4. Check that the Release Calendar Index page is pinned
5. Ensure that when a user selects a specific order, the Release Calendar Index page is not pinned

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

N/A


---
Ticket: [CMS-1245](https://officefornationalstatistics.atlassian.net/browse/CMS-1245)

[CMS-1216]: https://officefornationalstatistics.atlassian.net/browse/CMS-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CMS-1245]: https://officefornationalstatistics.atlassian.net/browse/CMS-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ