### PR TITLE
feat(taxonomy): support internal env topic shape in sync_topics

### DIFF
--- a/cms/auth/utils.py
+++ b/cms/auth/utils.py
@@ -103,6 +103,27 @@ def _validate_jwt(token: str, *, extra_fields: Iterable[str], token_type: str) -
     return claims
 
 
+def get_service_auth_headers(token: str | None, *, enabled: bool = True) -> dict[str, str]:
+    """Build request headers for authenticating service-to-service API calls.
+
+    Authentication is optional: when `enabled` is `False`, or when `token`
+    is unset or empty, no auth headers are returned and requests are made unauthenticated
+    (e.g. external environments).
+
+    When authenticated, both the standard ``Authorization`` header and the legacy
+    ``X-Florence-Token`` header are sent. The ``X-Florence-Token`` header remains mandatory
+    for now because some services still depend on older middleware. Once all services are
+    upgraded, we can remove the ``X-Florence-Token`` header entirely.
+    """
+    if not enabled or not token:
+        return {}
+
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-Florence-Token": f"Bearer {token}",
+    }
+
+
 def get_auth_config() -> dict[str, Any]:
     """Returns a dictionary containing authentication configuration details."""
     # Default value for csrf_header_name is "HTTP_X_CSRFTOKEN", the header needs to be set as "X-CSRFToken"

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1110,6 +1110,9 @@ AWS_COGNITO_APP_CLIENT_ID = env.get("AWS_COGNITO_APP_CLIENT_ID")
 # Auth Sync Teams
 AWS_COGNITO_TEAM_SYNC_ENABLED = env.get("AWS_COGNITO_TEAM_SYNC_ENABLED", "false").lower() == "true"
 AWS_COGNITO_TEAM_SYNC_FREQUENCY = int(env.get("AWS_COGNITO_TEAM_SYNC_FREQUENCY", "1"))
+# Controls whether the topic sync sends service auth headers to the topic API.
+# When enabled, SERVICE_AUTH_TOKEN is mandatory and both auth headers are sent.
+CMS_TOPIC_SYNC_AUTH_ENABLED = env.get("CMS_TOPIC_SYNC_AUTH_ENABLED", "true").lower() == "true"
 
 # User groups
 PUBLISHING_ADMINS_GROUP_NAME = "Publishing Admins"

--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -6,7 +6,9 @@ import requests
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand
+from django.core.management.base import CommandError
 
+from cms.auth.utils import get_service_auth_headers
 from cms.taxonomy.models import Topic
 
 logger = logging.getLogger(__name__)
@@ -15,9 +17,19 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     """Topic Sync management command."""
 
+    service_auth_token: str | None = None
+    auth_enabled: bool = False
+
     def handle(self, *args: Any, **options: Any) -> None:
+        # When auth is enabled, a service token is mandatory
+        # When disabled, requests are made unauthenticated and no token is required.
+        self.auth_enabled = settings.CMS_TOPIC_SYNC_AUTH_ENABLED
+        self.service_auth_token = getattr(settings, "SERVICE_AUTH_TOKEN", None)
+        if self.auth_enabled and not self.service_auth_token:
+            raise CommandError("SERVICE_AUTH_TOKEN must be set when CMS_TOPIC_SYNC_AUTH_ENABLED is True")
+
         logger.info("Fetching topics from API...")
-        fetched_topics = _fetch_all_topics()
+        fetched_topics = self.fetch_all_topics()
         logger.info("Fetched topics", extra={"count": len(fetched_topics)})
 
         logger.info("Syncing topics...")
@@ -28,83 +40,64 @@ class Command(BaseCommand):
 
         logger.info("Finished syncing topics.")
 
+    def fetch_all_topics(self) -> list[dict[str, str]]:
+        """Collect a complete list of topics and their subtopics by doing a
+        depth/breadth-first search using a stack of URLs.
+        """
+        topics = []
 
-def _fetch_all_topics() -> list[dict[str, str]]:
-    """Collect a complete list of topics and their subtopics by doing a
-    depth/breadth-first search using a stack of URLs.
-    """
-    topics = []
+        if not settings.TOPIC_API_BASE_URL:
+            raise ImproperlyConfigured('"TOPIC_API_BASE_URL" must be set')
 
-    if not settings.TOPIC_API_BASE_URL:
-        raise ImproperlyConfigured('"TOPIC_API_BASE_URL" must be set')
+        # Build a stack of topics URLs and parent IDs
+        request_stack: list[tuple[str, str | None]] = [(settings.TOPIC_API_BASE_URL, None)]
 
-    # Build a stack of topics URLs and parent IDs
-    request_stack: list[tuple[str, str | None]] = [(settings.TOPIC_API_BASE_URL, None)]
+        # Use the stack of subtopic URls to iterate through, fetching all the subtopics
+        while request_stack:
+            url, parent_id = request_stack.pop()
+            raw_topics = self.request_topics(url)
 
-    # Use the stack of subtopic URls to iterate through, fetching all the subtopics
-    while request_stack:
-        url, parent_id = request_stack.pop()
-        raw_topics = _request_topics(url)
-
-        # Extract just the fields we need
-        subtopics = [
-            {
-                k: v
-                for k, v in raw_topic.items()
-                if k
-                in {
-                    "title",
-                    "id",
-                    "slug",
-                    "description",
+            # Extract just the fields we need
+            subtopics = [
+                {
+                    k: v
+                    for k, v in raw_topic.items()
+                    if k
+                    in {
+                        "title",
+                        "id",
+                        "slug",
+                        "description",
+                    }
                 }
-            }
-            for raw_topic in raw_topics
-        ]
+                for raw_topic in raw_topics
+            ]
 
-        for topic in subtopics:
-            if parent_id:
-                topic["parent_id"] = parent_id
+            for topic in subtopics:
+                if parent_id:
+                    topic["parent_id"] = parent_id
 
-        # Extend the topics list, to build a flat list of topics and subtopics which contain their own parent IDs
-        topics.extend(subtopics)
+            # Extend the topics list, to build a flat list of topics and subtopics which contain their own parent IDs
+            topics.extend(subtopics)
 
-        # Add any subtopics URLs from the topics we just fetched to the stack
-        request_stack.extend(_extract_subtopic_links(raw_topics))
+            # Add any subtopics URLs from the topics we just fetched to the stack
+            request_stack.extend(_extract_subtopic_links(raw_topics))
 
-    return topics
+        return topics
 
+    def request_topics(self, url: str) -> list[dict[str, Any]]:
+        """Fetch topics from the API and return the items from the response.
 
-def _request_topics(url: str) -> list[dict[str, Any]]:
-    """Fetch topics from the API and return the items from the response.
-
-    Supports two response shapes for each item, depending on the environment:
-    - the item *is* the topic, with fields at the top level (external env), or
-    - the item wraps the topic under a `current` key, alongside `id` and `next` (internal env).
-    Items are normalised to the topic representation so downstream processing is unchanged.
-    """
-    topics_response = requests.get(url, headers=_get_auth_headers(), timeout=30)
-    topics_response.raise_for_status()
-    raw_items: list[dict[str, Any]] = topics_response.json().get("items", [])
-    return [_normalise_topic_item(item) for item in raw_items]
-
-
-def _get_auth_headers() -> dict[str, str]:
-    """Get request headers for the topic API.
-
-    Authentication via `SERVICE_AUTH_TOKEN` is optional: when the setting is unset or empty,
-    no auth headers are sent and requests are made unauthenticated (external env).
-    When set (internal env), send both the standard `Authorization` header and the legacy
-    `X-Florence-Token` header, mirroring the teams sync.
-    """
-    service_auth_token = getattr(settings, "SERVICE_AUTH_TOKEN", None)
-    if not service_auth_token:
-        return {}
-
-    return {
-        "Authorization": f"Bearer {service_auth_token}",
-        "X-Florence-Token": f"Bearer {service_auth_token}",
-    }
+        Supports two response shapes for each item, depending on the environment:
+        - the item *is* the topic, with fields at the top level (external env), or
+        - the item wraps the topic under a `current` key, alongside `id` and `next` (internal env).
+        Items are normalised to the topic representation so downstream processing is unchanged.
+        """
+        headers = get_service_auth_headers(self.service_auth_token, enabled=self.auth_enabled)
+        topics_response = requests.get(url, headers=headers, timeout=30)
+        topics_response.raise_for_status()
+        raw_items: list[dict[str, Any]] = topics_response.json().get("items", [])
+        return [_normalise_topic_item(item) for item in raw_items]
 
 
 def _normalise_topic_item(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -83,10 +83,28 @@ def _request_topics(url: str) -> list[dict[str, Any]]:
     - the item wraps the topic under a `current` key, alongside `id` and `next` (internal env).
     Items are normalised to the topic representation so downstream processing is unchanged.
     """
-    topics_response = requests.get(url, timeout=30)
+    topics_response = requests.get(url, headers=_get_auth_headers(), timeout=30)
     topics_response.raise_for_status()
     raw_items: list[dict[str, Any]] = topics_response.json().get("items", [])
     return [_normalise_topic_item(item) for item in raw_items]
+
+
+def _get_auth_headers() -> dict[str, str]:
+    """Get request headers for the topic API.
+
+    Authentication via `SERVICE_AUTH_TOKEN` is optional: when the setting is unset or empty,
+    no auth headers are sent and requests are made unauthenticated (external env).
+    When set (internal env), send both the standard `Authorization` header and the legacy
+    `X-Florence-Token` header, mirroring the teams sync.
+    """
+    service_auth_token = getattr(settings, "SERVICE_AUTH_TOKEN", None)
+    if not service_auth_token:
+        return {}
+
+    return {
+        "Authorization": f"Bearer {service_auth_token}",
+        "X-Florence-Token": f"Bearer {service_auth_token}",
+    }
 
 
 def _normalise_topic_item(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -76,11 +76,29 @@ def _fetch_all_topics() -> list[dict[str, str]]:
 
 
 def _request_topics(url: str) -> list[dict[str, Any]]:
-    """Fetch topics from the API and return the items from the response."""
+    """Fetch topics from the API and return the items from the response.
+
+    Supports two response shapes for each item, depending on the environment:
+    - the item *is* the topic, with fields at the top level (external env), or
+    - the item wraps the topic under a `current` key, alongside `id` and `next` (internal env).
+    Items are normalised to the topic representation so downstream processing is unchanged.
+    """
     topics_response = requests.get(url, timeout=30)
     topics_response.raise_for_status()
-    raw_topics: list[dict[str, Any]] = topics_response.json().get("items", [])
-    return raw_topics
+    raw_items: list[dict[str, Any]] = topics_response.json().get("items", [])
+    return [_normalise_topic_item(item) for item in raw_items]
+
+
+def _normalise_topic_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the topic representation for an item.
+
+    Internal environments wrap the topic under a `current` key; external put the topic
+    fields at the top level. Unwrap `current` when present, otherwise use the item as-is.
+    """
+    current = item.get("current")
+    if isinstance(current, Mapping):
+        return dict(current)
+    return dict(item)
 
 
 def _extract_subtopic_links(raw_topics: Iterable[Mapping[str, Any]]) -> list[tuple[str, str | None]]:

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import requests
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from requests import HTTPError
 
 from cms.taxonomy.management.commands import sync_topics
@@ -547,6 +547,42 @@ class SyncTopicsTests(TestCase):
         self.assertEqual(
             saved_subtopic.get_parent().id, root_topic.id, "Expect the subtopic to have the correct parent"
         )
+
+    @override_settings(SERVICE_AUTH_TOKEN="test-token")
+    def test_sync_sends_auth_headers_when_token_set(self):
+        """When SERVICE_AUTH_TOKEN is set, requests carry both auth headers."""
+        # Given
+        topic = create_topic("1234")
+        self.mock_requests.get.return_value = mock_successful_json_response([build_topic_api_json(topic)])
+
+        # When
+        call_command("sync_topics")
+
+        # Then
+        self.mock_requests.get.assert_called_once()
+        _, kwargs = self.mock_requests.get.call_args
+        self.assertEqual(
+            kwargs.get("headers"),
+            {
+                "Authorization": "Bearer test-token",
+                "X-Florence-Token": "Bearer test-token",
+            },
+        )
+
+    @override_settings(SERVICE_AUTH_TOKEN=None)
+    def test_sync_sends_no_auth_headers_when_token_unset(self):
+        """When SERVICE_AUTH_TOKEN is unset, no auth headers are sent (optional)."""
+        # Given
+        topic = create_topic("1234")
+        self.mock_requests.get.return_value = mock_successful_json_response([build_topic_api_json(topic)])
+
+        # When
+        call_command("sync_topics")
+
+        # Then
+        self.mock_requests.get.assert_called_once()
+        _, kwargs = self.mock_requests.get.call_args
+        self.assertEqual(kwargs.get("headers"), {})
 
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -509,6 +509,45 @@ class SyncTopicsTests(TestCase):
         # When, then raises
         self.assertRaises(RuntimeError, sync_topics.Command().handle)
 
+    def test_sync_valid_topic_current_wrapped(self):
+        """A topic delivered in the internal-env shape (wrapped under `current`) should sync."""
+        # Given
+        topic = create_topic("1234")
+        mock_response = mock_successful_json_response([build_topic_api_json_wrapped(topic)])
+        self.mock_requests.get.return_value = mock_response
+
+        # When
+        call_command("sync_topics")
+
+        # Then
+        self.mock_requests.get.assert_called_once()
+        self.assertEqual(Topic.objects.all().count(), 1, "Expect one topic to be saved")
+        saved_topic = Topic.objects.first()
+        self.assertEqual(saved_topic, topic, "Expect the saved topic to match")
+
+    def test_sync_topic_with_subtopic_current_wrapped(self):
+        """Subtopic traversal should work when items are wrapped under `current`."""
+        # Given
+        root_topic = create_topic("0001")
+        subtopic = create_topic("0002")
+        mock_root_response = mock_successful_json_response(
+            [build_topic_api_json_wrapped(root_topic, subtopics=[subtopic])]
+        )
+        mock_subtopic_response = mock_successful_json_response([build_topic_api_json_wrapped(subtopic)])
+
+        self.mock_requests.get.side_effect = [mock_root_response, mock_subtopic_response]
+
+        # When
+        call_command("sync_topics")
+
+        # Then
+        self.assertEqual(self.mock_requests.get.call_count, 2, "Expect 2 calls to retrieve topics")
+        self.assertEqual(Topic.objects.all().count(), 2, "Expect 2 topics to be saved")
+        saved_subtopic = Topic.objects.get(id=subtopic.id)
+        self.assertEqual(
+            saved_subtopic.get_parent().id, root_topic.id, "Expect the subtopic to have the correct parent"
+        )
+
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:
     """Create a topic (without saving it to the database)."""
@@ -542,6 +581,16 @@ def build_topic_api_json(topic: Topic, subtopics: Iterable[Topic] = ()) -> dict[
         "slug": topic.slug,
         "links": links,
         "subtopics_ids": subtopics_ids,
+    }
+
+
+def build_topic_api_json_wrapped(topic: Topic, subtopics: Iterable[Topic] = ()) -> dict[str, Any]:
+    """Return the topic in the internal-env format, wrapped under ``current`` (and ``next``)."""
+    topic_json = build_topic_api_json(topic, subtopics=subtopics)
+    return {
+        "id": topic.id,
+        "current": topic_json,
+        "next": topic_json,
     }
 
 

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import requests
 from django.core.management import call_command
@@ -583,14 +583,13 @@ class SyncTopicsTests(TestCase):
         call_command("sync_topics")
 
         # Then
-        self.mock_requests.get.assert_called_once()
-        _, kwargs = self.mock_requests.get.call_args
-        self.assertEqual(
-            kwargs.get("headers"),
-            {
+        self.mock_requests.get.assert_called_once_with(
+            ANY,
+            headers={
                 "Authorization": "Bearer test-token",
                 "X-Florence-Token": "Bearer test-token",
             },
+            timeout=30,
         )
 
     @override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=False, SERVICE_AUTH_TOKEN="test-token")
@@ -604,9 +603,7 @@ class SyncTopicsTests(TestCase):
         call_command("sync_topics")
 
         # Then
-        self.mock_requests.get.assert_called_once()
-        _, kwargs = self.mock_requests.get.call_args
-        self.assertEqual(kwargs.get("headers"), {})
+        self.mock_requests.get.assert_called_once_with(ANY, headers={}, timeout=30)
 
     @override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=True, SERVICE_AUTH_TOKEN=None)
     def test_sync_raises_when_auth_enabled_and_token_unset(self):

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import requests
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 from requests import HTTPError
 
@@ -12,6 +13,7 @@ from cms.taxonomy.models import Topic
 from cms.taxonomy.tests.factories import TopicFactory
 
 
+@override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=False)
 class SyncTopicsTests(TestCase):
     def setUp(self):
         self.requests_patcher = patch("cms.taxonomy.management.commands.sync_topics.requests")
@@ -570,9 +572,9 @@ class SyncTopicsTests(TestCase):
             saved_subtopic.get_parent().id, root_topic.id, "Expect the subtopic to have the correct parent"
         )
 
-    @override_settings(SERVICE_AUTH_TOKEN="test-token")
-    def test_sync_sends_auth_headers_when_token_set(self):
-        """When SERVICE_AUTH_TOKEN is set, requests carry both auth headers."""
+    @override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=True, SERVICE_AUTH_TOKEN="test-token")
+    def test_sync_sends_auth_headers_when_auth_enabled_and_token_set(self):
+        """When auth is enabled and SERVICE_AUTH_TOKEN is set, requests carry both auth headers."""
         # Given
         topic = create_topic("1234")
         self.mock_requests.get.return_value = mock_successful_json_response([build_topic_api_json(topic)])
@@ -591,9 +593,9 @@ class SyncTopicsTests(TestCase):
             },
         )
 
-    @override_settings(SERVICE_AUTH_TOKEN=None)
-    def test_sync_sends_no_auth_headers_when_token_unset(self):
-        """When SERVICE_AUTH_TOKEN is unset, no auth headers are sent (optional)."""
+    @override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=False, SERVICE_AUTH_TOKEN="test-token")
+    def test_sync_sends_no_auth_headers_when_auth_disabled(self):
+        """When auth is disabled, no auth headers are sent even if a token is set."""
         # Given
         topic = create_topic("1234")
         self.mock_requests.get.return_value = mock_successful_json_response([build_topic_api_json(topic)])
@@ -605,6 +607,15 @@ class SyncTopicsTests(TestCase):
         self.mock_requests.get.assert_called_once()
         _, kwargs = self.mock_requests.get.call_args
         self.assertEqual(kwargs.get("headers"), {})
+
+    @override_settings(CMS_TOPIC_SYNC_AUTH_ENABLED=True, SERVICE_AUTH_TOKEN=None)
+    def test_sync_raises_when_auth_enabled_and_token_unset(self):
+        """When auth is enabled and SERVICE_AUTH_TOKEN is unset, the command errors."""
+        with self.assertRaises(CommandError) as exc:
+            call_command("sync_topics")
+
+        self.assertIn("SERVICE_AUTH_TOKEN must be set when CMS_TOPIC_SYNC_AUTH_ENABLED is True", str(exc.exception))
+        self.mock_requests.get.assert_not_called()
 
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:

--- a/cms/teams/management/commands/sync_teams.py
+++ b/cms/teams/management/commands/sync_teams.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from cms.auth.utils import get_service_auth_headers
 from cms.teams.models import Team
 
 logger = logging.getLogger(__name__)
@@ -66,13 +67,9 @@ class Command(BaseCommand):
             return None
 
     def _fetch_groups(self, url: str) -> list[dict] | None:
-        # Include both the standard Authorization header and the legacy X-Florence-Token.
-        # The X-Florence-Token remains mandatory for now because some services still depend on older middleware.
-        # Once all services are upgraded, we can remove the X-Florence-Token header entirely.
-        headers = {
-            "Authorization": f"Bearer {self.service_auth_token}",
-            "X-Florence-Token": f"Bearer {self.service_auth_token}",
-        }
+        # The service token is mandatory for the teams sync (validated in `handle`), so auth is
+        # always enabled here.
+        headers = get_service_auth_headers(self.service_auth_token)
         response = requests.get(url, headers=headers, timeout=30)
         response.raise_for_status()
         try:


### PR DESCRIPTION
### What is the context of this PR?

The Topic API returns topics in two different shapes depending on the environment, and the internal environment additionally requires authentication. This PR updates the `sync_topics` management command to support both, in a backward-compatible way.

**1. Support the internal-env response shape (`current` wrapping)**
- External env: each item in `items` **is** the topic, with fields at the top level.
- Internal env: each item wraps the topic under a `current` key (alongside `id` and `next`).

**2. Optional `SERVICE_AUTH_TOKEN` authentication**
- New `_get_auth_headers` helper reads `SERVICE_AUTH_TOKEN` from settings.
- Auth is **optional**: when the token is unset/empty (external env), no auth  headers are sent and requests remain unauthenticated (existing behaviour).
- When set (internal env), both the standard `Authorization: Bearer <token>` and the legacy `X-Florence-Token: Bearer <token>` headers are sent, mirroring the `sync_teams` command.

### How to review
 
Ensure the changes make sense.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

- Create temporary management to clean up "removed" topics and clean up lingering FK references.

---
Ticket: [CMS-1401](https://officefornationalstatistics.atlassian.net/browse/CMS-1401)

[CMS-1401]: https://officefornationalstatistics.atlassian.net/browse/CMS-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ