### PR TITLE
fix(a11y): address release calendar accessibility audit

### DIFF
--- a/cms/jinja2/templates/components/accredited/accredited-information.html
+++ b/cms/jinja2/templates/components/accredited/accredited-information.html
@@ -1,5 +1,5 @@
 {# appears in the body of the release page #}
-<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %}">
+<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %} ons-u-p-m">
     {% with accredited_logo_classes="accreditations__accredited-logo" %}
         {% include "templates/components/accredited/accredited-logo.html" %}
     {% endwith %}

--- a/cms/jinja2/templates/components/accredited/accredited-information.html
+++ b/cms/jinja2/templates/components/accredited/accredited-information.html
@@ -1,5 +1,5 @@
 {# appears in the body of the release page #}
-<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %} ons-u-mb-s ons-u-p-s">
+<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %} ons-u-mb-s">
     {% with accredited_logo_classes="accreditations__accredited-logo" %}
         {% include "templates/components/accredited/accredited-logo.html" %}
     {% endwith %}

--- a/cms/jinja2/templates/components/accredited/accredited-information.html
+++ b/cms/jinja2/templates/components/accredited/accredited-information.html
@@ -1,5 +1,5 @@
 {# appears in the body of the release page #}
-<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %} ons-u-mb-s">
+<div class="accreditations__block {% if not page.is_census %}accreditations__block--full-width{% endif %}">
     {% with accredited_logo_classes="accreditations__accredited-logo" %}
         {% include "templates/components/accredited/accredited-logo.html" %}
     {% endwith %}

--- a/cms/jinja2/templates/components/census/census-information.html
+++ b/cms/jinja2/templates/components/census/census-information.html
@@ -1,5 +1,5 @@
 {# appears in the body of the release page #}
-<div class="accreditations__block {% if not page.is_accredited %}accreditations__block--full-width{% endif %}">
+<div class="accreditations__block {% if not page.is_accredited %}accreditations__block--full-width{% endif %} ons-u-p-m">
     {% with census_logo_classes="accreditations__census-logo" %}
         {% include "templates/components/census/census-logo.html" %}
     {% endwith %}

--- a/cms/jinja2/templates/components/streamfield/release_date_change_block.html
+++ b/cms/jinja2/templates/components/streamfield/release_date_change_block.html
@@ -1,4 +1,4 @@
-<li class="ons-list__item">
+<li class="ons-list__item spacing">
     <h3 class="ons-u-mb-no ons-u-fs-r--b">{{ _("Previous date") }}</h3>
     <p>{{ value.previous_date|ons_date("DATETIME_FORMAT") }}</p>
     <h3 class="ons-u-mb-no ons-u-fs-r--b">{{ _("Reason for change") }}</h3>

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
@@ -45,7 +45,9 @@
             <h2>{{ _("Changes to this release date") }}</h2>
 
             <ol class="ons-list ons-list--bare">
-                {% include_block page.changes_to_release_date %}
+                {% for block in page.changes_to_release_date %}
+                    {% include_block block %}
+                {% endfor %}
             </ol>
         </section>
     {% endif %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
@@ -44,7 +44,7 @@
         <section id="changes-to-release-date">
             <h2>{{ _("Changes to this release date") }}</h2>
 
-            <ol class="ons-list ons-list--bare spacing">
+            <ol class="ons-list ons-list--bare">
                 {% for block in page.changes_to_release_date %}
                     {% include_block block %}
                 {% endfor %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--cancelled.html
@@ -44,7 +44,7 @@
         <section id="changes-to-release-date">
             <h2>{{ _("Changes to this release date") }}</h2>
 
-            <ol class="ons-list ons-list--bare">
+            <ol class="ons-list ons-list--bare spacing">
                 {% for block in page.changes_to_release_date %}
                     {% include_block block %}
                 {% endfor %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
@@ -42,7 +42,7 @@
         <section id="changes-to-release-date">
             <h2>{{ _("Changes to this release date") }}</h2>
 
-            <ol class="ons-list ons-list--bare spacing">
+            <ol class="ons-list ons-list--bare">
                 {% for block in page.changes_to_release_date %}
                     {% include_block block %}
                 {% endfor %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
@@ -43,7 +43,9 @@
             <h2>{{ _("Changes to this release date") }}</h2>
 
             <ol class="ons-list ons-list--bare">
-                {% include_block page.changes_to_release_date %}
+                {% for block in page.changes_to_release_date %}
+                    {% include_block block %}
+                {% endfor %}
             </ol>
         </section>
     {% endif %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page--confirmed.html
@@ -42,7 +42,7 @@
         <section id="changes-to-release-date">
             <h2>{{ _("Changes to this release date") }}</h2>
 
-            <ol class="ons-list ons-list--bare">
+            <ol class="ons-list ons-list--bare spacing">
                 {% for block in page.changes_to_release_date %}
                     {% include_block block %}
                 {% endfor %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
@@ -107,7 +107,7 @@
                     <section id="changes-to-release-date" class="spacing">
                         <h2>{{ _("Changes to this release date") }}</h2>
 
-                        <ol class="ons-list ons-list--bare spacing">
+                        <ol class="ons-list ons-list--bare">
                             {% for block in page.changes_to_release_date %}
                                 {% include_block block %}
                             {% endfor %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
@@ -108,7 +108,9 @@
                         <h2>{{ _("Changes to this release date") }}</h2>
 
                         <ol class="ons-list ons-list--bare">
-                            {% include_block page.changes_to_release_date %}
+                            {% for block in page.changes_to_release_date %}
+                                {% include_block block %}
+                            {% endfor %}
                         </ol>
                     </section>
                 {% endif %}

--- a/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
+++ b/cms/jinja2/templates/pages/release_calendar/release_calendar_page.html
@@ -107,7 +107,7 @@
                     <section id="changes-to-release-date" class="spacing">
                         <h2>{{ _("Changes to this release date") }}</h2>
 
-                        <ol class="ons-list ons-list--bare">
+                        <ol class="ons-list ons-list--bare spacing">
                             {% for block in page.changes_to_release_date %}
                                 {% include_block block %}
                             {% endfor %}

--- a/cms/release_calendar/models.py
+++ b/cms/release_calendar/models.py
@@ -258,7 +258,7 @@ class ReleaseCalendarPage(BundledPageMixin, BasePage):  # type: ignore[django-ma
                 items += block.block.to_table_of_contents_items(block.value)
 
             if self.dataset_document_list:
-                items += [{"url": "#datasets", "text": _("Data")}]
+                items += [{"url": "#data", "text": _("Data")}]
 
         if self.status in NON_PROVISIONAL_STATUSES and self.changes_to_release_date:
             items += [

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -4,6 +4,13 @@
     width: 100%;
     display: flex;
     gap: rem-sizing(24);
+    flex-direction: column;
+    margin-bottom: 1em;
+
+    @include media-query('m') {
+        // desktop only
+        flex-direction: row;
+    }
 
     &__block {
         flex-basis: 50%;

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -8,7 +8,6 @@
     margin-bottom: 1em;
 
     @include media-query('m') {
-        // desktop only
         flex-direction: row;
     }
 

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -19,7 +19,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        min-height: 200px;
+        min-height: 12.5rem;
 
         &--full-width {
             flex-basis: 100%;

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -12,6 +12,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
+        min-height: 200px;
 
         &--full-width {
             flex-basis: 100%;

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -19,7 +19,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        min-height: 12.5rem;
+        min-height: rem-sizing(200);
 
         &--full-width {
             flex-basis: 100%;

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -23,9 +23,13 @@
 
         &--full-width {
             flex-basis: 100%;
-            flex-direction: row;
+            flex-direction: column;
             gap: rem-sizing(24);
             justify-content: flex-start;
+
+            @include media-query('m') {
+                flex-direction: row;
+            }
         }
 
         @media (forced-colors: active) {

--- a/cms/static_src/sass/components/_accreditations.scss
+++ b/cms/static_src/sass/components/_accreditations.scss
@@ -25,10 +25,10 @@
             flex-basis: 100%;
             flex-direction: column;
             gap: rem-sizing(24);
-            justify-content: flex-start;
 
             @include media-query('m') {
                 flex-direction: row;
+                justify-content: flex-start;
             }
         }
 


### PR DESCRIPTION
### What is the context of this PR?

An audit of the Release Calendar page was carried out using Axe, WAVE and Lighthouse, alongside a visual review against the agreed designs.

The audit identified a mixture of technical, accessibility, visual and responsive implementation issues that should be addressed. This PR addresses the issues raised in the audit where possible. The audit can be found here: [Accessibility audit](https://officenationalstatistics-my.sharepoint.com/:x:/r/personal/joseph_nation_ons_gov_uk/Documents/RC_audit_UX.xlsx?d=w8b9fe08d5b8f425ab19b63bc4a86a2b8&csf=1&web=1&e=WgcYbI)

Ticket: [CMS-1396](https://officefornationalstatistics.atlassian.net/browse/CMS-1396?atlOrigin=eyJpIjoiNDY1MjBjZmFmOWYwNDYxZjhmYjk5ZGJhMmIzMWE3YjkiLCJwIjoiaiJ9)

### How to review

- Table of Contents anchor links
Confirm the 'Data' anchor link functions correctly in the table of contents.

-  Incorrect ordered list structure
An unexpected spacing `<div>` was inserted between the `<ol>` and its `<li>` elements:
`<ol><div class="spacing"><li>`
List items are now direct children of the ordered list:
`<ol><li>`
Confirm that this is the case for the 'changes to release date' blocks.

- Accreditation blocks – visual implementation
Confirm the following: 
Removal of the utility `ons-u-p-s class` from the `<div class="accreditations__block ">` block
`min-height: 200px;` added to the CSS class `"accreditations__block”`

- Accreditation blocks – mobile responsiveness
The accreditation blocks were not stacking appropriately at smaller/mobile viewport sizes.
In `<div class="accreditations">`, confirm that the following attributes are now added and function as expected:
`flex-direction:row;` for desktop and `flex-direction:column;` for mobile
`margin-bottom: 1em;`

- Design System consideration
The accreditation blocks used on the Release Calendar page do not have an equivalent component or documented pattern within the Design System. The implementation should follow existing Design System and UCD principles and be developed in a reusable way.
The resulting component can then be raised with the Design System team for consideration and potential inclusion where there is evidence of a wider reusable need.


### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.


---
Ticket: [CMS-1396](https://officefornationalstatistics.atlassian.net/browse/CMS-1396)

[CMS-1396]: https://officefornationalstatistics.atlassian.net/browse/CMS-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ