### PR TITLE
fix: check pages have unpublished changes before allowing bundle to save

### DIFF
--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -381,14 +381,6 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
                 if page.live and not page.has_unpublished_changes:
                     form.add_error("page", "This page has no unpublished changes")
 
-    def _validate_release_calendar_page_no_unpublished_changes(self) -> None:
-        release_calendar_page = self.cleaned_data.get("release_calendar_page")
-        if not release_calendar_page:
-            return
-
-        if release_calendar_page.live and not release_calendar_page.has_unpublished_changes:
-            self.add_error("release_calendar_page", "This page has no unpublished changes")
-
     def _validate_release_calendar_page_status(self) -> None:
         release_calendar_page = self.cleaned_data["release_calendar_page"]
         if not release_calendar_page:
@@ -496,7 +488,6 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
 
         # pages must have unpublished changes
         self._validate_bundled_pages_no_unpublished_changes()
-        self._validate_release_calendar_page_no_unpublished_changes()
 
         self._validate_bundled_pages()
 

--- a/cms/bundles/forms.py
+++ b/cms/bundles/forms.py
@@ -366,6 +366,29 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
                 f"page{pluralize(num_pages_not_ready)} not ready to be published."
             )
 
+    def _validate_bundled_pages_no_unpublished_changes(self) -> None:
+
+        formset = self.formsets.get("bundled_pages")
+        if not formset:
+            return
+
+        for form in formset.forms:
+            if not form.is_valid() or form.cleaned_data.get("DELETE"):
+                continue
+
+            if page := form.clean().get("page"):
+                page = page.specific
+                if page.live and not page.has_unpublished_changes:
+                    form.add_error("page", "This page has no unpublished changes")
+
+    def _validate_release_calendar_page_no_unpublished_changes(self) -> None:
+        release_calendar_page = self.cleaned_data.get("release_calendar_page")
+        if not release_calendar_page:
+            return
+
+        if release_calendar_page.live and not release_calendar_page.has_unpublished_changes:
+            self.add_error("release_calendar_page", "This page has no unpublished changes")
+
     def _validate_release_calendar_page_status(self) -> None:
         release_calendar_page = self.cleaned_data["release_calendar_page"]
         if not release_calendar_page:
@@ -470,6 +493,10 @@ class BundleAdminForm(DeduplicateInlinePanelAdminForm):
         self.deduplicate_formset(formset="bundled_pages", target_field="page")
         self.deduplicate_formset(formset="bundled_datasets", target_field="dataset")
         self.deduplicate_formset(formset="teams", target_field="team")
+
+        # pages must have unpublished changes
+        self._validate_bundled_pages_no_unpublished_changes()
+        self._validate_release_calendar_page_no_unpublished_changes()
 
         self._validate_bundled_pages()
 

--- a/cms/bundles/tests/test_forms.py
+++ b/cms/bundles/tests/test_forms.py
@@ -79,6 +79,12 @@ class BundleAdminFormTestCase(TestCase):
             "bundled_datasets": inline_formset([]),
         }
 
+    def raw_form_data_with_unpublished_page_changes(self) -> dict[str, Any]:
+        """Returns form data with a bundled page that has an unpublished revision."""
+        self.page.title = "Updated statistical article title"
+        self.page.save_revision()
+        return self.raw_form_data()
+
     def _setup_bundle(self, ready_to_publish: bool = True) -> dict[str, Any]:
         """Sets up the bundle and returns raw form data."""
         page = StatisticalArticlePageFactory(title="A Page")
@@ -163,7 +169,7 @@ class BundleAdminFormTestCase(TestCase):
         another_bundle = BundleFactory(name="Another Bundle")
         BundlePageFactory(parent=another_bundle, page=self.page)
 
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["bundled_pages"] = inline_formset([{"page": self.page.id}])
 
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
@@ -176,6 +182,9 @@ class BundleAdminFormTestCase(TestCase):
         release_calendar_page = ReleaseCalendarPageFactory(release_date=nowish, title="Release Calendar Page")
         raw_data = self.raw_form_data()
         raw_data["release_calendar_page"] = release_calendar_page.id
+        # give the rc page unpublished changes so it passes validation when bundled
+        release_calendar_page.title = "Updated release calendar page"
+        release_calendar_page.save_revision()
         raw_data["bundled_pages"] = inline_formset([{"page": release_calendar_page.id}])
 
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
@@ -281,7 +290,7 @@ class BundleAdminFormTestCase(TestCase):
     def test_clean__removes_duplicate_pages(self):
         self.assertEqual(self.bundle.bundled_pages.count(), 0)
 
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["bundled_pages"] = inline_formset([{"page": self.page.id}, {"page": self.page.id}])
 
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
@@ -295,7 +304,7 @@ class BundleAdminFormTestCase(TestCase):
         dataset = DatasetFactory(id=123)
         self.assertEqual(self.bundle.bundled_datasets.count(), 0)
 
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["bundled_datasets"] = inline_formset([{"dataset": dataset.pk}, {"dataset": dataset.pk}])
 
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
@@ -309,7 +318,7 @@ class BundleAdminFormTestCase(TestCase):
         team = TeamFactory()
         self.assertEqual(self.bundle.teams.count(), 0)
 
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["teams"] = inline_formset([{"team": team.pk}, {"team": team.pk}])
 
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
@@ -353,14 +362,14 @@ class BundleAdminFormTestCase(TestCase):
 
         # add a dataset
         DatasetFactory(id=123)
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["bundled_datasets"] = inline_formset([{"dataset": 123}])
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
         self.assertTrue(form.is_valid())
 
     def test_clean_validates_the_bundle_has_datasets(self):
         dataset = DatasetFactory(id=123)
-        raw_data = self.raw_form_data()
+        raw_data = self.raw_form_data_with_unpublished_page_changes()
         raw_data["bundled_datasets"] = inline_formset([{"dataset": dataset.pk}])
         form = self.form_class(instance=self.bundle, data=nested_form_data(raw_data))
 
@@ -376,7 +385,10 @@ class BundleAdminFormTestCase(TestCase):
     def test_clean_sets_publication_date_seconds_to_zero(self):
         form = self.form_class(
             instance=self.bundle,
-            data=nested_form_data(self.raw_form_data() | {"publication_date": timezone.now() + timedelta(days=1)}),
+            data=nested_form_data(
+                self.raw_form_data_with_unpublished_page_changes()
+                | {"publication_date": timezone.now() + timedelta(days=1)}
+            ),
         )
 
         self.assertTrue(form.is_valid(), form.errors)


### PR DESCRIPTION
### What is the context of this PR?

If a user selects a page with unpublished changes in the bundle chooser, then that page is published before the bundle is saved, it still saves the bundle without an error.

This page adds validation for ~both the release calendar chooser and~ the page chooser in the bundle editor to ensure that all pages have unpublished changes befor the bundle can be saved. 

### How to review

- Create a bundle
- Create a page
- Go to the bundle editing page in one tab, select and confirm the page in the modal but don’t hit “Save Draft” or put the bundle to preview
- Go to the page, submit for moderation and move through the workflow stages to publish
- Return to the bundle and save
- Confirm that the bundle does not save and has validation errors
Confirm this works with both regular pages ~and release calendar pages (scheduling)~

**Updated**: This PR is no longer adding validation for the release calendar picker in bundles: we want to be able to use a published release calendar page without any unpublished content to be used for scheduling.

### Deployment Safety

Bleed and Sandbox deploy automatically on merge, so PRs should be safe to deploy immediately.

Please select one:

- [x] Safe to auto-deploy
- [ ] Not safe to auto-deploy

<!--
If this PR is not safe to auto-deploy, explain what is required before merge
(for example, Helm/config changes, another PR, migration sequencing, or coordinated release steps).
-->

### Follow-up Actions

n/a


---
Ticket: [CMS-1268](https://officefornationalstatistics.atlassian.net/browse/CMS-1268)

[CMS-1268]: https://officefornationalstatistics.atlassian.net/browse/CMS-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ