### PR TITLE
fix(taxonomy): build subtopics URL from TOPIC_API_BASE_URL

### DIFF
--- a/cms/taxonomy/management/commands/sync_topics.py
+++ b/cms/taxonomy/management/commands/sync_topics.py
@@ -84,16 +84,15 @@ def _request_topics(url: str) -> list[dict[str, Any]]:
 
 
 def _extract_subtopic_links(raw_topics: Iterable[Mapping[str, Any]]) -> list[tuple[str, str | None]]:
-    """Return a list of tuples of any subtopic links and their parent topic IDs found in raw_topics."""
+    """Return a list of tuples of the subtopics URL and parent topic ID for each topic that has subtopics.
+
+    The subtopics URL is built from `TOPIC_API_BASE_URL` and the topic ID rather than following the
+    `links.subtopics.href` value from the response, so we always call our configured API host.
+    """
     return [
-        (subtopic_link, raw_topic["id"])
+        (f"{settings.TOPIC_API_BASE_URL}/{raw_topic['id']}/subtopics", raw_topic["id"])
         for raw_topic in raw_topics
-        # NOTE: This assumes we can simply call the links in the response as they are provided,
-        # perhaps switch to building the URL ourselves
-        if (
-            (subtopic_link := raw_topic.get("links", {}).get("subtopics", {}).get("href"))
-            and raw_topic.get("subtopics_ids")
-        )
+        if raw_topic.get("subtopics_ids")
     ]
 
 

--- a/cms/taxonomy/tests/test_management_commands.py
+++ b/cms/taxonomy/tests/test_management_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import requests
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from requests import HTTPError
 
 from cms.taxonomy.management.commands import sync_topics
@@ -185,6 +185,28 @@ class SyncTopicsTests(TestCase):
         self.assertEqual(
             saved_subtopic.get_parent().id, root_topic.id, "Expect the subtopic to have the correct parent"
         )
+
+    @override_settings(TOPIC_API_BASE_URL="https://example.test/topics")
+    def test_subtopics_url_is_built_from_base_url_not_href(self):
+        """The subtopics URL should be constructed from TOPIC_API_BASE_URL, not the response href."""
+        # Given a root topic whose response href points at a different host we should ignore
+        root_topic = create_topic("0001")
+        subtopic = create_topic("0002")
+        root_json = build_topic_api_json(root_topic, subtopics=[subtopic])
+        root_json["links"] = {"subtopics": {"href": "https://malicious.example/should-not-be-used"}}
+
+        mock_root_response = mock_successful_json_response([root_json])
+        mock_subtopic_response = mock_successful_json_response([build_topic_api_json(subtopic)])
+        self.mock_requests.get.side_effect = [mock_root_response, mock_subtopic_response]
+
+        # When
+        call_command("sync_topics")
+
+        # Then the subtopics call uses the constructed URL, and the href is ignored
+        self.assertEqual(self.mock_requests.get.call_count, 2, "Expect 2 calls to retrieve topics")
+        requested_urls = [call.args[0] for call in self.mock_requests.get.call_args_list]
+        self.assertEqual(requested_urls[0], "https://example.test/topics")
+        self.assertEqual(requested_urls[1], "https://example.test/topics/0001/subtopics")
 
     def test_sync_two_root_topics(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?

When syncing topics we fetch the top level from `TOPIC_API_BASE_URL`, then walk into each topic's subtopics. Until now we followed the `links.subtopics.href` that the API handed back to reach those subtopics. That href can point at a different host depending on the environment, so we could end up calling somewhere other than the API host we configured.

`_extract_subtopic_links` now builds the subtopics URL itself from `TOPIC_API_BASE_URL` and the topic id (`{base}/{id}/subtopics`) and ignores the href. That means every request stays on the host we've configured, regardless of what the response says.

### How to review

- Ensure the changes make sense
- You could allowlist against staging and run against topic sync against the "external staging api" to truly exercise this. Reach out if you want to try this and have trouble with allowlisting.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.


---
Ticket: [CMS-1401](https://officefornationalstatistics.atlassian.net/browse/CMS-1401)

[CMS-1401]: https://officefornationalstatistics.atlassian.net/browse/CMS-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ