### PR TITLE
fix(taxonomy): skip already-removed topics in sync_topics

### DIFF
--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -206,12 +206,16 @@ def _create_topic(fetched_topic: Mapping[str, str]) -> None:
         Topic.save_new(new_topic)
 
 
-def _check_for_removed_topics(existing_topic_ids: set[str]) -> None:
+def _check_for_removed_topics(fetched_topic_ids: set[str]) -> None:
     """Figures out which topics exist in the database but were not returned
-    by the external API in this sync cycle.
+    by the external API in this sync cycle, and marks them as removed.
+
+    Only considers topics that are not already marked as removed, so the operation is
+    idempotent (already-removed topics are not re-saved) and the logged counts reflect
+    only topics newly removed in this cycle.
     """
-    existing_topics = _get_all_existing_topic_ids()
-    removed_topics = existing_topics.difference(existing_topic_ids)
+    active_topic_ids = _get_active_topic_ids()
+    removed_topics = active_topic_ids.difference(fetched_topic_ids)
     if removed_topics:
         logger.warning("Found removed topic(s)", extra={"count": len(removed_topics)})
     for removed_topic_id in removed_topics:
@@ -219,8 +223,8 @@ def _check_for_removed_topics(existing_topic_ids: set[str]) -> None:
         _set_topic_as_removed(removed_topic_id)
 
 
-def _get_all_existing_topic_ids() -> set[str]:
-    return set(Topic.objects.values_list("id", flat=True))
+def _get_active_topic_ids() -> set[str]:
+    return set(Topic.objects.filter(removed=False).values_list("id", flat=True))
 
 
 def _set_topic_as_removed(removed_topic_id: str) -> None:

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -509,18 +509,34 @@ class SyncTopicsTests(TestCase):
         # When, then raises
         self.assertRaises(RuntimeError, sync_topics.Command().handle)
 
-    def test_already_removed_topic_not_reprocessed(self):
-        """A topic already marked as removed, and still absent from the API, should not be re-saved."""
-        # Given an already-removed topic that the API still does not return
-        TopicFactory(id="9999", title="Gone", removed=True, slug="gone")
-        self.mock_requests.get.return_value = mock_successful_json_response([])
+    def test_only_missing_topics_are_marked_as_removed(self):
+        """A topic should only be marked as removed when it is no longer returned by the API.
+
+        This uses three topics to cover:
+        - a topic that the API still returns -> should not be marked as removed,
+        - a topic that the API no longer returns -> should be marked as removed (once),
+        - a topic that was already removed and is still not returned -> should be left alone (not saved again).
+        """
+        # Given a topic that the API still returns (should be not be marked as removed)
+        still_returned_topic = TopicFactory(id="0001", title="Still here", removed=False, slug="still-here")
+        # And a topic that the API no longer returns (should be newly marked as removed)
+        TopicFactory(id="0002", title="No longer returned", removed=False, slug="no-longer-returned")
+        # And a topic that was already removed and is still not returned (should not be touched again)
+        TopicFactory(id="9999", title="Already removed", removed=True, slug="already-removed")
+
+        # The API only returns the topic that still exists
+        self.mock_requests.get.return_value = mock_successful_json_response(
+            [build_topic_api_json(still_returned_topic)]
+        )
 
         # When
         with patch.object(sync_topics, "_set_topic_as_removed") as mock_set_removed:
             call_command("sync_topics")
 
-        # Then it should not be re-marked/re-saved
-        mock_set_removed.assert_not_called()
+        # Then only the topic that is no longer returned gets marked as removed, and only once.
+        # We assert the topic id to prove the still-returned topic (0001)
+        # and the already-removed topic (9999) were marked as removed.
+        mock_set_removed.assert_called_once_with("0002")
 
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -509,6 +509,19 @@ class SyncTopicsTests(TestCase):
         # When, then raises
         self.assertRaises(RuntimeError, sync_topics.Command().handle)
 
+    def test_already_removed_topic_not_reprocessed(self):
+        """A topic already marked as removed, and still absent from the API, should not be re-saved."""
+        # Given an already-removed topic that the API still does not return
+        TopicFactory(id="9999", title="Gone", removed=True, slug="gone")
+        self.mock_requests.get.return_value = mock_successful_json_response([])
+
+        # When
+        with patch.object(sync_topics, "_set_topic_as_removed") as mock_set_removed:
+            call_command("sync_topics")
+
+        # Then it should not be re-marked/re-saved
+        mock_set_removed.assert_not_called()
+
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:
     """Create a topic (without saving it to the database)."""


### PR DESCRIPTION
### What is the context of this PR?

`_check_for_removed_topics` in the `sync_topics` management command compared the topics returned by the API against **every** topic in the database, including those already marked as `removed=True`. As a result, every already-removed topic was re-saved (via `_set_topic_as_removed`) and re-logged as "removed" on every sync cycle, even though nothing had changed.

This PR makes the removal step idempotent by comparing the API response against only the **active** topics (`removed=False`):

### How to review

Ensure the changes make sense

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.

---
Ticket: [CMS-1401](https://officefornationalstatistics.atlassian.net/browse/CMS-1401)

[CMS-1401]: https://officefornationalstatistics.atlassian.net/browse/CMS-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ