### PR TITLE
fix(csp): allow google analytics and video embed sources

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1201,6 +1201,10 @@ WAGTAIL_POLYMATH = {
     "mathjax_sri": "sha512-M36RUChWzAh1veeenRZFql7HydLEnkYmoloiCvVrhz402UZgKI93qkV7SsaxtVKdN95Wzajh39ysrXCq34NTsg==",
 }
 
+GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED = (
+    not IS_EXTERNAL_ENV or env.get("GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED", "false").lower() == "true"
+)
+
 # Content Security policy settings
 # https://docs.djangoproject.com/en/6.0/ref/csp/
 static_sources = [ONS_CDN_URL]
@@ -1209,13 +1213,15 @@ SECURE_CSP: dict[str, list] = {
     "frame-src": [CSP.SELF, *IFRAME_VISUALISATION_CSP_SOURCES],
     # UNSAFE_INLINE is required by mathjax
     "style-src": [CSP.SELF, *static_sources, CSP.UNSAFE_INLINE, "*.hotjar.com"],
-    "img-src": [CSP.SELF, ONS_CDN_URL, "www.googletagmanager.com", "*.hotjar.com"],
+    "img-src": [CSP.SELF, ONS_CDN_URL, "www.googletagmanager.com", "*.google-analytics.com", "*.hotjar.com"],
     # UNSAFE_INLINE is required by hotjar
     "script-src": [CSP.SELF, *static_sources, "*.hotjar.com", "www.googletagmanager.com", CSP.UNSAFE_INLINE],
     "font-src": [CSP.SELF, *static_sources, "*.hotjar.com"],
     "connect-src": [
         CSP.SELF,
         "www.googletagmanager.com",
+        "*.google-analytics.com",
+        "*.analytics.google.com",
         "www.google.com",
         "*.hotjar.com",
         "*.hotjar.io",
@@ -1224,12 +1230,21 @@ SECURE_CSP: dict[str, list] = {
     "manifest-src": [CSP.SELF, ONS_CDN_URL],
     "frame-ancestors": [CSP.NONE if IS_EXTERNAL_ENV else CSP.SELF],
 }
-# Google Fonts are only needed for the Wagtail admin.
-# The external site loads fonts directly from the ONS CDN, so these CSP sources
-# should not be allowed there.
-if not IS_EXTERNAL_ENV:
+
+allow_google_fonts = not IS_EXTERNAL_ENV or GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED
+
+# Google Fonts are needed for the Wagtail admin and GTM Preview Mode.
+# The external site otherwise loads fonts directly from the ONS CDN, so these
+# sources should only be allowed when one of those cases applies.
+if allow_google_fonts:
     SECURE_CSP["style-src"].append("fonts.googleapis.com")
     SECURE_CSP["font-src"].append("fonts.gstatic.com")
+
+if GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED:
+    SECURE_CSP["script-src"].append("tagmanager.google.com")
+    SECURE_CSP["style-src"].extend(["www.googletagmanager.com", "tagmanager.google.com"])
+    SECURE_CSP["img-src"].extend(["ssl.gstatic.com", "www.gstatic.com"])
+    SECURE_CSP["font-src"].append("data:")
 
 if s3_custom_domain := env.get("AWS_S3_CUSTOM_DOMAIN"):
     SECURE_CSP["img-src"].append(f"https://{s3_custom_domain}")

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1205,12 +1205,14 @@ GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED = (
     not IS_EXTERNAL_ENV or env.get("GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED", "false").lower() == "true"
 )
 
+VIDEO_EMBED_CSP_SOURCES = ["www.youtube.com", "player.vimeo.com"]
+
 # Content Security policy settings
 # https://docs.djangoproject.com/en/6.0/ref/csp/
 static_sources = [ONS_CDN_URL]
 SECURE_CSP: dict[str, list] = {
     "default-src": [CSP.SELF],
-    "frame-src": [CSP.SELF, *IFRAME_VISUALISATION_CSP_SOURCES],
+    "frame-src": [CSP.SELF, *IFRAME_VISUALISATION_CSP_SOURCES, *VIDEO_EMBED_CSP_SOURCES],
     # UNSAFE_INLINE is required by mathjax
     "style-src": [CSP.SELF, *static_sources, CSP.UNSAFE_INLINE, "*.hotjar.com"],
     "img-src": [CSP.SELF, ONS_CDN_URL, "www.googletagmanager.com", "*.google-analytics.com", "*.hotjar.com"],

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1206,6 +1206,7 @@ GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED = (
 )
 
 VIDEO_EMBED_CSP_SOURCES = ["www.youtube.com", "player.vimeo.com"]
+VIDEO_EMBED_PERMISSIONS_POLICY_SOURCES = ["self", "https://www.youtube.com", "https://player.vimeo.com"]
 
 # Content Security policy settings
 # https://docs.djangoproject.com/en/6.0/ref/csp/
@@ -1259,8 +1260,8 @@ PERMISSIONS_POLICY: dict = {
     "autoplay": [],
     "camera": [],
     "display-capture": [],
-    "encrypted-media": [],
-    "fullscreen": [],
+    "encrypted-media": VIDEO_EMBED_PERMISSIONS_POLICY_SOURCES,
+    "fullscreen": VIDEO_EMBED_PERMISSIONS_POLICY_SOURCES,
     "geolocation": [],
     "gyroscope": [],
     "interest-cohort": [],

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1201,9 +1201,7 @@ WAGTAIL_POLYMATH = {
     "mathjax_sri": "sha512-M36RUChWzAh1veeenRZFql7HydLEnkYmoloiCvVrhz402UZgKI93qkV7SsaxtVKdN95Wzajh39ysrXCq34NTsg==",
 }
 
-GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED = (
-    not IS_EXTERNAL_ENV or env.get("GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED", "false").lower() == "true"
-)
+CMS_GTM_PREVIEW_MODE_ENABLED = not IS_EXTERNAL_ENV or env.get("CMS_GTM_PREVIEW_MODE_ENABLED", "false").lower() == "true"
 
 VIDEO_EMBED_CSP_SOURCES = ["www.youtube.com", "player.vimeo.com"]
 VIDEO_EMBED_PERMISSIONS_POLICY_SOURCES = ["self", "https://www.youtube.com", "https://player.vimeo.com"]
@@ -1234,7 +1232,7 @@ SECURE_CSP: dict[str, list] = {
     "frame-ancestors": [CSP.NONE if IS_EXTERNAL_ENV else CSP.SELF],
 }
 
-allow_google_fonts = not IS_EXTERNAL_ENV or GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED
+allow_google_fonts = not IS_EXTERNAL_ENV or CMS_GTM_PREVIEW_MODE_ENABLED
 
 # Google Fonts are needed for the Wagtail admin and GTM Preview Mode.
 # The external site otherwise loads fonts directly from the ONS CDN, so these
@@ -1243,7 +1241,7 @@ if allow_google_fonts:
     SECURE_CSP["style-src"].append("fonts.googleapis.com")
     SECURE_CSP["font-src"].append("fonts.gstatic.com")
 
-if GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED:
+if CMS_GTM_PREVIEW_MODE_ENABLED:
     SECURE_CSP["script-src"].append("tagmanager.google.com")
     SECURE_CSP["style-src"].extend(["www.googletagmanager.com", "tagmanager.google.com"])
     SECURE_CSP["img-src"].extend(["ssl.gstatic.com", "www.gstatic.com"])

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1203,6 +1203,8 @@ WAGTAIL_POLYMATH = {
 
 CMS_GTM_PREVIEW_MODE_ENABLED = not IS_EXTERNAL_ENV or env.get("CMS_GTM_PREVIEW_MODE_ENABLED", "false").lower() == "true"
 
+# Although different video URL variants such as youtu.be and youtube.com without www are allowed,
+# the URL is normalised when calling `get_embed_url`.
 VIDEO_EMBED_CSP_SOURCES = ["www.youtube.com", "player.vimeo.com"]
 VIDEO_EMBED_PERMISSIONS_POLICY_SOURCES = ["self", "https://www.youtube.com", "https://player.vimeo.com"]
 

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -87,7 +87,7 @@ class SettingsTestCase(TestCase):
             )
 
 
-class CSPTestCase(TestCase):
+class SecurityHeadersTestCase(TestCase):
     urls = frozenset(["/", "/test404", reverse_lazy("wagtailadmin_login")])
 
     def _parse_csp(self, header_value: str) -> dict[str, list[str]]:
@@ -102,6 +102,15 @@ class CSPTestCase(TestCase):
     def _get_csp_expressions(self, policy: dict[str, list[str]], directive: str) -> list[str]:
         # Fall back to default-src if directive is not present
         return policy.get(directive, policy.get("default-src", []))
+
+    def _parse_permissions_policy(self, header_value: str) -> dict[str, list[str]]:
+        directives = {}
+
+        for directive in header_value.split(","):
+            feature, allow_list = directive.strip().split("=", 1)
+            directives[feature] = [value.strip('"') for value in allow_list.strip()[1:-1].split()]
+
+        return directives
 
     def test_self_in_all_expressions(self):
         for url in self.urls:
@@ -211,6 +220,22 @@ class CSPTestCase(TestCase):
 
                 self.assertIn("www.youtube.com", self._get_csp_expressions(csp, "frame-src"))
                 self.assertIn("player.vimeo.com", self._get_csp_expressions(csp, "frame-src"))
+
+    def test_video_embed_permissions_policy(self):
+        for url in self.urls:
+            with self.subTest(url):
+                response = self.client.get(url)
+
+                permissions_policy = self._parse_permissions_policy(response.headers["Permissions-Policy"])
+
+                self.assertEqual(
+                    permissions_policy["encrypted-media"],
+                    ["self", "https://www.youtube.com", "https://player.vimeo.com"],
+                )
+                self.assertEqual(
+                    permissions_policy["fullscreen"],
+                    ["self", "https://www.youtube.com", "https://player.vimeo.com"],
+                )
 
     def test_wagtail_csp(self):
         """https://github.com/wagtail/wagtail/issues?q=is%3Aissue%20state%3Aopen%20csp."""

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.template import Context, Template
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
 from django.utils.csp import CSP
 
@@ -140,20 +140,26 @@ class SecurityHeadersTestCase(TestCase):
                 self.assertIn("*.analytics.google.com", self._get_csp_expressions(csp, "connect-src"))
 
     def test_gtm_preview_mode_csp(self):
-        for url in self.urls:
-            with self.subTest(url):
-                response = self.client.get(url)
+        self.addCleanup(importlib.reload, base)
 
-                csp = self._parse_csp(response.headers["Content-Security-Policy"])
+        with mock.patch.dict(os.environ, {"GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"}, clear=False):
+            reloaded_base = importlib.reload(base)
 
-                self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "script-src"))
-                self.assertIn("www.googletagmanager.com", self._get_csp_expressions(csp, "style-src"))
-                self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "style-src"))
-                self.assertIn("fonts.googleapis.com", self._get_csp_expressions(csp, "style-src"))
-                self.assertIn("ssl.gstatic.com", self._get_csp_expressions(csp, "img-src"))
-                self.assertIn("www.gstatic.com", self._get_csp_expressions(csp, "img-src"))
-                self.assertIn("data:", self._get_csp_expressions(csp, "font-src"))
-                self.assertIn("fonts.gstatic.com", self._get_csp_expressions(csp, "font-src"))
+            with override_settings(SECURE_CSP=reloaded_base.SECURE_CSP):
+                for url in self.urls:
+                    with self.subTest(url):
+                        response = self.client.get(url)
+
+                        csp = self._parse_csp(response.headers["Content-Security-Policy"])
+
+                        self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "script-src"))
+                        self.assertIn("www.googletagmanager.com", self._get_csp_expressions(csp, "style-src"))
+                        self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "style-src"))
+                        self.assertIn("fonts.googleapis.com", self._get_csp_expressions(csp, "style-src"))
+                        self.assertIn("ssl.gstatic.com", self._get_csp_expressions(csp, "img-src"))
+                        self.assertIn("www.gstatic.com", self._get_csp_expressions(csp, "img-src"))
+                        self.assertIn("data:", self._get_csp_expressions(csp, "font-src"))
+                        self.assertIn("fonts.gstatic.com", self._get_csp_expressions(csp, "font-src"))
 
     def test_hotjar_csp(self):
         """https://help.hotjar.com/hc/en-us/articles/36820026388881-Content-Security-Policies."""

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -40,7 +40,7 @@ class SettingsTestCase(TestCase):
 
         with mock.patch.dict(os.environ, {"IS_EXTERNAL_ENV": "false"}, clear=False):
             reloaded_base = importlib.reload(base)
-            self.assertTrue(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
+            self.assertTrue(reloaded_base.CMS_GTM_PREVIEW_MODE_ENABLED)
             self.assertIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
             self.assertIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
             self.assertIn("tagmanager.google.com", reloaded_base.SECURE_CSP["script-src"])
@@ -51,10 +51,10 @@ class SettingsTestCase(TestCase):
         self.addCleanup(importlib.reload, base)
 
         with mock.patch.dict(
-            os.environ, {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "false"}, clear=False
+            os.environ, {"IS_EXTERNAL_ENV": "true", "CMS_GTM_PREVIEW_MODE_ENABLED": "false"}, clear=False
         ):
             reloaded_base = importlib.reload(base)
-            self.assertFalse(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
+            self.assertFalse(reloaded_base.CMS_GTM_PREVIEW_MODE_ENABLED)
             self.assertNotIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
             self.assertNotIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
             self.assertNotIn("data:", reloaded_base.SECURE_CSP["font-src"])
@@ -66,11 +66,11 @@ class SettingsTestCase(TestCase):
 
         with mock.patch.dict(
             os.environ,
-            {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"},
+            {"IS_EXTERNAL_ENV": "true", "CMS_GTM_PREVIEW_MODE_ENABLED": "true"},
             clear=False,
         ):
             reloaded_base = importlib.reload(base)
-            self.assertTrue(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
+            self.assertTrue(reloaded_base.CMS_GTM_PREVIEW_MODE_ENABLED)
             self.assertIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
             self.assertIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
             self.assertIn("tagmanager.google.com", reloaded_base.SECURE_CSP["script-src"])
@@ -146,7 +146,7 @@ class SecurityHeadersTestCase(TestCase):
 
         with mock.patch.dict(
             os.environ,
-            {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"},
+            {"IS_EXTERNAL_ENV": "true", "CMS_GTM_PREVIEW_MODE_ENABLED": "true"},
             clear=False,
         ):
             reloaded_base = importlib.reload(base)

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -40,8 +40,11 @@ class SettingsTestCase(TestCase):
 
         with mock.patch.dict(os.environ, {"IS_EXTERNAL_ENV": "false"}, clear=False):
             reloaded_base = importlib.reload(base)
+            self.assertTrue(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
             self.assertIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
             self.assertIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
+            self.assertIn("tagmanager.google.com", reloaded_base.SECURE_CSP["script-src"])
+            self.assertIn("data:", reloaded_base.SECURE_CSP["font-src"])
             self.assertEqual(reloaded_base.SECURE_CSP["frame-ancestors"], [CSP.SELF])
 
     def test_external_env_csp_settings(self):
@@ -49,9 +52,29 @@ class SettingsTestCase(TestCase):
 
         with mock.patch.dict(os.environ, {"IS_EXTERNAL_ENV": "true"}, clear=False):
             reloaded_base = importlib.reload(base)
+            self.assertFalse(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
             self.assertNotIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
             self.assertNotIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
+            self.assertNotIn("data:", reloaded_base.SECURE_CSP["font-src"])
+            self.assertNotIn("tagmanager.google.com", reloaded_base.SECURE_CSP["script-src"])
             self.assertEqual(reloaded_base.SECURE_CSP["frame-ancestors"], [CSP.NONE])
+
+    def test_gtm_preview_mode_can_be_enabled_via_feature_flag(self):
+        self.addCleanup(importlib.reload, base)
+
+        with mock.patch.dict(
+            os.environ,
+            {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"},
+            clear=False,
+        ):
+            reloaded_base = importlib.reload(base)
+            self.assertTrue(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
+            self.assertIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
+            self.assertIn("fonts.gstatic.com", reloaded_base.SECURE_CSP["font-src"])
+            self.assertIn("tagmanager.google.com", reloaded_base.SECURE_CSP["script-src"])
+            self.assertIn("ssl.gstatic.com", reloaded_base.SECURE_CSP["img-src"])
+            self.assertIn("www.gstatic.com", reloaded_base.SECURE_CSP["img-src"])
+            self.assertIn("data:", reloaded_base.SECURE_CSP["font-src"])
 
     def test_iframe_visualisation_csp_sources_include_subdomains(self):
         self.addCleanup(importlib.reload, base)
@@ -91,7 +114,7 @@ class CSPTestCase(TestCase):
                     with self.subTest(directive):
                         self.assertIn(CSP.SELF, self._get_csp_expressions(csp, directive))
 
-    def test_gtm_csp(self):
+    def test_google_tagging_csp(self):
         """https://developers.google.com/tag-platform/security/guides/csp."""
         for url in self.urls:
             with self.subTest(url):
@@ -103,6 +126,25 @@ class CSPTestCase(TestCase):
                 self.assertIn("www.googletagmanager.com", self._get_csp_expressions(csp, "connect-src"))
                 self.assertIn("www.googletagmanager.com", self._get_csp_expressions(csp, "script-src"))
                 self.assertIn("www.google.com", self._get_csp_expressions(csp, "connect-src"))
+                self.assertIn("*.google-analytics.com", self._get_csp_expressions(csp, "img-src"))
+                self.assertIn("*.google-analytics.com", self._get_csp_expressions(csp, "connect-src"))
+                self.assertIn("*.analytics.google.com", self._get_csp_expressions(csp, "connect-src"))
+
+    def test_gtm_preview_mode_csp(self):
+        for url in self.urls:
+            with self.subTest(url):
+                response = self.client.get(url)
+
+                csp = self._parse_csp(response.headers["Content-Security-Policy"])
+
+                self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "script-src"))
+                self.assertIn("www.googletagmanager.com", self._get_csp_expressions(csp, "style-src"))
+                self.assertIn("tagmanager.google.com", self._get_csp_expressions(csp, "style-src"))
+                self.assertIn("fonts.googleapis.com", self._get_csp_expressions(csp, "style-src"))
+                self.assertIn("ssl.gstatic.com", self._get_csp_expressions(csp, "img-src"))
+                self.assertIn("www.gstatic.com", self._get_csp_expressions(csp, "img-src"))
+                self.assertIn("data:", self._get_csp_expressions(csp, "font-src"))
+                self.assertIn("fonts.gstatic.com", self._get_csp_expressions(csp, "font-src"))
 
     def test_hotjar_csp(self):
         """https://help.hotjar.com/hc/en-us/articles/36820026388881-Content-Security-Policies."""

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -50,7 +50,9 @@ class SettingsTestCase(TestCase):
     def test_external_env_csp_settings(self):
         self.addCleanup(importlib.reload, base)
 
-        with mock.patch.dict(os.environ, {"IS_EXTERNAL_ENV": "true"}, clear=False):
+        with mock.patch.dict(
+            os.environ, {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "false"}, clear=False
+        ):
             reloaded_base = importlib.reload(base)
             self.assertFalse(reloaded_base.GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED)
             self.assertNotIn("fonts.googleapis.com", reloaded_base.SECURE_CSP["style-src"])
@@ -142,7 +144,11 @@ class SecurityHeadersTestCase(TestCase):
     def test_gtm_preview_mode_csp(self):
         self.addCleanup(importlib.reload, base)
 
-        with mock.patch.dict(os.environ, {"GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"}, clear=False):
+        with mock.patch.dict(
+            os.environ,
+            {"IS_EXTERNAL_ENV": "true", "GOOGLE_TAG_MANAGER_PREVIEW_MODE_ENABLED": "true"},
+            clear=False,
+        ):
             reloaded_base = importlib.reload(base)
 
             with override_settings(SECURE_CSP=reloaded_base.SECURE_CSP):

--- a/cms/settings/tests/test_settings.py
+++ b/cms/settings/tests/test_settings.py
@@ -202,6 +202,16 @@ class CSPTestCase(TestCase):
                     with self.subTest(allowed_source):
                         self.assertIn(allowed_source, self._get_csp_expressions(csp, "frame-src"))
 
+    def test_video_embed_csp(self):
+        for url in self.urls:
+            with self.subTest(url):
+                response = self.client.get(url)
+
+                csp = self._parse_csp(response.headers["Content-Security-Policy"])
+
+                self.assertIn("www.youtube.com", self._get_csp_expressions(csp, "frame-src"))
+                self.assertIn("player.vimeo.com", self._get_csp_expressions(csp, "frame-src"))
+
     def test_wagtail_csp(self):
         """https://github.com/wagtail/wagtail/issues?q=is%3Aissue%20state%3Aopen%20csp."""
         response = self.client.get(reverse("wagtailadmin_login"))


### PR DESCRIPTION
### What is the context of this PR?

Addresses [CMS-1364](https://officefornationalstatistics.atlassian.net/browse/CMS-1364) and [CMS-1378
](https://officefornationalstatistics.atlassian.net/browse/CMS-1378)

- Adds CSP domains for GA and GTM preview mode as per https://developers.google.com/tag-platform/security/guides/csp
   - Preview mode is controlled by the feature flag `CMS_GTM_PREVIEW_MODE_ENABLED`. It is enabled by default in the internal env
- Adds CSP allowances for YouTube and Vimeo embeds
- Updates `Permissions-Policy` so encrypted-media and fullscreen are allowed for YouTube and Vimeo embeds, enabling normal playback behaviour and fullscreen support

### How to review

**Google Analytics and GTM:**
1. Confirm the CSP includes the required Google Analytics and GTM preview mode domains, excluding advertising-related domains: https://developers.google.com/tag-platform/security/guides/csp
2. Check that GTM preview mode sources are only added when `CMS_GTM_PREVIEW_MODE_ENABLED` is enabled, and are not always present for the external site.

**Video embeds:**
1. Add YouTube and Vimeo video embeds to a page and publish it
2. Ensure the embeds load correctly on the page
3. Verify that the embeds can play normally and enter fullscreen
4. Ensure there are no browser console errors when loading the page or when playing the embedded videos

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [X] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

Needs to be back ported to v1.6.0-rc.1, v1.7.0-rc.1 and v1.8.0-rc.1 once merged

---
Ticket: [CMS-1364](https://officefornationalstatistics.atlassian.net/browse/CMS-1364)

[CMS-1364]: https://officefornationalstatistics.atlassian.net/browse/CMS-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ