### PR TITLE
feat(taxonomy): exclude configured topic slugs from sync

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -1012,6 +1012,12 @@ DATASETS_API_EDITIONS_URL = env.get("DATASETS_API_EDITIONS_URL", f"{ONS_API_BASE
 DIS_DATASETS_BUNDLE_API_BASE_URL = env.get("DIS_DATASETS_BUNDLE_API_BASE_URL", ONS_API_BASE_URL)
 TOPIC_API_BASE_URL = env.get("TOPIC_API_BASE_URL", f"{ONS_API_BASE_URL}/topics")  # used to sync topics
 
+# Comma-separated list of top-level topic slugs to exclude when syncing topics.
+# Excluded topics and all of their subtopics are skipped during sync.
+CMS_TOPIC_SYNC_EXCLUDED_SLUGS = {
+    slug.strip() for slug in env.get("CMS_TOPIC_SYNC_EXCLUDED_SLUGS", "census").split(",") if slug.strip()
+}
+
 # Feature flag to enable/disable interaction with the ONS Bundle API
 DIS_DATASETS_BUNDLE_API_ENABLED = env.get("DIS_DATASETS_BUNDLE_API_ENABLED", "false").lower() == "true"
 

--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -38,6 +38,9 @@ def _fetch_all_topics() -> list[dict[str, str]]:
     if not settings.TOPIC_API_BASE_URL:
         raise ImproperlyConfigured('"TOPIC_API_BASE_URL" must be set')
 
+    # Slugs configured to be excluded from syncing, along with all of their subtopics.
+    excluded_slugs = settings.CMS_TOPIC_SYNC_EXCLUDED_SLUGS
+
     # Build a stack of topics URLs and parent IDs
     request_stack: list[tuple[str, str | None]] = [(settings.TOPIC_API_BASE_URL, None)]
 
@@ -45,6 +48,11 @@ def _fetch_all_topics() -> list[dict[str, str]]:
     while request_stack:
         url, parent_id = request_stack.pop()
         raw_topics = _request_topics(url)
+
+        # Drop any topics whose slug is excluded. Because their subtopic links are not added to the
+        # request stack below, their whole subtree is skipped too.
+        if excluded_slugs:
+            raw_topics = [raw_topic for raw_topic in raw_topics if raw_topic.get("slug") not in excluded_slugs]
 
         # Extract just the fields we need
         subtopics = [

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import requests
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from requests import HTTPError
 
 from cms.taxonomy.management.commands import sync_topics
@@ -508,6 +508,79 @@ class SyncTopicsTests(TestCase):
 
         # When, then raises
         self.assertRaises(RuntimeError, sync_topics.Command().handle)
+
+    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS=["census"])
+    def test_excluded_topic_and_subtopics_are_not_synced(self):
+        """A top-level topic with an excluded slug, and its subtopics, should be skipped entirely."""
+        # Given
+        included_topic = create_topic("0001")
+        included_topic.slug = "economy"
+
+        excluded_topic = create_topic("4445")
+        excluded_topic.slug = "census"
+        excluded_subtopic = create_topic("6694")
+        excluded_subtopic.slug = "ageing"
+
+        mock_root_response = mock_successful_json_response(
+            [
+                build_topic_api_json(included_topic),
+                build_topic_api_json(excluded_topic, subtopics=[excluded_subtopic]),
+            ]
+        )
+        mock_subtopic_response = mock_successful_json_response([build_topic_api_json(excluded_subtopic)])
+        self.mock_requests.get.side_effect = [mock_root_response, mock_subtopic_response]
+
+        # When
+        call_command("sync_topics")
+
+        # Then
+        self.assertEqual(self.mock_requests.get.call_count, 1, "Expect no subtopic fetch for the excluded topic")
+        self.assertEqual(Topic.objects.count(), 1, "Expect only the included topic to be saved")
+        self.assertTrue(Topic.objects.filter(id=included_topic.id).exists())
+        self.assertFalse(Topic.objects.filter(id=excluded_topic.id).exists(), "Excluded topic should not be synced")
+        self.assertFalse(
+            Topic.objects.filter(id=excluded_subtopic.id).exists(), "Excluded subtopic should not be synced"
+        )
+
+    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS=["census"])
+    def test_existing_excluded_subtree_is_marked_removed_even_when_api_returns_it(self):
+        """Even when the API returns an excluded topic, exclusion drops it from the fetched set,
+        so an existing DB copy is marked removed. This isolates exclusion (not API-absence) as the cause.
+        """
+        # Given existing topics in the DB: an excluded subtree and an included topic
+        excluded_topic = create_topic("4445")
+        excluded_topic.slug = "census"
+        Topic.save_new(excluded_topic)
+        excluded_subtopic = create_topic("6694")
+        excluded_subtopic.slug = "ageing"
+        Topic.save_new(excluded_subtopic, parent_topic=excluded_topic)
+
+        included_topic = create_topic("0001")
+        included_topic.slug = "economy"
+        Topic.save_new(included_topic)
+
+        # The API DOES return the excluded topic (and its subtopic), plus the included topic. If exclusion
+        # were not applied, the excluded topic would be synced and kept; removal here can only be due to
+        # the exclusion list.
+        mock_root_response = mock_successful_json_response(
+            [
+                build_topic_api_json(included_topic),
+                build_topic_api_json(excluded_topic, subtopics=[excluded_subtopic]),
+            ]
+        )
+        mock_subtopic_response = mock_successful_json_response([build_topic_api_json(excluded_subtopic)])
+        self.mock_requests.get.side_effect = [mock_root_response, mock_subtopic_response]
+
+        # When
+        call_command("sync_topics")
+
+        # Then the excluded subtree is marked removed despite being present in the API response.
+        self.assertTrue(Topic.objects.get(id=excluded_topic.id).removed, "Excluded topic should be marked removed")
+        self.assertTrue(
+            Topic.objects.get(id=excluded_subtopic.id).removed, "Excluded subtopic should be marked removed"
+        )
+        # The included topic remains active.
+        self.assertFalse(Topic.objects.get(id=included_topic.id).removed, "Included topic should remain active")
 
 
 def create_topic(topic_id: str, include_description: bool = True, include_slug: bool = True) -> Topic:

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -531,7 +531,7 @@ class SyncTopicsTests(TestCase):
         # When, then raises
         self.assertRaises(RuntimeError, sync_topics.Command().handle)
 
-    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS=["census"])
+    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS={"census"})
     def test_excluded_topic_and_subtopics_are_not_synced(self):
         """A top-level topic with an excluded slug, and its subtopics, should be skipped entirely."""
         # Given
@@ -564,7 +564,7 @@ class SyncTopicsTests(TestCase):
             Topic.objects.filter(id=excluded_subtopic.id).exists(), "Excluded subtopic should not be synced"
         )
 
-    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS=["census"])
+    @override_settings(CMS_TOPIC_SYNC_EXCLUDED_SLUGS={"census"})
     def test_existing_excluded_subtree_is_marked_removed_even_when_api_returns_it(self):
         """Even when the API returns an excluded topic, exclusion drops it from the fetched set,
         so an existing DB copy is marked removed. This isolates exclusion (not API-absence) as the cause.


### PR DESCRIPTION
### What is the context of this PR?

We want a way to keep certain top-level topics, and everything under them, out of the topic sync, starting with `census`. There is duplication (2 different ones in prod) and issues with the census topic structure, which is why it is being excluded for now. It may be included in future once product decisions have been made on its future.

This PR adds a `CMS_TOPIC_SYNC_EXCLUDED_SLUGS` setting (comma-separated env var, defaults to `census`). In `_fetch_all_topics` we drop any topic whose slug is excluded and skip queuing its subtopics, so the whole branch is left out. Set it to an empty string to disable.

`_check_for_removed_topics` was left as is, so an excluded topic that already exists in the DB is treated as missing and marked removed.

### How to review

- Ensure changes make sense
- Run `sync_topics` with different values for `CMS_TOPIC_SYNC_EXCLUDED_SLUGS ` and ensure the behaviour is as expected.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.


---
Ticket: [CMS-1401](https://officefornationalstatistics.atlassian.net/browse/CMS-1401)

[CMS-1401]: https://officefornationalstatistics.atlassian.net/browse/CMS-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ